### PR TITLE
Add module `nailgun.config`

### DIFF
--- a/docs/api/nailgun.rst
+++ b/docs/api/nailgun.rst
@@ -8,3 +8,9 @@
 
 .. automodule:: nailgun.client
    :members:
+
+:mod:`nailgun.config`
+=====================
+
+.. automodule:: nailgun.config
+   :members:

--- a/docs/api/tests.rst
+++ b/docs/api/tests.rst
@@ -8,3 +8,9 @@
 
 .. automodule:: tests.test_client
    :members:
+
+:mod:`tests.test_config`
+========================
+
+.. automodule:: tests.test_config
+   :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,6 +35,9 @@ source_suffix = '.rst'
 master_doc = 'index'
 exclude_patterns = ['_build']
 nitpicky = True
+nitpick_ignore = [
+    ('py:obj', 'str'),
+]
 
 # Format-Specific Options -----------------------------------------------------
 

--- a/nailgun/config.py
+++ b/nailgun/config.py
@@ -1,0 +1,184 @@
+"""Tools for managing and presenting server connection configurations.
+
+NailGun needs to know certain facts about the remote server in order to do
+anything useful. For example, NailGun needs to know the URL of the remote
+server (e.g. 'https://example.com:250') and how to authenticate with the remote
+server. :class:`nailgun.config.ServerConfig` eases the task of managing and
+presenting that information.
+
+"""
+from os.path import isfile, join
+from threading import Lock
+from xdg import BaseDirectory
+import json
+
+
+_SENTINEL = object()
+XDG_CONFIG_DIR = 'nailgun'
+XDG_CONFIG_FILE = 'settings.json'
+
+
+class ConfigFileError(Exception):
+    """Indicates an error occurred when locating a configuration file."""
+
+
+def _get_config_file_path():
+    """Search for a NailGun configuration file and return the first one found.
+
+    Each of the standard XDG configuration directories (e.g.
+    `~/.config/nailgun/`) is searched for a NailGun configuration file. Beware
+    that a check is made that the file exists, but this check is cursory. By
+    the time client code attempts to open the file, it may be gone or otherwise
+    inaccessible.
+
+    :returns: A path to a configuration file.
+    :rtype: str
+    :raises ConfigFileError: When no configuration file can be found.
+
+    """
+    for config_dir in BaseDirectory.load_config_paths(XDG_CONFIG_DIR):
+        path = join(config_dir, XDG_CONFIG_FILE)
+        if isfile(path):
+            return path
+    raise ConfigFileError(
+        'No configuration files could be located after searching for a file '
+        'named "{0}" in the standard XDG configuration paths, such as '
+        '"~/.config/{1}/".'.format(XDG_CONFIG_FILE, XDG_CONFIG_DIR)
+    )
+
+
+class ServerConfig(object):
+    """A set of facts that are useful when communicating with a server."""
+    _file_lock = Lock()
+
+    def __init__(self, url, auth=_SENTINEL, verify=_SENTINEL):
+        """Create a server configuration.
+
+        :param str url: What is the URL Of the server? For example,
+            `https://example.com/250`.
+        :param auth: Credentials to use when communicating with the server. For
+            example, `('username', 'password')`. No object attribute is created
+            if no value is provided.
+        :param bool verify: Should SSL be verified when communicating with the
+            server? No object attribute is created if no value is provided.
+
+        """
+        self.url = url
+        if auth != _SENTINEL:
+            self.auth = auth
+        if verify != _SENTINEL:
+            self.verify = verify
+
+    @classmethod
+    def delete(cls, label='default', path=None):
+        """Delete a server configuration.
+
+        This method is thread safe.
+
+        :param str label: The configuration identified by ``label`` is deleted.
+        :param str path: The file at ``path`` is searched. By default, each of
+            the standard XDG configuration directories is searched for a
+            configuration file, and the first configuration file found is used.
+        :returns: Nothing.
+        :rtype: None
+
+        """
+        if path is None:
+            path = _get_config_file_path()
+        cls._file_lock.acquire()
+        try:
+            with open(path) as config_file:
+                config = json.load(config_file)
+            del config[label]
+            with open(path, 'w') as config_file:
+                json.dump(config, config_file)
+        finally:
+            cls._file_lock.release()
+
+    @staticmethod
+    def get(label='default', path=None):
+        """Get a server configuration.
+
+        :param str label: The configuration identified by ``label`` is read.
+        :param str path: The file at ``path`` is searched. By default, each of
+            the standard XDG configuration directories is searched for a
+            configuration file, and the first configuration file found is used.
+        :returns: A brand new :class:`nailgun.config.ServerConfig` object whose
+            attributes have been populated as appropriate.
+        :rtype: ServerConfig
+
+        """
+        if path is None:
+            path = _get_config_file_path()
+        with open(path) as config_file:
+            return ServerConfig(**json.load(config_file)[label])
+
+    def get_client_kwargs(self):
+        """Get a dict of object attributes, but with "url" omitted.
+
+        This method makes working with :mod:`nailgun.client` more pleasant.
+        Code such as the following can be written::
+
+            client.get(cfg.url + '/api/v2', **cfg.get_client_kwargs())
+
+        This method has been placed here to promote a better layering of
+        responsibilities: this class knows all about :mod:`nailgun.client`, and
+        :mod:`nailgun.client` knows nothing about this class.
+
+        """
+        config = vars(self)
+        config.pop('url')
+        return config
+
+    @staticmethod
+    def get_labels(path=None):
+        """Get all server configuration labels.
+
+        :param str path: The file at ``path`` is searched. By default, each of
+            the standard XDG configuration directories is searched for a
+            configuration file, and the first configuration file found is used.
+        :returns: Server configuration labels, where each label is a string.
+        :rtype: tuple
+
+        """
+        if path is None:
+            path = _get_config_file_path()
+        with open(path) as config_file:
+            # keys() returns a list in Python 2 and a view in Python 3.
+            return tuple(json.load(config_file).keys())
+
+    def save(self, label='default', path=None):
+        """Save the current connection configuration to a file.
+
+        This method is thread safe.
+
+        :param str label: An identifier for the current configuration. This
+            allows multiple configurations with unique labels to be saved in a
+            single file. If a configuration identified by ``label`` already
+            exists in the destination configuration file, it is replaced.
+        :param str path: A path to the file in which the current configuration
+            should be saved. By default, an XDG-compliant configuration file is
+            used. A configuration file is created if none exists already.
+        :returns: Nothing.
+        :rtype: None
+
+        """
+        if path is None:
+            path = join(
+                BaseDirectory.save_config_path(XDG_CONFIG_DIR),
+                XDG_CONFIG_FILE
+            )
+        self._file_lock.acquire()
+        try:
+            # Either read an existing config or make an empty one. Then update
+            # the config and write it out.
+            try:
+                with open(path) as config_file:
+                    config = json.load(config_file)
+            except IOError:
+                config = {}
+            config[label] = vars(self)
+            with open(path, 'w') as config_file:
+                json.dump(config, config_file)
+        finally:
+            self._file_lock.release()

--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,5 @@ setup(
         'Programming Language :: Python :: 3.4',
     ],
     packages=find_packages(),
-    install_requires=['requests'],
+    install_requires=['requests', 'pyxdg'],
 )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,139 @@
+"""Unit tests for :mod:`nailgun.config`."""
+from mock import call, mock_open, patch
+from nailgun.config import ServerConfig
+from unittest import TestCase
+import json
+
+from sys import version_info
+if version_info[0] == 2:
+    # The `__builtins__` module (note the "s") also provides the `open`
+    # function. However, that module is an implementation detail for CPython 2,
+    # so it should not be relied on.
+    import __builtin__ as builtins  # pylint:disable=import-error
+else:
+    import builtins  # pylint:disable=import-error
+
+
+FILE_PATH = '/tmp/bogus.json'
+CONFIGS = {
+    'default': {'url': 'http://example.com'},
+    'Ask Aak': {'url': 'bogus value', 'auth': ['username', 'password']},
+    'Abeloth': {'url': 'bogus value', 'verify': True},
+    'Admiral Gial Ackbar': {'url': 'bogus', 'auth': [], 'verify': False},
+}
+
+
+class ServerConfigTestCase(TestCase):
+    """Tests for :class:`nailgun.config.ServerConfig`."""
+    # The pylint star-args warning is disabled for several tests. This is
+    # because star args make the relevant tests _so_ much more compact than any
+    # alternatives, and the dicts in question are hardcoded in this module.
+
+    def test_init(self):
+        """Test instantiating :class:`nailgun.config.ServerConfig`.
+
+        Assert that only provided values become object attributes.
+
+        """
+        for _, config in CONFIGS.items():
+            # pylint:disable=star-args
+            self.assertEqual(config, vars(ServerConfig(**config)))
+
+    def test_get_client_kwargs(self):
+        """Test :meth:`nailgun.config.ServerConfig.get_client_kwargs`.
+
+        Assert that all attributes passed in are returned, but with "url"
+        omitted.
+
+        """
+        for _, config in CONFIGS.items():
+            out = config.copy()
+            out.pop('url')
+            # pylint:disable=star-args
+            self.assertEqual(out, ServerConfig(**config).get_client_kwargs())
+
+    def test_get(self):
+        """Test :meth:`nailgun.config.ServerConfig.get`.
+
+        Assert that the method extracts the asked-for section from a
+        configuration file and correctly populates a new ``ServerConfig``
+        object.
+
+        """
+        for label, config in CONFIGS.items():
+            open_ = mock_open(read_data=json.dumps(CONFIGS))
+            with patch.object(builtins, 'open', open_):
+                server_config = ServerConfig.get(label, FILE_PATH)
+            self.assertEqual(vars(server_config), config)
+            open_.assert_called_once_with(FILE_PATH)
+
+    def test_get_labels(self):
+        """Test :meth:`nailgun.config.ServerConfig.get_labels`.
+
+        Assert that the method returns the correct labels.
+
+        """
+        open_ = mock_open(read_data=json.dumps(CONFIGS))
+        with patch.object(builtins, 'open', open_):
+            self.assertEqual(
+                set(CONFIGS.keys()),
+                set(ServerConfig.get_labels(FILE_PATH)),
+            )
+        open_.assert_called_once_with(FILE_PATH)
+
+    def test_save(self):
+        """Test :meth:`nailgun.config.ServerConfig.save`.
+
+        Assert that the method reads the config file before writing, and that
+        it writes out a correct config file.
+
+        """
+        label = 'Ask Aak'
+        config = {label: {'url': 'https://example.org'}}
+        open_ = mock_open(read_data=json.dumps(CONFIGS))
+        with patch.object(builtins, 'open', open_):
+            ServerConfig(config[label]['url']).save(label, FILE_PATH)
+
+        # We care about two things: that this method reads the config file
+        # before writing, and that the written string is correct. The first is
+        # easy to verify...
+        self.assertEqual(
+            open_.call_args_list,
+            [call(FILE_PATH), call(FILE_PATH, 'w')],
+        )
+        # ...and the second is a PITA to verify.
+        actual_config = _get_written_json(open_)
+        target_config = CONFIGS.copy()
+        target_config[label] = config[label]
+        self.assertEqual(target_config, actual_config)
+
+    def test_delete(self):
+        """Test :meth:`nailgun.config.ServerConfig.delete`.
+
+        Assert that the method reads the config file before writing, and that
+        it writes out a correct config file.
+
+        """
+        open_ = mock_open(read_data=json.dumps(CONFIGS))
+        with patch.object(builtins, 'open', open_):
+            ServerConfig.delete('Ask Aak', FILE_PATH)
+
+        # See `test_save` for further commentary on what's being done here.
+        self.assertEqual(
+            open_.call_args_list,
+            [call(FILE_PATH), call(FILE_PATH, 'w')],
+        )
+        actual_config = _get_written_json(open_)
+        target_config = CONFIGS.copy()
+        del target_config['Ask Aak']
+        self.assertEqual(target_config, actual_config)
+
+
+def _get_written_json(mock_obj):
+    """Return the JSON that has been written to a mock `open` object."""
+    # json.dump() calls write() for each individual JSON token.
+    return json.loads(''.join(
+        tuple(call_obj)[1][0]
+        for call_obj
+        in mock_obj().write.mock_calls
+    ))


### PR DESCRIPTION
The module contains "tools for managing and presenting server connection
configurations." Most importantly, this module contains a class called
`ServerConfig`, and it does all the heavy lifting.

Include the new module in the documentation.

Add unit tests for the new module.

Fix #2.