### PR TITLE
Add class `BaseServerConfig`, update API docs

### DIFF
--- a/docs/api/nailgun.rst
+++ b/docs/api/nailgun.rst
@@ -7,11 +7,9 @@
 =====================
 
 .. automodule:: nailgun.client
-   :members:
 
 :mod:`nailgun.config`
 =====================
 
 .. automodule:: nailgun.config
-   :members:
    :private-members:

--- a/docs/api/nailgun.rst
+++ b/docs/api/nailgun.rst
@@ -14,3 +14,4 @@
 
 .. automodule:: nailgun.config
    :members:
+   :private-members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,8 +36,10 @@ master_doc = 'index'
 exclude_patterns = ['_build']
 nitpicky = True
 nitpick_ignore = [
+    ('py:obj', 'bool'),
     ('py:obj', 'str'),
 ]
+autodoc_default_flags = ['members', 'special-members']
 
 # Format-Specific Options -----------------------------------------------------
 

--- a/nailgun/config.py
+++ b/nailgun/config.py
@@ -13,61 +13,74 @@ from xdg import BaseDirectory
 import json
 
 
-_SENTINEL = object()
-XDG_CONFIG_DIR = 'nailgun'
-XDG_CONFIG_FILE = 'settings.json'
-
-
 class ConfigFileError(Exception):
-    """Indicates an error occurred when locating a configuration file."""
+    """Indicates an error occurred when locating a configuration file.
 
-
-def _get_config_file_path():
-    """Search for a NailGun configuration file and return the first one found.
-
-    Each of the standard XDG configuration directories (e.g.
-    `~/.config/nailgun/`) is searched for a NailGun configuration file. Beware
-    that a check is made that the file exists, but this check is cursory. By
-    the time client code attempts to open the file, it may be gone or otherwise
-    inaccessible.
-
-    :returns: A path to a configuration file.
-    :rtype: str
-    :raises ConfigFileError: When no configuration file can be found.
+    .. WARNING:: This class will likely be moved to a separate Python package
+        in a future release of NailGun. Be careful about making references to
+        this class, as those references will likely need to be changed.
 
     """
-    for config_dir in BaseDirectory.load_config_paths(XDG_CONFIG_DIR):
-        path = join(config_dir, XDG_CONFIG_FILE)
+
+
+def _get_config_file_path(xdg_config_dir, xdg_config_file):
+    """Search ``XDG_CONFIG_DIRS`` for a config file and return the first found.
+
+    Search each of the standard XDG configuration directories for a
+    configuration file. Return as soon as a configuration file is found. Beware
+    that by the time client code attempts to open the file, it may be gone or
+    otherwise inaccessible.
+
+    :param str xdg_config_dir: The name of the directory that is suffixed to
+        the end of each of the ``XDG_CONFIG_DIRS`` paths.
+    :param str xdg_config_file: The name of the configuration file that is
+        being searched for.
+    :returns: A path to a configuration file.
+    :rtype: str
+    :raises nailgun.config.ConfigFileError: When no configuration file can be
+        found.
+
+    """
+    for config_dir in BaseDirectory.load_config_paths(xdg_config_dir):
+        path = join(config_dir, xdg_config_file)
         if isfile(path):
             return path
     raise ConfigFileError(
         'No configuration files could be located after searching for a file '
         'named "{0}" in the standard XDG configuration paths, such as '
-        '"~/.config/{1}/".'.format(XDG_CONFIG_FILE, XDG_CONFIG_DIR)
+        '"~/.config/{1}/".'.format(xdg_config_file, xdg_config_dir)
     )
 
 
-class ServerConfig(object):
-    """A set of facts that are useful when communicating with a server."""
-    _file_lock = Lock()
+class BaseServerConfig(object):
+    """A minimal set of facts for communicating with a Satellite server.
 
-    def __init__(self, url, auth=_SENTINEL, verify=_SENTINEL):
-        """Create a server configuration.
+    .. WARNING:: This class will likely be moved to a separate Python package
+        in a future release of NailGun. Be careful about making references to
+        this class, as those references will likely need to be changed.
+
+    """
+    #: Used to lock access to the configuration file when performing certain
+    #: operations, such as saving.
+    _file_lock = Lock()
+    #: The name of the directory appended to ``XDG_CONFIG_DIRS``.
+    _xdg_config_dir = 'librobottelo'
+    #: The name of the file in which settings are stored.
+    _xdg_config_file = 'settings.json'
+
+    def __init__(self, url, auth=None):
+        """Create a server configuration object.
 
         :param str url: What is the URL Of the server? For example,
             `https://example.com/250`.
         :param auth: Credentials to use when communicating with the server. For
             example, `('username', 'password')`. No object attribute is created
             if no value is provided.
-        :param bool verify: Should SSL be verified when communicating with the
-            server? No object attribute is created if no value is provided.
 
         """
         self.url = url
-        if auth != _SENTINEL:
+        if auth is not None:
             self.auth = auth
-        if verify != _SENTINEL:
-            self.verify = verify
 
     @classmethod
     def delete(cls, label='default', path=None):
@@ -76,15 +89,17 @@ class ServerConfig(object):
         This method is thread safe.
 
         :param str label: The configuration identified by ``label`` is deleted.
-        :param str path: The file at ``path`` is searched. By default, each of
-            the standard XDG configuration directories is searched for a
-            configuration file, and the first configuration file found is used.
+        :param str path: The configuration file to be manipulated. Defaults to
+            what is returned by :func:`nailgun.config._get_config_file_path`.
         :returns: Nothing.
         :rtype: None
 
         """
         if path is None:
-            path = _get_config_file_path()
+            path = _get_config_file_path(
+                cls._xdg_config_dir,
+                cls._xdg_config_file
+            )
         cls._file_lock.acquire()
         try:
             with open(path) as config_file:
@@ -95,54 +110,41 @@ class ServerConfig(object):
         finally:
             cls._file_lock.release()
 
-    @staticmethod
-    def get(label='default', path=None):
+    @classmethod
+    def get(cls, label='default', path=None):
         """Get a server configuration.
 
         :param str label: The configuration identified by ``label`` is read.
-        :param str path: The file at ``path`` is searched. By default, each of
-            the standard XDG configuration directories is searched for a
-            configuration file, and the first configuration file found is used.
+        :param str path: The configuration file to be manipulated. Defaults to
+            what is returned by :func:`nailgun.config._get_config_file_path`.
         :returns: A brand new :class:`nailgun.config.ServerConfig` object whose
             attributes have been populated as appropriate.
         :rtype: ServerConfig
 
         """
         if path is None:
-            path = _get_config_file_path()
+            path = _get_config_file_path(
+                cls._xdg_config_dir,
+                cls._xdg_config_file
+            )
         with open(path) as config_file:
             return ServerConfig(**json.load(config_file)[label])
 
-    def get_client_kwargs(self):
-        """Get a dict of object attributes, but with "url" omitted.
-
-        This method makes working with :mod:`nailgun.client` more pleasant.
-        Code such as the following can be written::
-
-            client.get(cfg.url + '/api/v2', **cfg.get_client_kwargs())
-
-        This method has been placed here to promote a better layering of
-        responsibilities: this class knows all about :mod:`nailgun.client`, and
-        :mod:`nailgun.client` knows nothing about this class.
-
-        """
-        config = vars(self)
-        config.pop('url')
-        return config
-
-    @staticmethod
-    def get_labels(path=None):
+    @classmethod
+    def get_labels(cls, path=None):
         """Get all server configuration labels.
 
-        :param str path: The file at ``path`` is searched. By default, each of
-            the standard XDG configuration directories is searched for a
-            configuration file, and the first configuration file found is used.
+        :param str path: The configuration file to be manipulated. Defaults to
+            what is returned by :func:`nailgun.config._get_config_file_path`.
         :returns: Server configuration labels, where each label is a string.
         :rtype: tuple
 
         """
         if path is None:
-            path = _get_config_file_path()
+            path = _get_config_file_path(
+                cls._xdg_config_dir,
+                cls._xdg_config_file
+            )
         with open(path) as config_file:
             # keys() returns a list in Python 2 and a view in Python 3.
             return tuple(json.load(config_file).keys())
@@ -156,17 +158,17 @@ class ServerConfig(object):
             allows multiple configurations with unique labels to be saved in a
             single file. If a configuration identified by ``label`` already
             exists in the destination configuration file, it is replaced.
-        :param str path: A path to the file in which the current configuration
-            should be saved. By default, an XDG-compliant configuration file is
-            used. A configuration file is created if none exists already.
+        :param str path: The configuration file to be manipulated. By default,
+            an XDG-compliant configuration file is used. A configuration file
+            is created if one does not exist already.
         :returns: Nothing.
         :rtype: None
 
         """
         if path is None:
             path = join(
-                BaseDirectory.save_config_path(XDG_CONFIG_DIR),
-                XDG_CONFIG_FILE
+                BaseDirectory.save_config_path(self._xdg_config_dir),
+                self._xdg_config_file
             )
         self._file_lock.acquire()
         try:
@@ -182,3 +184,44 @@ class ServerConfig(object):
                 json.dump(config, config_file)
         finally:
             self._file_lock.release()
+
+
+class ServerConfig(BaseServerConfig):
+    """Facts for communicating with a server's API."""
+    # pylint:disable=too-few-public-methods
+    # It's OK that this class has only one public method. This class is
+    # intentionally small so that the parent class can be re-used.
+    _xdg_config_dir = 'nailgun'
+    _xdg_config_file = 'server_configs.json'
+
+    def __init__(self, url, auth=None, verify=None):
+        """Create a server configuration object.
+
+        See the parent class for information on the ``url`` and ``auth``
+        attributes.
+
+        :param bool verify: Should SSL be verified when communicating with the
+            server? No object attribute is created if no value is provided.
+
+        """
+        super(ServerConfig, self).__init__(url, auth)
+        if verify is not None:
+            self.verify = verify
+
+    def get_client_kwargs(self):
+        """Get a dict of object attributes, but with "url" omitted.
+
+        This method makes working with :mod:`nailgun.client` more pleasant.
+        Code such as the following can be written::
+
+            cfg = ServerConfig.get()
+            client.get(cfg.url + '/api/v2', **cfg.get_client_kwargs())
+
+        This method has been placed here to promote a better layering of
+        responsibilities: this class knows all about :mod:`nailgun.client`, and
+        :mod:`nailgun.client` knows nothing about this class.
+
+        """
+        config = vars(self)
+        config.pop('url')
+        return config

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,6 @@
 """Unit tests for :mod:`nailgun.config`."""
 from mock import call, mock_open, patch
-from nailgun.config import ServerConfig
+from nailgun.config import BaseServerConfig, ServerConfig
 from unittest import TestCase
 import json
 
@@ -18,57 +18,47 @@ FILE_PATH = '/tmp/bogus.json'
 CONFIGS = {
     'default': {'url': 'http://example.com'},
     'Ask Aak': {'url': 'bogus value', 'auth': ['username', 'password']},
+}
+CONFIGS2 = CONFIGS.copy()
+CONFIGS2.update({
     'Abeloth': {'url': 'bogus value', 'verify': True},
     'Admiral Gial Ackbar': {'url': 'bogus', 'auth': [], 'verify': False},
-}
+})
+# The pylint star-args warning is disabled for several tests. This is because
+# star args make the relevant tests _so_ much more compact than any
+# alternatives, and the dicts in question are hardcoded right here.
 
 
-class ServerConfigTestCase(TestCase):
-    """Tests for :class:`nailgun.config.ServerConfig`."""
-    # The pylint star-args warning is disabled for several tests. This is
-    # because star args make the relevant tests _so_ much more compact than any
-    # alternatives, and the dicts in question are hardcoded in this module.
+class BaseServerConfigTestCase(TestCase):
+    """Tests for :class:`nailgun.config.BaseServerConfig`."""
 
     def test_init(self):
-        """Test instantiating :class:`nailgun.config.ServerConfig`.
+        """Test instantiating :class:`nailgun.config.BaseServerConfig`.
 
         Assert that only provided values become object attributes.
 
         """
-        for _, config in CONFIGS.items():
+        for config in CONFIGS.values():
             # pylint:disable=star-args
-            self.assertEqual(config, vars(ServerConfig(**config)))
-
-    def test_get_client_kwargs(self):
-        """Test :meth:`nailgun.config.ServerConfig.get_client_kwargs`.
-
-        Assert that all attributes passed in are returned, but with "url"
-        omitted.
-
-        """
-        for _, config in CONFIGS.items():
-            out = config.copy()
-            out.pop('url')
-            # pylint:disable=star-args
-            self.assertEqual(out, ServerConfig(**config).get_client_kwargs())
+            self.assertEqual(config, vars(BaseServerConfig(**config)))
 
     def test_get(self):
-        """Test :meth:`nailgun.config.ServerConfig.get`.
+        """Test :meth:`nailgun.config.BaseServerConfig.get`.
 
         Assert that the method extracts the asked-for section from a
-        configuration file and correctly populates a new ``ServerConfig``
+        configuration file and correctly populates a new ``BaseServerConfig``
         object.
 
         """
         for label, config in CONFIGS.items():
             open_ = mock_open(read_data=json.dumps(CONFIGS))
             with patch.object(builtins, 'open', open_):
-                server_config = ServerConfig.get(label, FILE_PATH)
+                server_config = BaseServerConfig.get(label, FILE_PATH)
             self.assertEqual(vars(server_config), config)
             open_.assert_called_once_with(FILE_PATH)
 
     def test_get_labels(self):
-        """Test :meth:`nailgun.config.ServerConfig.get_labels`.
+        """Test :meth:`nailgun.config.BaseServerConfig.get_labels`.
 
         Assert that the method returns the correct labels.
 
@@ -77,12 +67,12 @@ class ServerConfigTestCase(TestCase):
         with patch.object(builtins, 'open', open_):
             self.assertEqual(
                 set(CONFIGS.keys()),
-                set(ServerConfig.get_labels(FILE_PATH)),
+                set(BaseServerConfig.get_labels(FILE_PATH)),
             )
         open_.assert_called_once_with(FILE_PATH)
 
     def test_save(self):
-        """Test :meth:`nailgun.config.ServerConfig.save`.
+        """Test :meth:`nailgun.config.BaseServerConfig.save`.
 
         Assert that the method reads the config file before writing, and that
         it writes out a correct config file.
@@ -92,7 +82,7 @@ class ServerConfigTestCase(TestCase):
         config = {label: {'url': 'https://example.org'}}
         open_ = mock_open(read_data=json.dumps(CONFIGS))
         with patch.object(builtins, 'open', open_):
-            ServerConfig(config[label]['url']).save(label, FILE_PATH)
+            BaseServerConfig(config[label]['url']).save(label, FILE_PATH)
 
         # We care about two things: that this method reads the config file
         # before writing, and that the written string is correct. The first is
@@ -108,7 +98,7 @@ class ServerConfigTestCase(TestCase):
         self.assertEqual(target_config, actual_config)
 
     def test_delete(self):
-        """Test :meth:`nailgun.config.ServerConfig.delete`.
+        """Test :meth:`nailgun.config.BaseServerConfig.delete`.
 
         Assert that the method reads the config file before writing, and that
         it writes out a correct config file.
@@ -116,7 +106,7 @@ class ServerConfigTestCase(TestCase):
         """
         open_ = mock_open(read_data=json.dumps(CONFIGS))
         with patch.object(builtins, 'open', open_):
-            ServerConfig.delete('Ask Aak', FILE_PATH)
+            BaseServerConfig.delete('Ask Aak', FILE_PATH)
 
         # See `test_save` for further commentary on what's being done here.
         self.assertEqual(
@@ -127,6 +117,33 @@ class ServerConfigTestCase(TestCase):
         target_config = CONFIGS.copy()
         del target_config['Ask Aak']
         self.assertEqual(target_config, actual_config)
+
+
+class ServerConfigTestCase(TestCase):
+    """Tests for :class:`nailgun.config.ServerConfig`."""
+
+    def test_init(self):
+        """Test instantiating :class:`nailgun.config.ServerConfig`.
+
+        Assert that only provided values become object attributes.
+
+        """
+        for config in CONFIGS2.values():
+            # pylint:disable=star-args
+            self.assertEqual(config, vars(ServerConfig(**config)))
+
+    def test_get_client_kwargs(self):
+        """Test :meth:`nailgun.config.ServerConfig.get_client_kwargs`.
+
+        Assert that all attributes passed in are returned, but with "url"
+        omitted.
+
+        """
+        for config in CONFIGS2.values():
+            out = config.copy()
+            out.pop('url')
+            # pylint:disable=star-args
+            self.assertEqual(out, ServerConfig(**config).get_client_kwargs())
 
 
 def _get_written_json(mock_obj):


### PR DESCRIPTION
Two commits are included in this pull request for the sake of expediency, not due to any particular technical constraint. Summary of changes:

* Create class `BaseServerConfig`, and make it the parent of class `ServerConfig`. The former contains re-usable functionality, and the latter contains NailGun-specific customizations.
* Make API documentation include documentation for members (functions, methods and attributes) and special members (e.g. `__init__`) by default.

Please see the individual commits for more detailed commit messages. This is likely to be the last pull request before releasing version 0.2.0.