### PR TITLE
Generate ``DateField`` and ``DatTimeField``.

### DIFF
--- a/nailgun/entity_fields.py
+++ b/nailgun/entity_fields.py
@@ -46,6 +46,8 @@ UTF-8 values, which is unpleasant to work with.
 from fauxfactory import (
     gen_boolean,
     gen_choice,
+    gen_date,
+    gen_datetime,
     gen_email,
     gen_integer,
     gen_ipaddr,
@@ -198,9 +200,27 @@ class StringField(Field):
 class DateField(Field):
     """Field that represents a date"""
 
+    def __init__(self, min_date=None, max_date=None):
+        # If ``None`` is passed then ``FauxFactory`` will deal with it.
+        self.min_date = min_date
+        self.max_date = max_date
+
+    def gen_value(self):
+        """Return a value suitable for a :class:`DateField`."""
+        return gen_date(self.min_date, self.max_date)
+
 
 class DateTimeField(Field):
     """Field that represents a datetime"""
+
+    def __init__(self, min_date=None, max_date=None):
+        # If ``None`` is passed then ``FauxFactory`` will deal with it.
+        self.min_date = min_date
+        self.max_date = max_date
+
+    def gen_value(self):
+        """Return a value suitable for a :class:`DateTimeField`."""
+        return gen_datetime(self.min_date, self.max_date)
 
 
 class DictField(Field):

--- a/tests/test_entity_fields.py
+++ b/tests/test_entity_fields.py
@@ -3,6 +3,7 @@ from nailgun import entity_fields
 from random import randint
 from sys import version_info
 from unittest import TestCase
+import datetime
 import socket
 
 
@@ -45,6 +46,18 @@ class GenValueTestCase(TestCase):
     def test_boolean_field(self):
         """Test :class:`nailgun.entity_fields.BooleanField`."""
         self.assertIn(entity_fields.BooleanField().gen_value(), (True, False))
+
+    def test_date_field(self):
+        """Test :class:`nailgun.entity_fields.DateField`."""
+        self.assertIsInstance(
+            entity_fields.DateField().gen_value(), datetime.date
+        )
+
+    def test_datetime_field(self):
+        """Test :class:`nailgun.entity_fields.DateTimeField`."""
+        self.assertIsInstance(
+            entity_fields.DateTimeField().gen_value(), datetime.datetime
+        )
 
     def test_email_field(self):
         """Test :class:`nailgun.entity_fields.EmailField`.


### PR DESCRIPTION
Added code that generates ``DateField`` and ``DatTimeField`` entities.
This will be useful for synchronization plans and schedule tasks in
``Robottelo``.