### PR TITLE
Let NailGun target multiple server versions

### DIFF
--- a/nailgun/entity_fields.py
+++ b/nailgun/entity_fields.py
@@ -56,8 +56,6 @@ from fauxfactory import (
     gen_string,
     gen_url,
 )
-from importlib import import_module
-from inspect import isclass
 import random
 # pylint:disable=too-few-public-methods
 # The classes in this module serve a declarative role. It is OK that they don't
@@ -73,10 +71,6 @@ import random
 
 # A sentinel object, used when `None` does not suffice.
 _SENTINEL = object()
-
-#: The default module that will be searched when an entity class needs to be
-#: found. Used by at least :class:`OneToOneField` and `OneToManyField`.
-ENTITIES_MODULE = 'nailgun.entities'
 
 
 class Field(object):
@@ -280,14 +274,8 @@ class OneToOneField(Field):
         super(OneToOneField, self).__init__(*args, **kwargs)
 
     def gen_value(self):
-        """Return the class that this field references.
-
-        If ``self.entity`` is a class, return that class. Otherwise, search
-        ``self.module`` (default: :data:`ENTITIES_MODULE`) for a class named
-        ``self.entity`` and return it.
-
-        """
-        return _get_class(self.entity, self.module)
+        """Return the class that this field references."""
+        return self.entity
 
 
 class OneToManyField(Field):
@@ -304,12 +292,8 @@ class OneToManyField(Field):
         super(OneToManyField, self).__init__(*args, **kwargs)
 
     def gen_value(self):
-        """Return the class that this field references.
-
-        This method behaves exactly like :meth:`OneToOneField.gen_value`.
-
-        """
-        return _get_class(self.entity, self.module)
+        """Return the class that this field references."""
+        return self.entity
 
 
 class URLField(StringField):
@@ -318,22 +302,3 @@ class URLField(StringField):
     def gen_value(self):
         """Return a value suitable for a :class:`URLField`."""
         return gen_url()
-
-
-def _get_class(class_or_name, module=None):
-    """Return a class object.
-
-    If ``class_or_name`` is a class, it is returned untouched. Otherwise,
-    ``class_or_name`` is assumed to be a string. In this case, ``module`` is
-    searched for a class by that name and returned.
-
-    :param class_or_name: Either a class or the name of a class.
-    :param module: A string. A dotted module name.
-    :return: Either the class passed in or a class from ``module``.
-
-    """
-    if isclass(class_or_name):
-        return class_or_name
-    if module is None:
-        module = ENTITIES_MODULE
-    return getattr(import_module(module), class_or_name)

--- a/nailgun/entity_fields.py
+++ b/nailgun/entity_fields.py
@@ -2,45 +2,20 @@
 
 Each of the fields in this module corresponds to some type of information that
 Satellite tracks. When paired the classes in :class:`nailgun.entity_mixins`, it
-is possible to represent the entities that Satellite manages. For example,
-consider this abbreviated class definition::
+is possible to represent the entities that Satellite manages. For a concrete
+example of how this works, see :class:`nailgun.entity_mixins.Entity`.
 
-    class User(
-            entity_mixins.Entity,
-            entity_mixins.EntityCreateMixin,
-            entity_mixins.EntityDeleteMixin,
-            entity_mixins.EntityReadMixin):
-        entity_fields.login = StringField(
-            length=(1, 100),
-            required=True,
-            str_type=('alpha', 'alphanumeric', 'cjk', 'latin1'),
-        )
-        entity_fields.admin = BooleanField(null=True)
-        entity_fields.firstname = StringField(null=True, length=(1, 50))
-        entity_fields.lastname = StringField(null=True, length=(1, 50))
-        entity_fields.mail = EmailField(required=True)
-        entity_fields.password = StringField(required=True)
-
-The class represents a user account on a Satellite server. Each of the fields
-represents some piece of information that is associated with a user account,
-and the mixins provide useful methods.
-
-Fields are intended to be used declaratively. You probably should not be
-interacting with the field classes or their methods directly. Instead, they are
-used by the various mixins. For example,
-:meth:`nailgun.entity_mixins.EntityReadMixin.read` can be used like this::
-
-    user = User(id=5).read()
-
-:meth:`nailgun.entity_mixins.EntityReadMixin.read` creates a new ``User``
-object and populates it. The method knows how to deal with the data returned by
-the server because of the fields on the ``User`` class.
+Fields are typically used declaratively in an entity's ``__init__`` function
+and are otherwise left untouched, except by the mixin methods. For example,
+:meth:`nailgun.entity_mixins.EntityReadMixin.read` looks at the fields on an
+entity to determine what information it should expect the server to return.
 
 A secondary use of fields is to generate random data. For example, you could
-call ``User.login.gen_value()`` (implemented at :meth:`StringField.gen_value`)
-to generate a random login. Beware that these methods strive to produce the
-most outrageous values that are still legal, so they will often return nonsense
-UTF-8 values, which is unpleasant to work with.
+call ``User.get_fields()['login'].gen_value()`` to generate a random login.
+(``gen_value`` is implemented at :meth:`StringField.gen_value`) Beware that the
+``gen_value`` methods strive to produce the most outrageous values that are
+still legal, so they will often return nonsense UTF-8 values, which is
+unpleasant to work with manually.
 
 """
 from fauxfactory import (

--- a/nailgun/entity_mixins.py
+++ b/nailgun/entity_mixins.py
@@ -152,7 +152,7 @@ class NoSuchFieldError(Exception):
 
 
 class Entity(object):
-    """A logical representation of a Foreman entity.
+    """A representation of a logically related set of API paths.
 
     This class is rather useless as is, and it is intended to be subclassed.
     Subclasses can specify two useful types of information:
@@ -160,23 +160,24 @@ class Entity(object):
     * fields
     * metadata
 
-    Fields are represented by setting class attributes, and metadata is
-    represented by settings attributes on the inner class named ``Meta``. For
-    example, consider this class declaration:
+    Fields are represented by populating the ``_fields`` instance attribute,
+    and metadata is represented by settings attributes on the inner class named
+    ``Meta``. For example, consider this class definition:
 
     >>> class User(Entity):
     ...     def __init__(self, server_config=None, **kwargs):
-    ...         fields = {
+    ...         self._fields = {
     ...             'name': StringField(),
     ...             'supervisor': OneToOneField('User'),
     ...             'subordinate': OneToManyField('User'),
     ...         }
+    ...         return super(User, self).__init__(server_config, **kwargs)
     ...     class Meta(object):
     ...         api_path = 'api/users'
 
-    In the example above, the class attributes of ``User`` are fields, and the
-    class attributes of ``Meta`` are metadata. Here is one way to instantiate
-    the ``User`` object shown above:
+    In the example above, instance attribute ``User._fields`` defines fields
+    and class attribute ``Meta`` defines metadata. Here is one way to
+    instantiate the ``User`` object shown above:
 
     >>> user = User(
     ...     name='Alice',
@@ -200,14 +201,17 @@ class Entity(object):
 
     An entity object is useless if you are unable to use it to communicate with
     a server. The solution is to provide a :class:`nailgun.config.ServerConfig`
-    when instantiating a new entity. This configuration object is stored as an
-    instance variable named ``_server_config`` and used by methods such as
-    :meth:`nailgun.entity_mixins.Entity.path`.
+    when instantiating a new entity.
 
     1. If the ``server_config`` argument is specified, then that is used.
     2. Otherwise, if :data:`nailgun.entity_mixins.DEFAULT_SERVER_CONFIG` is
        set, then that is used.
     3. Otherwise, call :meth:`nailgun.config.ServerConfig.get`.
+
+    This configuration object is stored as a private instance variable and is
+    used by mixin methods, such as :meth:`nailgun.entity_mixins.Entity.path`.
+    For more information on server configuration objects, see
+    :class:`nailgun.config.BaseServerConfig`.
 
     """
 

--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,5 @@ setup(
         'Programming Language :: Python :: 3.4',
     ],
     packages=find_packages(),
-    install_requires=['requests', 'pyxdg'],
+    install_requires=['pyxdg', 'requests', 'setuptools'],
 )

--- a/tests/test_entity_fields.py
+++ b/tests/test_entity_fields.py
@@ -23,25 +23,17 @@ class GenValueTestCase(TestCase):
 
     def test_one_to_one_field(self):
         """Test :class:`nailgun.entity_fields.OneToOneField`."""
-        for klass in (
-                entity_fields.OneToOneField(TestClass).gen_value(),
-                entity_fields.OneToOneField(
-                    'TestClass',
-                    'tests.test_entity_fields'
-                ).gen_value(),
-        ):
-            self.assertEqual(klass, TestClass)
+        self.assertEqual(
+            entity_fields.OneToOneField(TestClass).gen_value(),
+            TestClass
+        )
 
     def test_one_to_many_field(self):
         """Test :class:`nailgun.entity_fields.OneToManyField`."""
-        for klass in (
-                entity_fields.OneToManyField(TestClass).gen_value(),
-                entity_fields.OneToManyField(
-                    'TestClass',
-                    'tests.test_entity_fields'
-                ).gen_value(),
-        ):
-            self.assertEqual(klass, TestClass)
+        self.assertEqual(
+            entity_fields.OneToManyField(TestClass).gen_value(),
+            TestClass
+        )
 
     def test_boolean_field(self):
         """Test :class:`nailgun.entity_fields.BooleanField`."""


### PR DESCRIPTION
There are two commits in this branch, and I recommend looking at both commit messages for full details. Summary of changes in this branch:

* Give class `BaseServerConfig` (and `ServerConfig`) an instance attribute named   "version". This attribute can be used by entity classes when figuring out how to talk to a server. For example, method `Product.read` will perform a time-consuming work-around for a bug in the server's response, but only if the server is running version 6.0.
* Change entity fields from class attributes to instance attributes:

  > Representing entity fields as instance attributes allows the exact set of
  > fields on a given entity to be determined at run-time. Thus, you could have
  > one Repository object that targets 6.0 and does not have a
  > `docker_upstream_name` field and a second Repository object that targets 6.1
  > and does have that field.

* Update documentation to deal with the changes.

For further examples of how to use the new "version" server configuration attribute, see class `nailgun.config.BaseServerConfig`. For a look at how entity fields are now defined, see class `nailgun.entity_mixins.Entity`. For examples of how the new "version" server configuration attribute is used by entities, see method `nailgun.entities.Product.read` and `nailgun.entities.Repository.__init__`.