### PR TITLE
Fix entities.Product.fetch_rhproduct_id returning no results

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2081,10 +2081,7 @@ class Product(
         response = client.get(
             self.path(which='base'),
             auth=self._server_config.auth,
-            data={
-                u'organization_id': org_id,
-                u'search': 'name={0}'.format(name),
-            },
+            data={u'organization_id': org_id, u'name': name},
             verify=self._server_config.verify,
         )
         response.raise_for_status()


### PR DESCRIPTION
Issue is similar to described in pull request [SatelliteQE/robottelo#1611](https://github.com/SatelliteQE/robottelo/pull/1611) (full description there)

Robottelo tests ```test_associate_product_1``` and ```test_associate_product_3``` were failing for me with following trace:
```
File "robottelo/tests/foreman/ui/test_activationkey.py", line 1244, in test_associate_product_3
    rh_repo['releasever']
  File "robottelo/robottelo/api/utils.py", line 117, in enable_rhrepo_and_fetchid
    prd_id = entities.Product().fetch_rhproduct_id(name=product, org_id=org_id)
  File "nailgun/nailgun/entities.py", line 2094, in fetch_rhproduct_id
    "The length of the results is:", len(results))
APIResponseError: ('The length of the results is:', 0)
```
The root cause is ```entities.Product.fetch_rhproduct_id``` returning no results. After applying similar to [SatelliteQE/robottelo#1611](https://github.com/SatelliteQE/robottelo/pull/1611) fix for ```fetch_rhproduct_id``` the tests are working fine.
