### PR TITLE
Adding support for Location entity.

### DIFF
--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -241,6 +241,7 @@ class CreatePayloadTestCase(TestCase):
         entities.HostCollection,
         entities.Host,
         entities.LifecycleEnvironment,
+        entities.Location,
         entities.Media,
         entities.OperatingSystem,
         entities.UserGroup,


### PR DESCRIPTION
You can now create, read and delete locations.

```python
In [1]: from nailgun.entities import Location

In [2]: foo = Location().create()

In [3]: foo.get_values()
Out[3]:
{'compute_resource': [],
 'config_template': [<nailgun.entities.ConfigTemplate at 0x107c0be90>,
  <nailgun.entities.ConfigTemplate at 0x107c0b910>,
  <nailgun.entities.ConfigTemplate at 0x107c16050>,
  <nailgun.entities.ConfigTemplate at 0x107c16310>,
  <nailgun.entities.ConfigTemplate at 0x107c165d0>,
  <nailgun.entities.ConfigTemplate at 0x107c16890>,
  <nailgun.entities.ConfigTemplate at 0x107c16b50>,
  <nailgun.entities.ConfigTemplate at 0x107c16e10>,
  <nailgun.entities.ConfigTemplate at 0x107c19110>,
  <nailgun.entities.ConfigTemplate at 0x107c193d0>,
  <nailgun.entities.ConfigTemplate at 0x107c19690>,
  <nailgun.entities.ConfigTemplate at 0x107c19950>,
  <nailgun.entities.ConfigTemplate at 0x107c19c10>],
 'description': None,
 'domain': [],
 'environment': [],
 'hostgroup': [],
 'id': 18,
 'media': [],
 'name': u'\ufc8d\u1c73\uc3a5\u0564\ud17e\u7f1a\u55a2\ub819\u040f\uc88b\u569f\u478c\uadc5\uc8c0\ubeb7\u1565\u13c4\ucd9f\u588d\u4258\u42d3\ub4f5\u82e9\u3153\ub04b',
 'organization': [],
 'smart_proxy': [],
 'subnet': [],
 'user': []}

In [4]: foo.read()
Out[4]: <nailgun.entities.Location at 0x105ef4850>

In [5]: foo.delete()
Out[5]:
{u'ancestry': None,
 u'apply_info_task_id': None,
 u'created_at': u'2015-04-28T16:06:18Z',
 u'default_info': None,
 u'description': None,
 u'id': 18,
 u'ignore_types': [u'ConfigTemplate', u'Hostgroup'],
 u'katello_default': False,
 u'label': None,
 u'name': u'\ufc8d\u1c73\uc3a5\u0564\ud17e\u7f1a\u55a2\ub819\u040f\uc88b\u569f\u478c\uadc5\uc8c0\ubeb7\u1565\u13c4\ucd9f\u588d\u4258\u42d3\ub4f5\u82e9\u3153\ub04b',
 u'title': u'\ufc8d\u1c73\uc3a5\u0564\ud17e\u7f1a\u55a2\ub819\u040f\uc88b\u569f\u478c\uadc5\uc8c0\ubeb7\u1565\u13c4\ucd9f\u588d\u4258\u42d3\ub4f5\u82e9\u3153\ub04b',
 u'updated_at': u'2015-04-28T16:06:18Z'}
```

Notes:
* The attribute ``Realm`` is not being returned by the API. It needs to
  be discussed with DEV.
* The APIDOC does not mention that ``Organizations`` and ``Parameters``
  are valid attributes.
* Finally, when using the web ui, one can 'nest' Locations, which is
  also not mentioned by APIDOC.