### PR TITLE
Adding ``EntityReadMixin`` to ``SmartProxy``.

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2815,7 +2815,7 @@ class Role(
         server_modes = ('sat', 'sam')
 
 
-class SmartProxy(Entity):
+class SmartProxy(Entity, EntityReadMixin):
     """A representation of a Smart Proxy entity."""
 
     def __init__(self, server_config=None, **kwargs):
@@ -2829,6 +2829,39 @@ class SmartProxy(Entity):
         """Non-field information about this entity."""
         api_path = 'api/v2/smart_proxies'
         server_modes = ('sat')
+
+    def path(self, which=None):
+        """Extend ``nailgun.entity_mixins.Entity.path``.
+
+        The format of the returned path depends on the value of ``which``:
+
+        refresh
+            /katello/api/v2/smart_proxies/:id/refresh
+
+        """
+        if which in ('refresh',):
+            return '{0}/{1}'.format(
+                super(SmartProxy, self).path(which='self'),
+                which
+            )
+        return super(SmartProxy, self).path(which)
+
+    def refresh(self, synchronous=True):
+        """Refresh Capsule features
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's reponse otherwise.
+        :returns: The server's JSON-decoded response.
+
+        """
+        response = client.put(
+            self.path('refresh'),
+            {},
+            auth=self._server_config.auth,
+            verify=self._server_config.verify,
+        )
+        return _handle_response(response, self._server_config, synchronous)
 
 
 class SmartVariable(Entity):

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -33,6 +33,7 @@ class PathTestCase(TestCase):
         (entities.Organization, '/organizations'),
         (entities.Product, '/products'),
         (entities.Repository, '/repositories'),
+        (entities.SmartProxy, '/smart_proxies'),
         (entities.System, '/systems'),
     )
     @unpack
@@ -130,6 +131,7 @@ class PathTestCase(TestCase):
         (entities.Product, 'repository_sets'),
         (entities.Repository, 'sync'),
         (entities.Repository, 'upload_content'),
+        (entities.SmartProxy, 'refresh'),
         (entities.System, 'self'),
     )
     @unpack


### PR DESCRIPTION
Though creating a new capsule (aka smart proxy) via the API is something
thst requires a bit more research, one can at least GET existing ones:

```python
In [5]: from nailgun.entities import SmartProxy

In [6]: sp = SmartProxy(id=1).read()

In [7]: sp.get_values()
Out[7]:
{'id': 1,
 'name': u'$FQDN',
 'url': u'https://$FQDN:9090'}

```

Also, added a new ``refresh`` method to ``SmartProxy``:

```python
In [2]: SmartProxy(id=1).refresh()
Out[2]:
{u'created_at': u'2015-04-27T20:34:54Z',
 u'id': 1,
 u'name': u'$FQDN',
 u'updated_at': u'2015-04-27T20:34:54Z',
 u'url': u'https://$FQDN:9090'}
```