### PR TITLE
Updated instance attributes for ``Subnet``.

### DIFF
--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -246,6 +246,7 @@ class CreatePayloadTestCase(TestCase):
         entities.Location,
         entities.Media,
         entities.OperatingSystem,
+        entities.Subnet,
         entities.UserGroup,
         entities.User,
     )


### PR DESCRIPTION
I have updated the instance attibutes for ``Subnet`` to match what's
currently exposed via the v2 API.

```python
In [21]: from nailgun import entity_mixins

In [22]: entity_mixins.CREATE_MISSING = True

In [23]: foo = Subnet().create()

In [24]: foo.get_values()
Out[24]:
{'boot_mode': u'DHCP',
 'dhcp': None,
 'dns': None,
 'dns_primary': None,
 'dns_secondary': None,
 'domain': [],
 'from_': None,
 'gateway': None,
 'id': 4,
 'ipam': u'DHCP',
 'location': [],
 'mask': u'192.0.0.0',
 'name': u'\ub05b\u7330\u34bf\u5ad6\u58ae\u80e0\ua45e\u86dc\u3d32\u77d9\u587b\u51f1\uba8f\u39ab\u4fee\u7180\u3de3\u5e04\u0510\u5d94\u5133\u49ab\u5c48\u95a9\uad34\u8fbb\u48f4\u81ad\ua5b3',
 'network': u'242.126.150.103',
 'organization': [],
 'tftp': None,
 'to': None,
 'vlanid': None}

In [25]: foo.delete()
Out[25]:
{u'boot_mode': u'DHCP',
 u'created_at': u'2015-04-29T14:43:08Z',
 u'dhcp_id': None,
 u'discovery_id': None,
 u'dns_id': None,
 u'dns_primary': None,
 u'dns_secondary': None,
 u'from': None,
 u'gateway': None,
 u'id': 4,
 u'ipam': u'DHCP',
 u'mask': u'192.0.0.0',
 u'name': u'\ub05b\u7330\u34bf\u5ad6\u58ae\u80e0\ua45e\u86dc\u3d32\u77d9\u587b\u51f1\uba8f\u39ab\u4fee\u7180\u3de3\u5e04\u0510\u5d94\u5133\u49ab\u5c48\u95a9\uad34\u8fbb\u48f4\u81ad\ua5b3',
 u'network': u'242.126.150.103',
 u'priority': None,
 u'tftp_id': None,
 u'to': None,
 u'updated_at': u'2015-04-29T14:43:08Z',
 u'vlanid': None}

In [26]: entity_mixins.CREATE_MISSING = False

In [27]: foo = Subnet().create()
---------------------------------------------------------------------------
HTTPError                                 Traceback (most recent call last)
<ipython-input-27-e59b852028fc> in <module>()
----> 1 foo = Subnet().create()

/hacking/nailgun/nailgun/entity_mixins.py in create(self, create_missing)
    668
    669         """
--> 670         return self.read(attrs=self.create_json(create_missing))

/hacking/nailgun/nailgun/entity_mixins.py in create_json(self, create_missing)
    639         """
    640         response = self.create_raw(create_missing)
--> 641         response.raise_for_status()
    642         return response.json()
    643

/.virtualenvs/nailgun/lib/python2.7/site-packages/requests/models.pyc in raise_for_status(self)
    849
    850         if http_error_msg:
--> 851             raise HTTPError(http_error_msg, response=self)
    852
    853     def close(self):

HTTPError: 422 Client Error: Unprocessable Entity

In [28]: foo = Subnet().create_raw()

In [29]: foo.json()
Out[29]:
{u'error': {u'errors': {u'mask': [u"can't be blank", u'is invalid'],
   u'name': [u"can't be blank"],
   u'network': [u"can't be blank", u'is invalid']},
  u'full_messages': [u"Network address can't be blank",
   u'Network address is invalid',
   u"Network mask can't be blank",
   u'Network mask is invalid',
   u"Name can't be blank"],
  u'id': None}}

In [30]: foo = Subnet().create_raw(create_missing=True)

In [31]: foo.json()
Out[31]:
{u'boot_mode': u'DHCP',
 u'cidr': 23,
 u'created_at': u'2015-04-29T14:44:16Z',
 u'dhcp': None,
 u'dns': None,
 u'dns_primary': None,
 u'dns_secondary': None,
 u'domains': [],
 u'from': None,
 u'gateway': None,
 u'id': 5,
 u'interfaces': [],
 u'ipam': u'DHCP',
 u'locations': [],
 u'mask': u'255.255.254.0',
 u'name': u'\u038e\uce70\u70ee\uacf6\u5a4f\u14a7\u7edd\u67d5\uc6d9\u7b48\u8003\u7681\u65ed\u656e\u87f4\u581a\uc7d6\u6459\ubb1a\u399d\u1986\u8b38\u6bbd\u1663\u7aaa\uff68\uc3fe\u0547\u2d21\ub881',
 u'network': u'88.167.55.226',
 u'network_address': u'88.167.55.226/23',
 u'organizations': [],
 u'priority': None,
 u'tftp': None,
 u'to': None,
 u'updated_at': u'2015-04-29T14:44:16Z',
 u'vlanid': None}
```