### PR TITLE
Add the "role" field to the "User" entity

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -3350,6 +3350,7 @@ class User(
                 null=True,
             ),
             'password': entity_fields.StringField(required=True),
+            'role': entity_fields.OneToManyField(Role, null=True),
         }
         super(User, self).__init__(server_config, **kwargs)
 


### PR DESCRIPTION
Users can be associated with zero or more roles via the API, as stated by [BZ 1216239](https://bugzilla.redhat.com/show_bug.cgi?id=1216239).