### PR TITLE
Check values assigned to `OneToManyField`s

### DIFF
--- a/tests/test_entity_mixins.py
+++ b/tests/test_entity_mixins.py
@@ -241,6 +241,18 @@ class EntityTestCase(unittest.TestCase):
         with self.assertRaises(entity_mixins.NoSuchPathError):
             SampleEntity(self.server_config).path('self')
 
+    def test_no_such_field_error(self):
+        """Try to raise a :class:`nailgun.entity_mixins.NoSuchFieldError`."""
+        SampleEntity(self.server_config, name='Alice')
+        with self.assertRaises(entity_mixins.NoSuchFieldError):
+            SampleEntity(self.server_config, namee='Alice')
+
+    def test_bad_value_error(self):
+        """Try to raise a :class:`nailgun.entity_mixins.BadValueError`."""
+        ManyRelatedEntity(self.server_config, entities=[1])
+        with self.assertRaises(entity_mixins.BadValueError):
+            ManyRelatedEntity(self.server_config, entities=1)
+
 
 class EntityDeleteMixinTestCase(unittest.TestCase):
     """Tests for entity mixin classes."""


### PR DESCRIPTION
Fix #55. Prevent users from assigning non-iterable values to `OneToManyField`s.
For example:

    >>> from nailgun.entities import Architecture
    >>> Architecture(operatingsystem=[1])
    <nailgun.entities.Architecture object at 0x7f17df759390>
    >>> Architecture(operatingsystem=1)
    Traceback (most recent call last):
    File "<stdin>", line 1, in <module>
    File "nailgun/entities.py", line 239, in __init__
        super(Architecture, self).__init__(server_config, **kwargs)
    File "nailgun/entity_mixins.py", line 280, in __init__
        .format(field_name, field_value)
    nailgun.entity_mixins.BadValueError: An inappropriate value was assigned to the "operatingsystem" field. An iterable of entities and/or entity IDs should be assigned, but the following was given: 1