### PR TITLE
Customize how entity objects are stringified

### DIFF
--- a/nailgun/client.py
+++ b/nailgun/client.py
@@ -116,13 +116,13 @@ def head(url, **kwargs):
     return response
 
 
-def get(url, **kwargs):
+def get(url, params=None, **kwargs):
     """A wrapper for ``requests.get``."""
     _set_content_type(kwargs)
     if _content_type_is_json(kwargs) and kwargs.get('data') is not None:
         kwargs['data'] = dumps(kwargs['data'])
     _log_request('GET', url, kwargs)
-    response = requests.get(url, **kwargs)
+    response = requests.get(url, params, **kwargs)
     _log_response(response)
     return response
 

--- a/nailgun/config.py
+++ b/nailgun/config.py
@@ -107,6 +107,17 @@ class BaseServerConfig(object):
         if version is not None:
             self.version = parse_version(version)
 
+    def __repr__(self):
+        return '{0}.{1}({2})'.format(
+            self.__module__,
+            type(self).__name__,
+            ', '.join(
+                '{0}={1}'.format(key, repr(value))
+                for key, value
+                in vars(self).items()
+            )
+        )
+
     @classmethod
     def delete(cls, label='default', path=None):
         """Delete a server configuration.

--- a/nailgun/entity_mixins.py
+++ b/nailgun/entity_mixins.py
@@ -374,6 +374,18 @@ class Entity(object):
         attrs.pop('_fields')
         return attrs
 
+    def __repr__(self):
+        return '{0}.{1}({2}{3})'.format(
+            self.__module__,
+            type(self).__name__,
+            repr(self._server_config),
+            ''.join(
+                ', {0}={1}'.format(key, repr(value))
+                for key, value
+                in self.get_values().items()
+            )
+        )
+
 
 class EntityDeleteMixin(object):
     """A mixin that adds the ability to delete an entity."""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -84,12 +84,12 @@ class ClientTestCase(TestCase):
                 )
 
                 # Did the wrapper function pass the correct params to requests?
-                if meth in ('delete', 'get', 'head'):
+                if meth in ('delete', 'head'):
                     requests_meth.assert_called_once_with(
                         self.bogus_url,
                         headers={'content-type': 'application/json'}
                     )
-                elif meth in ('patch', 'put'):
+                elif meth in ('get', 'patch', 'put'):
                     requests_meth.assert_called_once_with(
                         self.bogus_url,
                         None,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,7 @@
 """Unit tests for :mod:`nailgun.config`."""
 from mock import call, mock_open, patch
 from nailgun.config import BaseServerConfig, ServerConfig
+from pkg_resources import parse_version
 from unittest import TestCase
 import json
 
@@ -181,6 +182,123 @@ class ServerConfigTestCase(TestCase):
                 server_config = ServerConfig.get(label, FILE_PATH)
             if hasattr(server_config, 'auth'):
                 self.assertIsInstance(server_config.auth, tuple)
+
+
+class ReprTestCase(TestCase):
+    """Test method ``nailgun.config.BaseServerConfig.__repr__``."""
+
+    def test_bsc_v1(self):
+        """Test :class:`nailgun.config.BaseServerConfig`.
+
+        Assert that ``__repr__`` works correctly when ``url`` is specified.
+
+        """
+        target = "nailgun.config.BaseServerConfig(url='bogus')"
+        self.assertEqual(target, repr(BaseServerConfig('bogus')))
+        import nailgun  # noqa pylint:disable=unused-variable
+        # pylint:disable=eval-used
+        self.assertEqual(target, repr(eval(repr(BaseServerConfig('bogus')))))
+
+    def test_bsc_v2(self):
+        """Test :class:`nailgun.config.BaseServerConfig`.
+
+        Assert that ``__repr__`` works correctly when ``url`` and ``auth`` are
+        specified.
+
+        """
+        targets = (
+            "nailgun.config.BaseServerConfig(url='flim', auth='flam')",
+            "nailgun.config.BaseServerConfig(auth='flam', url='flim')",
+        )
+        self.assertIn(repr(BaseServerConfig('flim', auth='flam')), targets)
+        import nailgun  # noqa pylint:disable=unused-variable
+        # pylint:disable=eval-used
+        self.assertIn(
+            repr(eval(repr(BaseServerConfig('flim', auth='flam')))),
+            targets
+        )
+
+    def test_bsc_v3(self):
+        """Test :class:`nailgun.config.BaseServerConfig`.
+
+        Assert that ``__repr__`` works correctly when ``url`` and ``version``
+        are specified.
+
+        """
+        ver = repr(parse_version('1'))
+        targets = (
+            "nailgun.config.BaseServerConfig(url='flim', version={0})".format(
+                ver
+            ),
+            "nailgun.config.BaseServerConfig(version={0}, url='flim')".format(
+                ver
+            ),
+        )
+        self.assertIn(repr(BaseServerConfig('flim', version='1')), targets)
+
+    def test_sc_v1(self):
+        """Test :class:`nailgun.config.ServerConfig`.
+
+        Assert that ``__repr__`` works correctly when only a URL is passed in.
+
+        """
+        target = "nailgun.config.ServerConfig(url='bogus')"
+        self.assertEqual(target, repr(ServerConfig('bogus')))
+        import nailgun  # noqa pylint:disable=unused-variable
+        # pylint:disable=eval-used
+        self.assertEqual(target, repr(eval(repr(ServerConfig('bogus')))))
+
+    def test_sc_v2(self):
+        """Test :class:`nailgun.config.ServerConfig`.
+
+        Assert that ``__repr__`` works correctly when ``url`` and ``auth`` are
+        specified.
+
+        """
+        targets = (
+            "nailgun.config.ServerConfig(url='flim', auth='flam')",
+            "nailgun.config.ServerConfig(auth='flam', url='flim')",
+        )
+        self.assertIn(repr(ServerConfig('flim', auth='flam')), targets)
+        import nailgun  # noqa pylint:disable=unused-variable
+        # pylint:disable=eval-used
+        self.assertIn(
+            repr(eval(repr(ServerConfig('flim', auth='flam')))),
+            targets
+        )
+
+    def test_sc_v3(self):
+        """Test :class:`nailgun.config.ServerConfig`.
+
+        Assert that ``__repr__`` works correctly when ``url`` and ``version``
+        are specified.
+
+        """
+        ver = repr(parse_version('1'))
+        targets = (
+            "nailgun.config.ServerConfig(url='flim', version={0})".format(ver),
+            "nailgun.config.ServerConfig(version={0}, url='flim')".format(ver),
+        )
+        self.assertIn(repr(ServerConfig('flim', version='1')), targets)
+
+    def test_sc_v4(self):
+        """Test :class:`nailgun.config.ServerConfig`.
+
+        Assert that ``__repr__`` works correctly when ``url`` and ``verify``
+        are specified.
+
+        """
+        targets = (
+            "nailgun.config.ServerConfig(url='flim', verify='flub')",
+            "nailgun.config.ServerConfig(verify='flub', url='flim')",
+        )
+        self.assertIn(repr(ServerConfig('flim', verify='flub')), targets)
+        import nailgun  # noqa pylint:disable=unused-variable
+        # pylint:disable=eval-used
+        self.assertIn(
+            repr(eval(repr(ServerConfig('flim', verify='flub')))),
+            targets
+        )
 
 
 def _get_written_json(mock_obj):

--- a/tests/test_entity_mixins.py
+++ b/tests/test_entity_mixins.py
@@ -253,6 +253,69 @@ class EntityTestCase(unittest.TestCase):
         with self.assertRaises(entity_mixins.BadValueError):
             ManyRelatedEntity(self.server_config, entities=1)
 
+    def test_repr_v1(self):
+        """Test method ``nailgun.entity_mixins.Entity.__repr__``.
+
+        Assert that ``__repr__`` works correctly when no arguments are passed
+        to an entity.
+
+        """
+        entity = ManyRelatedEntity(self.server_config)
+        target = 'tests.test_entity_mixins.ManyRelatedEntity({0})'.format(
+            repr(self.server_config)
+        )
+        self.assertEqual(repr(entity), target)
+        import nailgun  # noqa pylint:disable=unused-variable
+        import tests  # noqa pylint:disable=unused-variable
+        # pylint:disable=eval-used
+        self.assertEqual(repr(eval(repr(entity))), target)
+
+    def test_repr_v2(self):
+        """Test method ``nailgun.entity_mixins.Entity.__repr__``.
+
+        Assert that ``__repr__`` works correctly when an ID is passed to an
+        entity.
+
+        """
+        entity = ManyRelatedEntity(self.server_config, id=gen_integer())
+        target = (
+            'tests.test_entity_mixins.ManyRelatedEntity({0}, id={1})'
+            .format(
+                repr(self.server_config),
+                entity.id  # pylint:disable=no-member
+            )
+        )
+        self.assertEqual(repr(entity), target)
+        import nailgun  # noqa pylint:disable=unused-variable
+        import tests  # noqa pylint:disable=unused-variable
+        # pylint:disable=eval-used
+        self.assertEqual(repr(eval(repr(entity))), target)
+
+    def test_repr_v3(self):
+        """Test method ``nailgun.entity_mixins.Entity.__repr__``.
+
+        Assert that ``__repr__`` works correctly when one entity has a foreign
+        key relationship to a second entity.
+
+        """
+        entity_id = gen_integer()
+        target = (
+            'tests.test_entity_mixins.ManyRelatedEntity('
+            '{0}, '
+            'entities=[tests.test_entity_mixins.SampleEntity({0}, id={1})]'
+            ')'
+            .format(self.server_config, entity_id)
+        )
+        entity = ManyRelatedEntity(
+            self.server_config,
+            entities=[SampleEntity(self.server_config, id=entity_id)]
+        )
+        self.assertEqual(repr(entity), target)
+        import nailgun  # noqa pylint:disable=unused-variable
+        import tests  # noqa pylint:disable=unused-variable
+        # pylint:disable=eval-used
+        self.assertEqual(repr(eval(repr(entity))), target)
+
 
 class EntityDeleteMixinTestCase(unittest.TestCase):
     """Tests for entity mixin classes."""


### PR DESCRIPTION
Fix #53:

> When a nailgun.entity_mixins.Entity object is stringified, little useful
> information is provided. The full dotted path to the object's type is
> provided, in addition to its memory address. However, […] that's not terribly
> useful, and it's ugly to boot

Implement and unit test the following methods:

* `nailgun.config.ServerConfig.__repr__`
* `nailgun.entity_mixins.Entity.__repr__`

Example usage (slightly edited):

```python
>>> from nailgun.entities import Product
>>> product = Product(id=1).read()
>>> product
nailgun.entities.Product(
    nailgun.config.ServerConfig(
        url=u'https://sat.example.com';,
        verify=False,
        version=<Version('6.1')>,
        auth=(…)
    ),
    gpg_key=None,
    description=None,
    label=u'Red_Hat_Beta',
    organization=nailgun.entities.Organization(
        nailgun.config.ServerConfig(
            url=u'https://sat.example.com';,
            verify=False,
            version=<Version('6.1')>,
            auth=(…)
        ),
        id=3
    ),
    sync_plan=None,
    id=1,
    name=u'Red Hat Beta'
)
```