### PR TITLE
Properly configure logging system

### DIFF
--- a/nailgun/__init__.py
+++ b/nailgun/__init__.py
@@ -15,3 +15,7 @@ As an end user, you'll typically want to use the classes exposed by
 :mod:`nailgun.entities`.
 
 """
+from logging import basicConfig
+
+
+basicConfig()

--- a/nailgun/client.py
+++ b/nailgun/client.py
@@ -89,7 +89,7 @@ def _log_response(response):
         response.text
     )
     if response.status_code >= 400:
-        logger.warn(message)
+        logger.warning(message)
     else:
         logger.debug(message)
 


### PR DESCRIPTION
Fix #61:

> When a message is sent to the logging system, that message must be handled
> some how. A typical method of handling a logging message is to simply print it
> to stderr, but other handlers might send the message to a file, fire off an
> email, emit an SMTP message or anything else you can dream up.
>
> Currently, NailGun has no logging handlers. Thus, when the nailgun.client
> logging element a logging message, that message is handed up to nailgun
> logging element, and it is then discarded.

Here's what a logging message now looks like:

> WARNING:nailgun.client:Received HTTP 422 response: {
>   "error": {"id":null,"errors":{"name":["can't be blank"]},"full_messages":["DNS domain can't be blank"]}
> }

Also, replace a call to `warn` with a call to `warning`. `warn` is deprecated.