### PR TITLE
Give generated entities a server config object

### DIFF
--- a/nailgun/entity_mixins.py
+++ b/nailgun/entity_mixins.py
@@ -582,26 +582,17 @@ class EntityCreateMixin(object):
             if field.required and not hasattr(self, field_name):
                 # Most `gen_value` methods return a value such as an integer,
                 # string or dictionary, but OneTo{One,Many}Field.gen_value
-                # returns the referenced class. Thus, for foreign key fields,
-                # this is possible:
-                #
-                #     value = field.gen_value()().create()
-                #
-                # However, `create` is more susceptible to unexpected data
-                # returned by the server. This is expecially problematic so
-                # long as NailGun has no facility for dealing with different
-                # server API versions. Until then, the more kludgy
-                # `create_json` is used.
+                # returns the referenced class.
                 if hasattr(field, 'default'):
                     value = field.default
                 elif hasattr(field, 'choices'):
                     value = gen_choice(field.choices)
                 elif isinstance(field, OneToOneField):
-                    value = field.gen_value()()
-                    value.id = field.gen_value()().create_json()['id']
+                    value = field.gen_value()(self._server_config).create(True)
                 elif isinstance(field, OneToManyField):
-                    value = [field.gen_value()()]
-                    value[0].id = field.gen_value()().create_json()['id']
+                    value = [
+                        field.gen_value()(self._server_config).create(True)
+                    ]
                 else:
                     value = field.gen_value()
                 setattr(self, field_name, value)


### PR DESCRIPTION
Fix #63 and add unit tests for the fix:

> When `create_missing` is called on an entity, it fills in all fields that are
> required and that do not have values. When filling in a field such as an
> `IntegerField` or a `StringField`, the process of creating a bogus value is
> straight-forward. When filling in a `OneToOneField` or `OneToManyField`, the
> process is more delicate. The correct entity class must be instantiated with
> an appropriate `nailgun.config.ServerConfig` object, and all of the dependent
> entity's required fields must also be filled in. Currently, method
> `nailgun.entity_mixins.EntityCreateMixin.create_missing` does not do that.
> Currently, the method instantiates a new entity without passing in a
> `ServerConfig` object (causing the new object to search for a server config)
> and `create_missing` is not called on the new entity.