### PR TITLE
Provide examples of using ServerConfig objects

### DIFF
--- a/docs/create_organization_nailgun_v2.py
+++ b/docs/create_organization_nailgun_v2.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Create an organization, print out its attributes and delete it."""
+from nailgun.entities import Organization
+from pprint import PrettyPrinter
+
+
+def main():
+    """Create an organization, print out its attributes and delete it."""
+    org = Organization(name='junk org').create()
+    PrettyPrinter().pprint(org.get_values())
+    org.delete()
+
+
+if __name__ == '__main__':
+    main()

--- a/nailgun/config.py
+++ b/nailgun/config.py
@@ -149,7 +149,7 @@ class BaseServerConfig(object):
 
     @classmethod
     def get(cls, label='default', path=None):
-        """Get a server configuration.
+        """Read a server configuration from a configuration file.
 
         :param label: A string. The configuration identified by ``label`` is
             read.
@@ -276,7 +276,10 @@ class ServerConfig(BaseServerConfig):
 
     @classmethod
     def get(cls, label='default', path=None):
-        """If ``auth`` is a two element list, convert it to a tuple.
+        """Read a server configuration from a configuration file.
+
+        This method extends :meth:`nailgun.config.BaseServerConfig.get`. Please
+        read up on that method before trying to understand this one.
 
         The entity classes rely on the requests library to be a transport
         mechanism. The methods provided by that library, such as ``get`` and
@@ -285,12 +288,13 @@ class ServerConfig(BaseServerConfig):
             Auth tuple to enable Basic/Digest/Custom HTTP Auth.
 
         However, the JSON decoder does not recognize a tuple as a type, and
-        represents sequences of elements as a tuple. Compensate for that.
+        represents sequences of elements as a tuple. Compensate for that by
+        converting ``auth`` to a two element tuple if it is a two element list.
 
         This override is done here, and not in the base class, because the base
         class may be extracted out into a separate library and used in other
         contexts. In those contexts, the presence of a list may not matter or
-        may be desireable.
+        may be desirable.
 
         """
         config = super(ServerConfig, cls).get(label, path)


### PR DESCRIPTION
Fix #44:

> The API documentation briefly mentions how to effectively use `ServerConfig`
> objects in the docstring for class `Entity`:
>
> > An entity object is useless if you are unable to use it to communicate with a
> > server. The solution is to provide a nailgun.config.ServerConfig when
> > instantiating a new entity. This configuration object is stored as an instance
> > variable named _server_config and used by methods such as
> > nailgun.entity_mixins.Entity.path().
> >
> > 1. If the server_config argument is specified, then that is used.
> > 2. Otherwise, if nailgun.entity_mixins.DEFAULT_SERVER_CONFIG is set, then that
> > is used.
> > 3. Otherwise, call nailgun.config.ServerConfig.get().
>
> That's it, though. And the docstring for `ServerConfig.get` is pretty terrible.
> The existing API documentation should be fixed up, and a nice example of how to
> effectively use this capability should be provided.