### PR TITLE
Abstracted Docker entity should inherit fields.

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -719,14 +719,14 @@ class DockerHubContainer(AbstractDockerContainer):
     """A docker container that comes from Docker Hub."""
 
     def __init__(self, server_config=None, **kwargs):
-        self._fields = {
+        super(DockerHubContainer, self).__init__(server_config, **kwargs)
+        self._fields.update({
             'repository_name': entity_fields.StringField(
                 default='busybox',
                 required=True,
             ),
             'tag': entity_fields.StringField(required=True, default='latest'),
-        },
-        super(DockerHubContainer, self).__init__(server_config, **kwargs)
+        })
 
 
 class ContentUpload(Entity):

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -431,3 +431,37 @@ class ReadTestCase(TestCase):
             # read.call_args[0] is the tuple of arguments to read().
             # pylint:disable=protected-access
             self.assertEqual(read.call_args[0][0]._server_config, self.cfg)
+
+
+class AbstractDockerTestCase(TestCase):
+    """Tests for :class:`nailgun.entities.AbstractDockerContainer`."""
+
+    def setUp(self):
+        """Set a server configuration at ``self.cfg``."""
+        self.cfg = config.ServerConfig('http://example.com')
+
+    def test_get_fields(self):
+        """Call ``nailgun.entity_mixins.Entity.get_fields``.
+
+        Assert that ``nailgun.entities.DockerHubContainer.get_fields`` returns
+        a dictionary of attributes that match what is returned by
+        ``nailgun.entities.AbstractDockerContainer.get_fields`` but also
+        returns extra attibutes unique to
+        :class:`nailgun.entities.DockerHubContainer`.
+
+        """
+        abstract_docker = entities.AbstractDockerContainer(
+            self.cfg
+        ).get_fields()
+        docker_hub = entities.DockerHubContainer(self.cfg).get_fields()
+        # Attributes should not match
+        self.assertNotEqual(abstract_docker, docker_hub)
+        # All attributes from a `entities.AbstractDockerContainer`
+        # should be found in a `entities.DockerHubContainer`.
+        for key in abstract_docker:
+            self.assertIn(key, docker_hub)
+        # These fields should be present in a `entities.DockerHubContainer`
+        # class but not in a `entities.AbstractDockerContainer` class.
+        for attr in ['repository_name', 'tag']:
+            self.assertIn(attr, docker_hub)
+            self.assertNotIn(attr, abstract_docker)


### PR DESCRIPTION
`entities.DockerHubContainer` needs to 'inherit' the fields from
`entities.AbstractDockerContainer`.

Before change:

```python
In [9]: AbstractDockerContainer().get_fields().keys()
Out[9]:
['cpu_set',
 'tty',
 'attach_stderr',
 'name',
 'attach_stdin',
 'compute_resource',
 'command',
 'location',
 'memory',
 'organization',
 'entrypoint',
 'id',
 'attach_stdout',
 'cpu_shares']

In [10]: DockerHubContainer().get_fields().keys()
Out[10]:
['cpu_set',
 'tty',
 'attach_stderr',
 'name',
 'attach_stdin',
 'compute_resource',
 'command',
 'location',
 'memory',
 'organization',
 'entrypoint',
 'id',
 'attach_stdout',
 'cpu_shares']

In [11]: AbstractDockerContainer().get_fields().keys() == DockerHubContainer().get_fields().keys()
Out[11]: True
```

After changes:

```python
In [2]: DockerHubContainer().get_fields().keys()
Out[2]:
['tty',
 'attach_stdin',
 'tag',
 'entrypoint',
 'id',
 'cpu_set',
 'repository_name',
 'attach_stderr',
 'name',
 'compute_resource',
 'command',
 'location',
 'memory',
 'organization',
 'attach_stdout',
 'cpu_shares']

In [3]: AbstractDockerContainer().get_fields().keys()
Out[3]:
['cpu_set',
 'tty',
 'attach_stderr',
 'name',
 'attach_stdin',
 'compute_resource',
 'command',
 'location',
 'memory',
 'organization',
 'entrypoint',
 'id',
 'attach_stdout',
 'cpu_shares']

In [4]: AbstractDockerContainer().get_fields().keys() == DockerHubContainer().get_fields().keys()
Out[4]: False
```