### PR TITLE
Improve test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ __pycache__/
 /build/
 /dist/
 /nailgun.egg-info/
+
+# Coverage information
+/.coverage
+/htmlcov/

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ help:
 	@echo "  help           to show this message"
 	@echo "  lint           to run flake8 and pylint"
 	@echo "  test           to run unit tests"
+	@echo "  test-coverage  to run unit tests and measure test coverage"
 	@echo "  docs-html      to generate HTML documentation"
 	@echo "  docs-clean     to remove documentation"
 	@echo "  package        to generate installable Python packages"

--- a/nailgun/client.py
+++ b/nailgun/client.py
@@ -77,8 +77,7 @@ def _set_content_type(kwargs):
 
     """
     if 'files' in kwargs:
-        return  # requests will automatically set content-type
-
+        return  # requests will automatically set the content-type
     headers = kwargs.pop('headers', {})
     headers.setdefault('content-type', 'application/json')
     kwargs['headers'] = headers

--- a/nailgun/entity_mixins.py
+++ b/nailgun/entity_mixins.py
@@ -8,12 +8,12 @@ import threading
 import time
 
 from sys import version_info
-if version_info.major == 2:
+if version_info.major == 2:  # pragma: no cover
     # pylint:disable=import-error
     from urlparse import urljoin
     import httplib as http_client
     import thread
-else:
+else:  # pragma: no cover
     from urllib.parse import urljoin  # pylint:disable=F0401,E0611
     import _thread as thread  # pylint:disable=import-error
     import http.client as http_client  # pylint:disable=import-error

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -43,10 +43,16 @@ class SetContentTypeTestCase(TestCase):
         )
 
     def test_existing_value(self):
-        """Assert that an existing content-type is not overridden."""
+        """Assert that no content-type is provided if one is set."""
         kwargs = {'headers': {'content-type': ''}}
         client._set_content_type(kwargs)  # pylint:disable=protected-access
         self.assertEqual(kwargs, {'headers': {'content-type': ''}})
+
+    def test_files_in_kwargs(self):
+        """Assert that no content-type is provided if files are given."""
+        kwargs = {'files': None}
+        client._set_content_type(kwargs)  # pylint:disable=protected-access
+        self.assertEqual(kwargs, {'files': None})
 
 
 class ClientTestCase(TestCase):

--- a/tests/test_entity_fields.py
+++ b/tests/test_entity_fields.py
@@ -1,10 +1,17 @@
+# -*- coding: utf-8 -*-
 """Unit tests for :mod:`nailgun.entity_fields`."""
+from fauxfactory.constants import VALID_NETMASKS
 from nailgun import entity_fields
 from random import randint
-from sys import version_info
 from unittest import TestCase
 import datetime
 import socket
+
+from sys import version_info
+if version_info.major == 2:
+    from urlparse import urlparse  # pylint:disable=import-error
+else:
+    from urllib.parse import urlparse  # pylint:disable=E0611,F0401
 
 
 # It is OK that this class has no public methods. It just needs to exist for use
@@ -22,37 +29,37 @@ class GenValueTestCase(TestCase):
     """
 
     def test_one_to_one_field(self):
-        """Test :class:`nailgun.entity_fields.OneToOneField`."""
+        """Test :meth:`nailgun.entity_fields.OneToOneField.gen_value`."""
         self.assertEqual(
             entity_fields.OneToOneField(TestClass).gen_value(),
             TestClass
         )
 
     def test_one_to_many_field(self):
-        """Test :class:`nailgun.entity_fields.OneToManyField`."""
+        """Test :meth:`nailgun.entity_fields.OneToManyField.gen_value`."""
         self.assertEqual(
             entity_fields.OneToManyField(TestClass).gen_value(),
             TestClass
         )
 
     def test_boolean_field(self):
-        """Test :class:`nailgun.entity_fields.BooleanField`."""
+        """Test :meth:`nailgun.entity_fields.BooleanField.gen_value`."""
         self.assertIn(entity_fields.BooleanField().gen_value(), (True, False))
 
     def test_date_field(self):
-        """Test :class:`nailgun.entity_fields.DateField`."""
+        """Test :meth:`nailgun.entity_fields.DateField.gen_value`."""
         self.assertIsInstance(
             entity_fields.DateField().gen_value(), datetime.date
         )
 
     def test_datetime_field(self):
-        """Test :class:`nailgun.entity_fields.DateTimeField`."""
+        """Test :meth:`nailgun.entity_fields.DateTimeField.gen_value`."""
         self.assertIsInstance(
             entity_fields.DateTimeField().gen_value(), datetime.datetime
         )
 
     def test_email_field(self):
-        """Test :class:`nailgun.entity_fields.EmailField`.
+        """Test :meth:`nailgun.entity_fields.EmailField.gen_value`.
 
         Ensure :meth:`nailgun.entity_fields.EmailField.gen_value` returns a
         unicode string containing the character '@'.
@@ -66,11 +73,11 @@ class GenValueTestCase(TestCase):
         self.assertIn('@', email)
 
     def test_float_field(self):
-        """Test :class:`nailgun.entity_fields.FloatField`."""
+        """Test :meth:`nailgun.entity_fields.FloatField.gen_value`."""
         self.assertIsInstance(entity_fields.FloatField().gen_value(), float)
 
     def test_ip_address_field(self):
-        """Test :class:`nailgun.entity_fields.IPAddressField`.
+        """Test :meth:`nailgun.entity_fields.IPAddressField.gen_value`.
 
         Ensure the value returned is acceptable to ``socket.inet_aton``.
 
@@ -82,7 +89,7 @@ class GenValueTestCase(TestCase):
             self.fail('({0}) {1}'.format(addr, err))
 
     def test_mac_address_field(self):
-        """Test :class:`nailgun.entity_fields.MACAddressField`.
+        """Test :meth:`nailgun.entity_fields.MACAddressField.gen_value`.
 
         Ensure the value returned is a string containing 12 hex digits (either
         upper or lower case), grouped into pairs of digits and separated by
@@ -99,6 +106,41 @@ class GenValueTestCase(TestCase):
         validator(
             entity_fields.MACAddressField().gen_value().upper(),
             '^([0-9A-F]{2}[:]){5}[0-9A-F]{2}$'
+        )
+
+    def test_dict_field(self):
+        """Test :meth:`nailgun.entity_fields.DictField.gen_value`.
+
+        Assert that an empty dict is returned by default. There are very few
+        occurrences of dict fields in the entity classes, so it is hard to
+        intelligently produce a randomized value that will be of use in a wide
+        variety of entities. Instead, those few entities override or extend
+        this method.
+
+        """
+        self.assertEqual(entity_fields.DictField().gen_value(), {})
+
+    def test_url_field(self):
+        """Test :meth:`nailgun.entity_fields.URLField.gen_value`.
+
+        Check that the result can be parsed by the urlparse/urllib.parse
+        module and that the resultant object has a ``netloc`` attribute.
+
+        """
+        self.assertTrue(hasattr(
+            urlparse(entity_fields.URLField().gen_value()),
+            'netloc'
+        ))
+
+    def test_gen_netmask(self):
+        """Test :meth:`nailgun.entity_fields.NetmaskField.gen_value`.
+
+        Assert that the result is in ``fauxfactory.constants.VALID_NETMASKS``.
+
+        """
+        self.assertIn(
+            entity_fields.NetmaskField().gen_value(),
+            VALID_NETMASKS
         )
 
 
@@ -165,15 +207,15 @@ class IntegerFieldTestCase(TestCase):
         min_val = randint(-1000, 0)
         max_val = randint(0, 1000)
 
-        # First, we'll allow a range of values...
+        # First, we'll allow a range of values…
         val = entity_fields.IntegerField(min_val, max_val).gen_value()
         self.assertGreaterEqual(val, min_val)
         self.assertLessEqual(val, max_val)
 
-        # ... then, we'll allow only a single value...
+        # … then, we'll allow only a single value…
         val = entity_fields.IntegerField(min_val, min_val).gen_value()
         self.assertEqual(val, min_val)
 
-        # ... twice over, just to be sure.
+        # … twice over, just to be sure.
         val = entity_fields.IntegerField(max_val, max_val).gen_value()
         self.assertEqual(val, max_val)


### PR DESCRIPTION
Add unit tests for all manner of code in NailGun. Improve coverage from 64% to
82%. There is still room for significantly improving the test suite, and these
added tests simply represent some of the low-hanging fruit.

Test results against a downstream system:

    $ nosetests tests/foreman/api/test_multiple_paths.py
    ...S...S......S...............................................................S...S..........................................................................................................................................SSS..S.S.SSSSSS.S..SS.SSSSSSSSSSSSSSSSSSSSSSSSSSSS
    ----------------------------------------------------------------------
    Ran 271 tests in 487.348s

    OK (SKIP=47)

Also, document the new `test-coverage` make target.