### PR TITLE
Mark fauxfactory as a required dependency

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,5 @@
 # For `make test`
 ddt
-fauxfactory
 mock
 
 # For `make lint`

--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,5 @@ setup(
         'Programming Language :: Python :: 3.4',
     ],
     packages=find_packages(),
-    install_requires=['fauxfactory', 'pyxdg', 'requests', 'setuptools'],
+    install_requires=['fauxfactory', 'pyxdg', 'requests>=2.7', 'setuptools'],
 )

--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,5 @@ setup(
         'Programming Language :: Python :: 3.4',
     ],
     packages=find_packages(),
-    install_requires=['pyxdg', 'requests', 'setuptools'],
+    install_requires=['fauxfactory', 'pyxdg', 'requests', 'setuptools'],
 )


### PR DESCRIPTION
First commit:

> Mark fauxfactory as a required dependency
>
> Fix #81. fauxfactory is a required dependency of NailGun. Mark it as such.

Second commit:

> List `requests>=2.7` in dependencies
>
> NailGun requires that requests 2.7.0 or higher be installed. List this
> requirement in `setup.py`. This should address the following use case:
>
> ```sh
> rm -rf env
> virtualenv env
> source env/bin/activate
> pip install requests==2.6.0
> pip install -e ~/code/nailgun
> pip list | grep requests
> ```
>
> If no minimum requests version is specified, then the above script will output
> `requests (2.6.0)`. Specifying a minimum version will cause the above script to
> output `requests (2.7.0)`.