### PR TITLE
Add fauxfactory as an install requirement

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,5 @@
 # For `make test`
 ddt
-fauxfactory
 mock
 
 # For `make lint`

--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,5 @@ setup(
         'Programming Language :: Python :: 3.4',
     ],
     packages=find_packages(),
-    install_requires=['pyxdg', 'requests', 'setuptools'],
+    install_requires=['fauxfactory', 'pyxdg', 'requests', 'setuptools'],
 )


### PR DESCRIPTION
Nailgun's entities, entity_fields and entity_mixins modules requires
that fauxfactory is installed.

Closes #81