### PR TITLE
Update documentation

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -4,8 +4,10 @@ API Documentation
 This is the NailGun API documentation. It is mostly auto generated from the
 source code. A good place to start reading is :doc:`nailgun`.
 
+The :mod:`nailgun` namespace is the public API. The :mod:`tests` is not part of
+the public API, and it is documented here for easy reference for developers.
+
 .. toctree::
-    :maxdepth: 2
 
     nailgun
     tests

--- a/docs/api/nailgun.client.rst
+++ b/docs/api/nailgun.client.rst
@@ -1,0 +1,4 @@
+:mod:`nailgun.client`
+=====================
+
+.. automodule:: nailgun.client

--- a/docs/api/nailgun.config.rst
+++ b/docs/api/nailgun.config.rst
@@ -1,0 +1,5 @@
+:mod:`nailgun.config`
+=====================
+
+.. automodule:: nailgun.config
+   :private-members:

--- a/docs/api/nailgun.entities.rst
+++ b/docs/api/nailgun.entities.rst
@@ -1,0 +1,4 @@
+:mod:`nailgun.entities`
+=======================
+
+.. automodule:: nailgun.entities

--- a/docs/api/nailgun.entity_fields.rst
+++ b/docs/api/nailgun.entity_fields.rst
@@ -1,0 +1,4 @@
+:mod:`nailgun.entity_fields`
+============================
+
+.. automodule:: nailgun.entity_fields

--- a/docs/api/nailgun.entity_mixins.rst
+++ b/docs/api/nailgun.entity_mixins.rst
@@ -1,0 +1,5 @@
+:mod:`nailgun.entity_mixins`
+============================
+
+.. automodule:: nailgun.entity_mixins
+   :private-members:

--- a/docs/api/nailgun.rst
+++ b/docs/api/nailgun.rst
@@ -3,29 +3,10 @@
 
 .. automodule:: nailgun
 
-:mod:`nailgun.client`
-=====================
+.. toctree::
 
-.. automodule:: nailgun.client
-
-:mod:`nailgun.config`
-=====================
-
-.. automodule:: nailgun.config
-   :private-members:
-
-:mod:`nailgun.entities`
-=======================
-
-.. automodule:: nailgun.entities
-
-:mod:`nailgun.entity_fields`
-============================
-
-.. automodule:: nailgun.entity_fields
-
-:mod:`nailgun.entity_mixins`
-============================
-
-.. automodule:: nailgun.entity_mixins
-   :private-members:
+    nailgun.entities
+    nailgun.entity_mixins
+    nailgun.entity_fields
+    nailgun.config
+    nailgun.client

--- a/docs/api/tests.rst
+++ b/docs/api/tests.rst
@@ -3,27 +3,10 @@
 
 .. automodule:: tests
 
-:mod:`tests.test_client`
-========================
+.. toctree::
 
-.. automodule:: tests.test_client
-
-:mod:`tests.test_config`
-========================
-
-.. automodule:: tests.test_config
-
-:mod:`tests.test_entities`
-==========================
-
-.. automodule:: tests.test_entities
-
-:mod:`tests.test_entity_fields`
-===============================
-
-.. automodule:: tests.test_entity_fields
-
-:mod:`tests.test_entity_mixins`
-===============================
-
-.. automodule:: tests.test_entity_mixins
+    tests.test_client
+    tests.test_config
+    tests.test_entities
+    tests.test_entity_fields
+    tests.test_entity_mixins

--- a/docs/api/tests.test_client.rst
+++ b/docs/api/tests.test_client.rst
@@ -1,0 +1,4 @@
+:mod:`tests.test_client`
+========================
+
+.. automodule:: tests.test_client

--- a/docs/api/tests.test_config.rst
+++ b/docs/api/tests.test_config.rst
@@ -1,0 +1,4 @@
+:mod:`tests.test_config`
+========================
+
+.. automodule:: tests.test_config

--- a/docs/api/tests.test_entities.rst
+++ b/docs/api/tests.test_entities.rst
@@ -1,0 +1,4 @@
+:mod:`tests.test_entities`
+==========================
+
+.. automodule:: tests.test_entities

--- a/docs/api/tests.test_entity_fields.rst
+++ b/docs/api/tests.test_entity_fields.rst
@@ -1,0 +1,4 @@
+:mod:`tests.test_entity_fields`
+===============================
+
+.. automodule:: tests.test_entity_fields

--- a/docs/api/tests.test_entity_mixins.rst
+++ b/docs/api/tests.test_entity_mixins.rst
@@ -1,0 +1,5 @@
+:mod:`tests.test_entity_mixins`
+===============================
+
+.. automodule:: tests.test_entity_mixins
+

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -19,6 +19,8 @@ For example scripts that do not use NailGun, this is the set-up procedure::
     pip install requests
     ./some_script.py  # some script of your choice
 
+.. _label-simple:
+
 Simple
 ------
 
@@ -74,7 +76,7 @@ configurations, but only want to work with one at a time::
 In addition, if no server configuration object is specified when instantiating
 an :class:`nailgun.entity_mixins.Entity` object, the server configuration
 labeled "default" is used. With this in mind, here's a revised version of the
-first script in section `Simple`:
+first script in section :ref:`label-simple`:
 
 .. literalinclude:: create_organization_nailgun_v2.py
 

--- a/nailgun/__init__.py
+++ b/nailgun/__init__.py
@@ -2,8 +2,8 @@
 """The root of the NailGun namespace.
 
 NailGun's modules are organized in to a tree of dependencies, where each module
-only knows about the modules below it in the tree. They can be visualized like
-this::
+only knows about the modules below it in the tree and no module knows about
+others at the same level in the tree. The modules can be visualized like this::
 
     nailgun.entities
     └── nailgun.entity_mixins
@@ -11,8 +11,8 @@ this::
         ├── nailgun.config
         └── nailgun.client
 
-As an end user, you'll typically want to use the classes exposed by
-:mod:`nailgun.entities`.
+If this is your first time working with NailGun, please read several of the
+:doc:`/examples` before the documentation here.
 
 """
 from logging import basicConfig

--- a/nailgun/entity_mixins.py
+++ b/nailgun/entity_mixins.py
@@ -374,7 +374,21 @@ class Entity(object):
 
 
 class EntityDeleteMixin(object):
-    """A mixin that adds the ability to delete an entity."""
+    """This mixin provides the ability to delete an entity.
+
+    The methods provided by this class work together. The call tree looks like
+    this::
+
+        delete → delete_raw
+
+    In short, here is what the methods do:
+
+    :meth:`delete_raw`
+        Make an HTTP DELETE request to the server.
+    :meth:`delete`
+        Check the server's response for errors and decode the response.
+
+    """
 
     def delete_raw(self):
         """Delete the current entity.
@@ -424,7 +438,27 @@ class EntityDeleteMixin(object):
 
 
 class EntityReadMixin(object):
-    """A mixin that provides the ability to read an entity."""
+    """This mixin provides the ability to read an entity.
+
+    The methods provided by this class work together. The call tree looks like
+    this::
+
+        read → read_json → read_raw
+
+    In short, here is what the methods do:
+
+    :meth:`read_raw`
+        Make an HTTP GET request to the server.
+    :meth:`read_json`
+        Check the server's response for errors and decode the response.
+    :meth:`read`
+        Create a :class:`nailgun.entity_mixins.Entity` object representing the
+        created entity and populate its fields with data returned from the
+        server.
+
+    See the individual methods for more detailed information.
+
+    """
 
     def read_raw(self):
         """Get information about the current entity.
@@ -530,18 +564,35 @@ class EntityReadMixin(object):
 
 
 class EntityCreateMixin(object):
-    """A mixin that provides the ability to create an entity.
+    """This mixin provides the ability to create an entity.
 
-    The methods provided by this mixin work together to create an entity. A
-    typical tree of method calls looks like this::
+    The methods provided by this class work together. The call tree looks like
+    this::
 
         create
         └── create_json
             └── create_raw
-                ├── create_missing
-                └── create_payload
+                ├── create_payload
+                └── create_missing
 
-    Only :meth:`create_raw` communicates with the server.
+    In short, here is what the methods do:
+
+    :meth:`create_missing`
+        Populate required fields with random values. Required fields that
+        already have a value are not populated. This method is not called
+        by default.
+    :meth:`create_payload`
+        Assemble a payload of data that can be encoded and sent to the server.
+    :meth:`create_raw`
+        Make an HTTP POST request to the server, including the payload.
+    :meth:`create_json`
+        Check the server's response for errors and decode the response.
+    :meth:`create`
+        Create a :class:`nailgun.entity_mixins.Entity` object representing the
+        created entity and populate its fields with data returned from the
+        server.
+
+    See the individual methods for more detailed information.
 
     """
 


### PR DESCRIPTION
Currently, all of the modules in the `nailgun` package are documented in a
single reST file. Similarly, all of the modules in the `tests` package are
documented in a single reST file. This technically works, but the compiled
documentation contains some enormously long pages, and the navigation trees are
not intuitive. Fix this by breaking documentation down so there is one reST file
per module. As a result, the compiled documentation contains smaller pages and
more intuitive navigation trees.

Rework the actual documentation contents in several other locations. Provide a
brief explanation of how the methods in each mixin cooperate to do work, provide
a better introduction to the documentation at the root of the API documentation,
and fix a link in the "Examples" documentation.