### PR TITLE
Fix AbstractComputeResource inheritance

### DIFF
--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -829,6 +829,14 @@ class InitTestCase(TestCase):
             )
         ]
         entities_.extend([
+            (
+                entities.LibvirtComputeResource,
+                {'display_type': 'VNC', 'set_console_password': False},
+            ),
+            (
+                entities.DockerComputeResource,
+                {'email': 'nobody@example.com', 'url': 'http://example.com'},
+            ),
             (entities.ContentViewFilterRule, {'content_view_filter': 1}),
             (entities.ContentViewPuppetModule, {'content_view': 1}),
             (entities.OperatingSystemParameter, {'operatingsystem': 1}),


### PR DESCRIPTION
The entity class `AbstractComputeResource` defines a set of fields that all
inheriting classes use. For example, all compute resources have a name and
provider. Child classes should be able to extend that set of fields. For
example, `LibvirtComputeResource` adds the `display_type` and
`set_console_password` fields.

Currently, that inheritance is broken. The following fails:

    from nailgun.entities import LibvirtComputeResource
    LibvirtComputeResource(display_type='VNC')

Similarly, any field which is defined on a child class cannot be assigned to
directly. Fix this.