### PR TITLE
Update `Domain` to include a `SmartProxy` field.

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -1175,6 +1175,7 @@ class Domain(
 
     def __init__(self, server_config=None, **kwargs):
         self._fields = {
+            'dns_id': entity_fields.IntegerField(),
             'domain_parameters_attributes': entity_fields.ListField(null=True),
             'fullname': entity_fields.StringField(null=True),
             'location': entity_fields.OneToManyField(Location, null=True),


### PR DESCRIPTION
Since a `entities.Domain` can be associated to a `entities.SmartProxy`
by its `id`, I have updated the class to accept a new field (integer).

Preliminary testing shows:

```python
In [10]: org = Organization(id=1).read()

In [12]: loc = Location(id=2).read()

In [13]: capsule = SmartProxy(id=1).read()

In [15]: foo = Domain(organization=[org], location=[loc], dns_id=capsule.id).create()

In [16]: foo
Out[16]: nailgun.entities.Domain(nailgun.config.ServerConfig(url=u'https://ibm-x3250m4-06.lab.eng.rdu2.redhat.com', verify=False, version=<Version('6.1')>, auth=(u'admin', u'fromgod1')), domain_parameters_attributes=[], location=[nailgun.entities.Location(nailgun.config.ServerConfig(url=u'https://ibm-x3250m4-06.lab.eng.rdu2.redhat.com', verify=False, version=<Version('6.1')>, auth=(u'admin', u'fromgod1')), id=2)], dns_id=1, organization=[nailgun.entities.Organization(nailgun.config.ServerConfig(url=u'https://ibm-x3250m4-06.lab.eng.rdu2.redhat.com', verify=False, version=<Version('6.1')>, auth=(u'admin', u'fromgod1')), id=1)], fullname=None, id=4, name=u'shg36dpgdz')

In [18]: Domain(id=4).read()

Out[18]: nailgun.entities.Domain(nailgun.config.ServerConfig(url=u'https://ibm-x3250m4-06.lab.eng.rdu2.redhat.com', verify=False, version=<Version('6.1')>, auth=(u'admin', u'fromgod1')), domain_parameters_attributes=[], location=[nailgun.entities.Location(nailgun.config.ServerConfig(url=u'https://ibm-x3250m4-06.lab.eng.rdu2.redhat.com', verify=False, version=<Version('6.1')>, auth=(u'admin', u'fromgod1')), id=2)], dns_id=1, organization=[nailgun.entities.Organization(nailgun.config.ServerConfig(url=u'https://ibm-x3250m4-06.lab.eng.rdu2.redhat.com', verify=False, version=<Version('6.1')>, auth=(u'admin', u'fromgod1')), id=1)], fullname=None, id=4, name=u'shg36dpgdz')

In [19]: Domain(id=4).delete()

Out[19]:
{u'created_at': u'2015-05-29T00:10:46Z',
 u'dns_id': 1,
 u'fullname': None,
 u'hostgroups_count': 0,
 u'hosts_count': 0,
 u'id': 4,
 u'name': u'shg36dpgdz',
 u'updated_at': u'2015-05-29T00:10:46Z'}
```