### PR TITLE
Mark "test-coverage" as a phony make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,4 +37,4 @@ package:
 package-clean:
 	rm -rf build dist nailgun.egg-info
 
-.PHONY: help lint test docs-html docs-clean package package-clean
+.PHONY: help docs-html docs-clean lint test test-coverage package package-clean


### PR DESCRIPTION
Also, rearrange the `.PHONY` list of targets to match the actual ordering of the
targets in the body of the make file.