### PR TITLE
Add field `Domain.dns`

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -1190,6 +1190,7 @@ class Domain(
 
     def __init__(self, server_config=None, **kwargs):
         self._fields = {
+            'dns': entity_fields.OneToOneField(SmartProxy, null=True),
             'domain_parameters_attributes': entity_fields.ListField(null=True),
             'fullname': entity_fields.StringField(null=True),
             'location': entity_fields.OneToManyField(Location, null=True),
@@ -1243,10 +1244,15 @@ class Domain(
         returns a list named ``parameters``. These appear to be the same data.
         Deal with this naming weirdness.
 
+        Also, the server returns an entity ID instead of a hash of attributes
+        for the ``dns`` one to one field.
+
         """
         if attrs is None:
             attrs = self.read_json()
         attrs['domain_parameters_attributes'] = attrs.pop('parameters')
+        dns_id = attrs.pop('dns_id')
+        attrs['dns'] = None if dns_id is None else {'id': dns_id}
         return super(Domain, self).read(entity, attrs, ignore)
 
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -563,6 +563,11 @@ class ReadTestCase(TestCase):
                 {'puppet_module': None},
             ),
             (
+                entities.Domain(self.cfg),
+                {'dns_id': None, 'parameters': None},
+                {'dns': None, 'domain_parameters_attributes': None},
+            ),
+            (
                 entities.Host(self.cfg),
                 {
                     # These two params are renamed individually.


### PR DESCRIPTION
A domain can be associated with a smart proxy via its "dns" field. Add this
field and all workaround necessary for this field to function properly. Example
usage:

```python
>>> from nailgun import entities
>>> domain = entities.Domain(dns=1).create()
>>> domain.get_values()
{
    'dns': nailgun.entities.SmartProxy(
        nailgun.config.ServerConfig(…),  # redacted
        id=1
    ),
    'domain_parameters_attributes': [],
    'fullname': None,
    'id': 53,
    'location': [],
    'name': 'j9jm4wvery',
    'organization': [],
}
>>> domain2 = domain.read()
>>> domain3 = entities.Domain(id=53).read()
```

Fix #93. Related to #94.