### PR TITLE
Reference the "NailGun Hands On" video

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -19,6 +19,18 @@ For example scripts that do not use NailGun, this is the set-up procedure::
     pip install requests
     ./some_script.py  # some script of your choice
 
+Additionally, a video demonstration entitled `NailGun Hands On
+<https://www.youtube.com/watch?v=_FNjAQdNoRc>`_ is available.
+
+.. raw:: html
+
+    <iframe
+        width="560"
+        height="315"
+        src="https://www.youtube.com/embed/_FNjAQdNoRc"
+        allowfullscreen
+    ></iframe>
+
 .. _label-simple:
 
 Simple


### PR DESCRIPTION
Fix #90.

Link directly to the YouTube video so that all documents produced by Sphinx —
HTML, EPUB, PDF, etc — can properly reference the video. In addition, embed the
video directly in to the documentation when HTML output is generated.

For technical details, see:
http://docutils.sourceforge.net/docs/ref/rst/directives.html#raw-data-pass-through

Tested with `make html` and `make epub`.