### PR TITLE
Change dependencies, revamp tests/test_entities.py

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2259,8 +2259,7 @@ class Organization(
             self.path('subscriptions'),
             **self._server_config.get_client_kwargs()
         )
-        response.raise_for_status()
-        return response.json()['results']
+        return _handle_response(response, self._server_config)['results']
 
     def upload_manifest(self, path, repository_url=None, synchronous=True):
         """Helper method that uploads a subscription manifest file
@@ -2347,10 +2346,13 @@ class Organization(
             an HTTP 4XX or 5XX message.
 
         """
-        sync_date = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         response = client.post(
             self.path('sync_plans'),
-            {u'interval': interval, u'name': name, u'sync_date': sync_date},
+            {
+                u'interval': interval,
+                u'name': name,
+                u'sync_date': datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
+            },
             **self._server_config.get_client_kwargs()
         )
         return _handle_response(response, self._server_config)
@@ -2366,8 +2368,7 @@ class Organization(
             data={u'per_page': per_page},
             **self._server_config.get_client_kwargs()
         )
-        response.raise_for_status()
-        return response.json()['results']
+        return _handle_response(response, self._server_config)['results']
 
 
 class OSDefaultTemplate(Entity):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 # For `make test`
-ddt
 mock
+unittest2
 
 # For `make lint`
 flake8

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,7 @@ from unittest import TestCase
 import json
 
 from sys import version_info
-if version_info[0] == 2:
+if version_info.major == 2:
     # The `__builtins__` module (note the "s") also provides the `open`
     # function. However, that module is an implementation detail for CPython 2,
     # so it should not be relied on.

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1,223 +1,23 @@
+# -*- encoding: utf-8 -*-
 """Tests for :mod:`nailgun.entities`."""
 from datetime import datetime
-from ddt import data, ddt, unpack
 from fauxfactory import gen_integer
 from nailgun import client, config, entities
 from nailgun.entity_mixins import EntityReadMixin, NoSuchPathError
-from sys import version_info
-from unittest import TestCase
+from unittest2 import TestCase
 import mock
-# pylint:disable=too-many-public-methods
+# pylint:disable=too-many-lines
+# The size of this file is a direct reflection of the size of module
+# `nailgun.entities` and the Satellite API.
 
 
-@ddt
-class PathTestCase(TestCase):
-    """Tests for extensions of :meth:`nailgun.entity_mixins.Entity.path`."""
-    longMessage = True
-
-    def setUp(self):
-        """Set ``self.server_config`` and ``self.id_``."""
-        self.server_config = config.ServerConfig('http://example.com')
-        self.id_ = gen_integer(min_value=1)
-        if version_info.major == 2:
-            self.re_assertion = self.assertRegexpMatches
-        else:
-            self.re_assertion = self.assertRegex  # pylint:disable=no-member
-
-    @data(
-        (entities.AbstractDockerContainer, '/containers'),
-        (entities.ActivationKey, '/activation_keys'),
-        (entities.ConfigTemplate, '/config_templates'),
-        (entities.ContentView, '/content_views'),
-        (entities.ContentViewVersion, '/content_view_versions'),
-        (entities.ForemanTask, '/tasks'),
-        (entities.Organization, '/organizations'),
-        (entities.Product, '/products'),
-        (entities.Repository, '/repositories'),
-        (entities.RHCIDeployment, '/deployments'),
-        (entities.SmartProxy, '/smart_proxies'),
-        (entities.System, '/systems'),
-    )
-    @unpack
-    def test_path_without_which(self, entity, path):
-        """Test what happens when the ``which`` argument is omitted.
-
-        Assert that ``path`` returns a valid string when the ``which`` argument
-        is omitted, regardless of whether an entity ID is provided.
-
-        """
-        # There is no API path for all foreman tasks.
-        if entity != entities.ForemanTask:
-            self.assertIn(path, entity(self.server_config).path(), entity)
-        self.assertIn(
-            '{0}/{1}'.format(path, self.id_),
-            entity(self.server_config, id=self.id_).path(),
-            entity
-        )
-
-    @data(
-        (entities.AbstractDockerContainer, 'containers', 'logs'),
-        (entities.AbstractDockerContainer, 'containers', 'power'),
-        (entities.ActivationKey, '/activation_keys', 'add_subscriptions'),
-        (entities.ActivationKey, '/activation_keys', 'content_override'),
-        (entities.ActivationKey, '/activation_keys', 'releases'),
-        (entities.ActivationKey, '/activation_keys', 'remove_subscriptions'),
-        (entities.ContentView, '/content_views', 'available_puppet_module_names'),  # noqa pylint:disable=C0301
-        (entities.ContentView, '/content_views', 'content_view_puppet_modules'),  # noqa pylint:disable=C0301
-        (entities.ContentView, '/content_views', 'content_view_versions'),
-        (entities.ContentView, '/content_views', 'copy'),
-        (entities.ContentView, '/content_views', 'publish'),
-        (entities.ContentViewVersion, '/content_view_versions', 'promote'),
-        (entities.Organization, '/organizations', 'products'),
-        (entities.Organization, '/organizations', 'subscriptions'),
-        (entities.Organization, '/organizations', 'subscriptions/delete_manifest'),  # noqa pylint:disable=C0301
-        (entities.Organization, '/organizations', 'subscriptions/refresh_manifest'),  # noqa pylint:disable=C0301
-        (entities.Organization, '/organizations', 'subscriptions/upload'),
-        (entities.Organization, '/organizations', 'sync_plans'),
-        (entities.Product, '/products', 'repository_sets'),
-        (entities.Product, '/products', 'repository_sets/2396/disable'),
-        (entities.Product, '/products', 'repository_sets/2396/enable'),
-        (entities.Repository, '/repositories', 'sync'),
-        (entities.Repository, '/repositories', 'upload_content'),
-        (entities.RHCIDeployment, '/deployments', 'deploy'),
-    )
-    @unpack
-    def test_self_path_with_which(self, entity, path, which):
-        """Test what happens when an entity ID is given and ``which=which``.
-
-        Assert that when ``entity(id=<id>).path(which=which)`` is called, the
-        resultant path contains the following string::
-
-            'path/<id>/which'
-
-        """
-        gen_path = entity(self.server_config, id=self.id_).path(which=which)
-        self.assertIn(
-            '{0}/{1}/{2}'.format(path, self.id_, which),
-            gen_path,
-            entity.__name__
-        )
-        self.re_assertion(gen_path, '{0}$'.format(which), entity.__name__)
-
-    @data(
-        (entities.ConfigTemplate, '/config_templates', 'build_pxe_default'),
-        (entities.ConfigTemplate, '/config_templates', 'revision'),
-    )
-    @unpack
-    def test_base_path_with_which(self, entity, path, which):
-        """Test what happens when no entity ID is given and ``which=which``.
-
-        Assert that a path in the fllowing format is returned::
-
-            {path}/{which}
-
-        """
-        gen_path = entity(self.server_config).path(which=which)
-        self.assertIn('{0}/{1}'.format(path, which), gen_path, entity.__name__)
-        self.re_assertion(gen_path, which + '$', entity.__name__)
-
-    @data(
-        (entities.ActivationKey, 'releases'),
-        (entities.ContentView, 'available_puppet_module_names'),
-        (entities.ContentView, 'content_view_puppet_modules'),
-        (entities.ContentView, 'content_view_versions'),
-        (entities.ContentView, 'publish'),
-        (entities.ContentViewVersion, 'promote'),
-        (entities.ForemanTask, 'self'),
-        (entities.Organization, 'products'),
-        (entities.Organization, 'self'),
-        (entities.Organization, 'subscriptions'),
-        (entities.Organization, 'subscriptions/delete_manifest'),
-        (entities.Organization, 'subscriptions/refresh_manifest'),
-        (entities.Organization, 'subscriptions/upload'),
-        (entities.Organization, 'sync_plans'),
-        (entities.Product, 'repository_sets'),
-        (entities.Repository, 'sync'),
-        (entities.Repository, 'upload_content'),
-        (entities.RHCIDeployment, 'deploy'),
-        (entities.SmartProxy, 'refresh'),
-        (entities.System, 'self'),
-    )
-    @unpack
-    def test_no_such_path(self, entity, path):
-        """Test what happens when no entity ID is provided and ``which=path``.
-
-        Assert that :class:`nailgun.entity_mixins.NoSuchPathError` is raised.
-
-        """
-        with self.assertRaises(NoSuchPathError):
-            entity(self.server_config).path(which=path)
-
-    def test_foremantask_path(self):
-        """Test :meth:`nailgun.entities.ForemanTask.path`.
-
-        Assert that correct paths are returned when:
-
-        * an entity ID is provided and the ``which`` argument to ``path`` is
-          omitted
-        * ``which = 'bulk_search'``
-
-        """
-        self.assertIn(
-            '/foreman_tasks/api/tasks/{0}'.format(self.id_),
-            entities.ForemanTask(self.server_config, id=self.id_).path()
-        )
-        for gen_path in (
-                entities.ForemanTask(self.server_config).path(
-                    which='bulk_search'
-                ),
-                entities.ForemanTask(self.server_config, id=self.id_).path(
-                    which='bulk_search'
-                )
-        ):
-            self.assertIn('/foreman_tasks/api/tasks/bulk_search', gen_path)
-
-    def test_syncplan_path(self):
-        """Test :meth:`nailgun.entities.SyncPlan.path`.
-
-        Assert that the correct paths are returned when the following paths are
-        provided to :meth:`nailgun.entities.SyncPlan.path`:
-
-        * ``add_products``
-        * ``remove_products``
-
-        """
-        for which in ('add_products', 'remove_products'):
-            path = entities.SyncPlan(
-                self.server_config,
-                id=2,
-                organization=1,
-            ).path(which)
-            self.assertIn(
-                'organizations/1/sync_plans/2/{0}'.format(which),
-                path
-            )
-            self.re_assertion(path, '{0}$'.format(which))
-
-    def test_system_path(self):
-        """Test :meth:`nailgun.entities.System.path`.
-
-        Assert that correct paths are returned when:
-
-        * A UUID is provided and ``which`` is omitted.
-        * A UUID is provided and ``which='self'``.
-        * A UUID is omitted and ``which`` is omitted.
-        * A UUID is omitted and ``which='base'``.
-
-        """
-        for gen_path in (
-                entities.System(self.server_config, uuid=self.id_).path(),
-                entities.System(self.server_config, uuid=self.id_).path(
-                    which='self'
-                )
-        ):
-            self.assertIn('/systems/{0}'.format(self.id_), gen_path)
-            self.re_assertion(gen_path, '{0}$'.format(self.id_))
-        for gen_path in (
-                entities.System(self.server_config).path(),
-                entities.System(self.server_config).path(which='base')):
-            self.assertIn('/systems', gen_path)
-            self.re_assertion(gen_path, 'systems$')
+# This file is divided in to three sets of test cases (`TestCase` subclasses):
+#
+# 1. Tests for inherited methods.
+# 2. Tests for entity-specific methods.
+# 3. Other tests.
+#
+# 1. Tests for inherited methods. ---------------------------------------- {{{1
 
 
 class CreatePayloadTestCase(TestCase):
@@ -248,6 +48,7 @@ class CreatePayloadTestCase(TestCase):
                 entities.Architecture,
                 entities.ConfigTemplate,
                 entities.Domain,
+                entities.Environment,
                 entities.Host,
                 entities.HostCollection,
                 entities.HostGroup,
@@ -265,17 +66,11 @@ class CreatePayloadTestCase(TestCase):
             (entities.ContentViewPuppetModule, {'content_view': 1}),
         ])
         for entity, params in entities_:
-            if version_info < (3, 4):  # subTest() introduced in Python 3.4
+            with self.subTest():
                 self.assertIsInstance(
                     entity(self.cfg, **params).create_payload(),
                     dict
                 )
-            else:
-                with self.subTest(entity):  # pylint:disable=no-member
-                    self.assertIsInstance(
-                        entity(self.cfg, **params).create_payload(),
-                        dict
-                    )
 
     def test_sync_plan(self):
         """Call ``create_payload`` on a :class:`nailgun.entities.SyncPlan`."""
@@ -323,126 +118,302 @@ class CreatePayloadTestCase(TestCase):
         self.assertIn('path', payload['medium'])
 
 
-@ddt
-class OrganizationTestCase(TestCase):
-    """Tests for :class:`nailgun.entities.Organization`."""
+class InitTestCase(TestCase):
+    """Tests for all of the ``__init__`` methods.
 
-    def setUp(self):
-        """Set ``self.server_config`` and ``self.entity_id``."""
-        self.server_config = config.ServerConfig(
-            'http://example.com',
-            auth=('foo', 'bar'),
-            verify=False
-        )
-        self.entity_id = gen_integer(min_value=1)
+    The tests in this class are a sanity check. They simply check to see if you
+    can instantiate each entity.
 
-    @data(200, 202)
-    def test_delete_manifest(self, http_status_code):
-        """Call :meth:`nailgun.entities.Organization.delete_manifest`.
-
-        Assert that :meth:`nailgun.entities.Organization.delete_manifest`
-        returns a dictionary when an HTTP 202 or some other success status code
-        is returned.
-
-        """
-        # `client.post` will return this.
-        post_return = mock.Mock()
-        post_return.status_code = http_status_code
-        post_return.raise_for_status.return_value = None
-        post_return.json.return_value = {'id': gen_integer()}  # mock task ID
-
-        # Start by patching `client.post` and `ForemanTask.poll`...
-        # NOTE: Python 3 allows for better nested context managers.
-        with mock.patch.object(client, 'post') as client_post:
-            client_post.return_value = post_return
-            with mock.patch.object(entities.ForemanTask, 'poll') as ft_poll:
-                ft_poll.return_value = {}
-
-                # ... then see if `delete_manifest` acts correctly.
-                for synchronous in (True, False):
-                    reply = entities.Organization(
-                        self.server_config,
-                        id=self.entity_id
-                    ).delete_manifest(synchronous)
-                    self.assertIsInstance(reply, dict)
-
-    def test_subscriptions(self):
-        """Call :meth:`nailgun.entities.Organization.subscriptions`.
-
-        Asserts that :meth:`nailgun.entities.Organization.subscriptions`
-        returns a list.
-
-        """
-        # Create a mock server response object.
-        mock_response = mock.Mock()
-        mock_response.status_code = 200
-        mock_response.raise_for_status.return_value = None
-        mock_response.json.return_value = {u'results': []}
-
-        with mock.patch.object(client, 'get') as mocked_client_get:
-            mocked_client_get.return_value = mock_response
-            # See if `subscriptions` behaves correctly.
-            response = entities.Organization(
-                self.server_config,
-                id=self.entity_id,
-            ).subscriptions()
-            self.assertEqual(response, [])
-
-
-class VersionTestCase(TestCase):
-    """Tests for entities that vary based on the server's software version."""
+    """
 
     @classmethod
     def setUpClass(cls):
-        """Create several server configs with different versions."""
-        super(VersionTestCase, cls).setUpClass()
-        cls.cfg_608 = config.ServerConfig('bogus url', version='6.0.8')
-        cls.cfg_610 = config.ServerConfig('bogus url', version='6.1.0')
+        """Set a server configuration at ``cls.cfg``."""
+        cls.cfg = config.ServerConfig('http://example.com')
 
-    def test_repository_fields(self):
-        """Check :class:`nailgun.entities.Repository`'s fields.
+    def test_init_succeeds(self):
+        """Instantiate every entity.
 
-        Assert that ``Repository`` has fields named "docker_upstream_name" and
-        "checksum_type", and that "docker" is a choice for the "content_type"
-        field starting with version 6.1.
+        Assert that the returned object is an instance of the class that
+        produced it.
 
         """
-        repo_608 = entities.Repository(self.cfg_608)
-        repo_610 = entities.Repository(self.cfg_610)
-        for field_name in ('docker_upstream_name', 'checksum_type'):
-            self.assertNotIn(field_name, repo_608.get_fields())
-            self.assertIn(field_name, repo_610.get_fields())
-        self.assertNotIn(
-            'docker',
-            repo_608.get_fields()['content_type'].choices
+        entities_ = [
+            (entity, {})
+            for entity in (
+                # entities.ContentViewFilterRule,  # see below
+                # entities.ContentViewPuppetModule,  # see below
+                # entities.OperatingSystemParameter,  # see below
+                # entities.SyncPlan,  # see below
+                entities.AbstractComputeResource,
+                entities.AbstractContentViewFilter,
+                entities.AbstractDockerContainer,
+                entities.ActivationKey,
+                entities.Architecture,
+                entities.AuthSourceLDAP,
+                entities.Bookmark,
+                entities.CommonParameter,
+                entities.ComputeAttribute,
+                entities.ComputeProfile,
+                entities.ConfigGroup,
+                entities.ConfigTemplate,
+                entities.ContentUpload,
+                entities.ContentView,
+                entities.ContentViewVersion,
+                entities.DockerComputeResource,
+                entities.DockerHubContainer,
+                entities.Domain,
+                entities.Environment,
+                entities.Errata,
+                entities.ErratumContentViewFilter,
+                entities.Filter,
+                entities.ForemanTask,
+                entities.GPGKey,
+                entities.Host,
+                entities.HostCollection,
+                entities.HostCollectionErrata,
+                entities.HostCollectionPackage,
+                entities.HostGroup,
+                entities.Image,
+                entities.Interface,
+                entities.LibvirtComputeResource,
+                entities.LifecycleEnvironment,
+                entities.Location,
+                entities.Media,
+                entities.Model,
+                entities.OSDefaultTemplate,
+                entities.OperatingSystem,
+                entities.Organization,
+                entities.OverrideValue,
+                entities.PackageGroupContentViewFilter,
+                entities.PartitionTable,
+                entities.Permission,
+                entities.Ping,
+                entities.Product,
+                entities.PuppetClass,
+                entities.PuppetModule,
+                entities.RPMContentViewFilter,
+                entities.Realm,
+                entities.Report,
+                entities.Repository,
+                entities.Role,
+                entities.RoleLDAPGroups,
+                entities.SmartProxy,
+                entities.SmartVariable,
+                entities.Status,
+                entities.Subnet,
+                entities.Subscription,
+                entities.System,
+                entities.SystemPackage,
+                entities.TemplateCombination,
+                entities.TemplateKind,
+                entities.User,
+                entities.UserGroup,
+            )
+        ]
+        entities_.extend([
+            (
+                entities.LibvirtComputeResource,
+                {'display_type': 'VNC', 'set_console_password': False},
+            ),
+            (
+                entities.DockerComputeResource,
+                {'email': 'nobody@example.com', 'url': 'http://example.com'},
+            ),
+            (entities.ContentViewFilterRule, {'content_view_filter': 1}),
+            (entities.ContentViewPuppetModule, {'content_view': 1}),
+            (entities.OperatingSystemParameter, {'operatingsystem': 1}),
+            (entities.SyncPlan, {'organization': 1}),
+        ])
+        for entity, params in entities_:
+            with self.subTest():
+                self.assertIsInstance(entity(self.cfg, **params), entity)
+
+    def test_required_params(self):
+        """Instantiate entities that require extra parameters.
+
+        Assert that ``TypeError`` is raised if the required extra parameters
+        are not provided.
+
+        """
+        for entity in (
+                entities.ContentViewFilterRule,
+                entities.ContentViewPuppetModule,
+                entities.OperatingSystemParameter,
+                entities.SyncPlan,
+        ):
+            with self.subTest():
+                with self.assertRaises(TypeError):
+                    entity(self.cfg)
+
+
+class PathTestCase(TestCase):
+    """Tests for extensions of :meth:`nailgun.entity_mixins.Entity.path`."""
+    longMessage = True
+
+    def setUp(self):
+        """Set ``self.cfg`` and ``self.id_``."""
+        self.cfg = config.ServerConfig('http://example.com')
+        self.id_ = gen_integer(min_value=1)
+
+    def test_nowhich(self):
+        """Execute ``entity().path()`` and ``entity(id=…).path()``."""
+        for entity, path in (
+                (entities.AbstractDockerContainer, '/containers'),
+                (entities.ActivationKey, '/activation_keys'),
+                (entities.ConfigTemplate, '/config_templates'),
+                (entities.ContentView, '/content_views'),
+                (entities.ContentViewVersion, '/content_view_versions'),
+                (entities.Organization, '/organizations'),
+                (entities.Product, '/products'),
+                (entities.RHCIDeployment, '/deployments'),
+                (entities.Repository, '/repositories'),
+                (entities.SmartProxy, '/smart_proxies'),
+                (entities.System, '/systems'),
+        ):
+            with self.subTest():
+                self.assertIn(path, entity(self.cfg).path())
+                self.assertIn(
+                    '{}/{}'.format(path, self.id_),
+                    entity(self.cfg, id=self.id_).path()
+                )
+
+    def test_id_and_which(self):
+        """Execute ``entity(id=…).path(which=…)``."""
+        for entity, which in (
+                (entities.AbstractDockerContainer, 'logs'),
+                (entities.AbstractDockerContainer, 'power'),
+                (entities.ActivationKey, 'add_subscriptions'),
+                (entities.ActivationKey, 'content_override'),
+                (entities.ActivationKey, 'releases'),
+                (entities.ActivationKey, 'remove_subscriptions'),
+                (entities.ContentView, 'available_puppet_module_names'),
+                (entities.ContentView, 'content_view_puppet_modules'),
+                (entities.ContentView, 'content_view_versions'),
+                (entities.ContentView, 'copy'),
+                (entities.ContentView, 'publish'),
+                (entities.ContentViewVersion, 'promote'),
+                (entities.Organization, 'products'),
+                (entities.Organization, 'subscriptions'),
+                (entities.Organization, 'subscriptions/delete_manifest'),
+                (entities.Organization, 'subscriptions/refresh_manifest'),
+                (entities.Organization, 'subscriptions/upload'),
+                (entities.Organization, 'sync_plans'),
+                (entities.Product, 'repository_sets'),
+                (entities.Product, 'repository_sets/2396/disable'),
+                (entities.Product, 'repository_sets/2396/enable'),
+                (entities.Repository, 'sync'),
+                (entities.Repository, 'upload_content'),
+                (entities.RHCIDeployment, 'deploy'),
+        ):
+            with self.subTest():
+                path = entity(self.cfg, id=self.id_).path(which=which)
+                self.assertIn('{}/{}'.format(self.id_, which), path)
+                self.assertRegex(path, which + '$')
+
+    def test_noid_and_which(self):
+        """Execute ``entity().path(which=…)``."""
+        for entity, which in (
+                (entities.ConfigTemplate, 'build_pxe_default'),
+                (entities.ConfigTemplate, 'revision'),
+        ):
+            with self.subTest():
+                path = entity(self.cfg).path(which=which)
+                self.assertIn(which, path)
+                self.assertRegex(path, which + '$')
+
+    def test_no_such_path_error(self):
+        """Trigger :class:`nailgun.entity_mixins.NoSuchPathError` exceptions.
+
+        Do this by calling ``entity().path(which=…)``.
+
+        """
+        for entity, which in (
+                (entities.ActivationKey, 'releases'),
+                (entities.ContentView, 'available_puppet_module_names'),
+                (entities.ContentView, 'content_view_puppet_modules'),
+                (entities.ContentView, 'content_view_versions'),
+                (entities.ContentView, 'publish'),
+                (entities.ContentViewVersion, 'promote'),
+                (entities.ForemanTask, 'self'),
+                (entities.Organization, 'products'),
+                (entities.Organization, 'self'),
+                (entities.Organization, 'subscriptions'),
+                (entities.Organization, 'subscriptions/delete_manifest'),
+                (entities.Organization, 'subscriptions/refresh_manifest'),
+                (entities.Organization, 'subscriptions/upload'),
+                (entities.Organization, 'sync_plans'),
+                (entities.Product, 'repository_sets'),
+                (entities.Repository, 'sync'),
+                (entities.Repository, 'upload_content'),
+                (entities.RHCIDeployment, 'deploy'),
+                (entities.SmartProxy, 'refresh'),
+                (entities.System, 'self'),
+        ):
+            with self.assertRaises(NoSuchPathError):
+                entity(self.cfg).path(which=which)
+
+    def test_foreman_task(self):
+        """Test :meth:`nailgun.entities.ForemanTask.path`.
+
+        Assert that the following return appropriate paths:
+
+        * ``ForemanTask(id=…).path()``
+        * ``ForemanTask().path('bulk_search')``
+        * ``ForemanTask(id=…).path('bulk_search')``
+
+        """
+        self.assertIn(
+            '/foreman_tasks/api/tasks/{}'.format(self.id_),
+            entities.ForemanTask(self.cfg, id=self.id_).path()
         )
-        self.assertIn('docker', repo_610.get_fields()['content_type'].choices)
+        for path in (
+                entities.ForemanTask(self.cfg).path('bulk_search'),
+                entities.ForemanTask(self.cfg, id=self.id_).path('bulk_search')
+        ):
+            self.assertIn('/foreman_tasks/api/tasks/bulk_search', path)
 
-    def test_subnet_fields(self):
-        """Check :class:`nailgun.entities.Subnet`'s fields.
+    def test_sync_plan(self):
+        """Test :meth:`nailgun.entities.SyncPlan.path`.
 
-        Assert that ``Subnet`` has the following fields starting in version
-        6.1:
+        Assert that the following return appropriate paths:
 
-        * boot_mode
-        * dhcp
-        * dns
-        * location
-        * organization
-        * tftp
+        * ``SyncPlan(id=…).path('add_products')``
+        * ``SyncPlan(id=…).path('remove_products')``
 
         """
-        subnet_608 = entities.Subnet(self.cfg_608)
-        subnet_610 = entities.Subnet(self.cfg_610)
-        for field_name in (
-                'boot_mode',
-                'dhcp',
-                'dns',
-                'location',
-                'organization',
-                'tftp'):
-            self.assertNotIn(field_name, subnet_608.get_fields())
-            self.assertIn(field_name, subnet_610.get_fields())
+        for which in ('add_products', 'remove_products'):
+            path = entities.SyncPlan(
+                self.cfg,
+                id=2,
+                organization=1,
+            ).path(which)
+            self.assertIn('organizations/1/sync_plans/2/' + which, path)
+            self.assertRegex(path, '{}$'.format(which))
+
+    def test_system(self):
+        """Test :meth:`nailgun.entities.System.path`.
+
+        Assert that the following return appropriate paths:
+
+        * ``System().path('base')``
+        * ``System().path()``
+        * ``System(uuid=…).path('self')``
+        * ``System(uuid=…).path()``
+
+        """
+        for path in (
+                entities.System(self.cfg).path('base'),
+                entities.System(self.cfg).path(),
+        ):
+            self.assertIn('/systems', path)
+            self.assertRegex(path, 'systems$')
+        for path in (
+                entities.System(self.cfg, uuid=self.id_).path('self'),
+                entities.System(self.cfg, uuid=self.id_).path(),
+        ):
+            self.assertIn('/systems/{}'.format(self.id_), path)
+            self.assertRegex(path, '{}$'.format(self.id_))
 
 
 class ReadTestCase(TestCase):
@@ -506,15 +477,10 @@ class ReadTestCase(TestCase):
         ):
             with mock.patch.object(EntityReadMixin, 'read_json') as read_json:
                 with mock.patch.object(EntityReadMixin, 'read') as read:
-                    if version_info < (3, 4):  # subTest() introduced in 3.4
+                    with self.subTest():
                         entity(self.cfg).read()
                         self.assertEqual(read_json.call_count, 1)
                         self.assertEqual(read.call_count, 1)
-                    else:
-                        with self.subTest(entity):  # pylint:disable=no-member
-                            entity(self.cfg).read()
-                            self.assertEqual(read_json.call_count, 1)
-                            self.assertEqual(read.call_count, 1)
 
     def test_attrs_arg_v2(self):
         """Validate :meth:`nailgun.entities.UserGroup.read`.
@@ -696,7 +662,7 @@ class ReadTestCase(TestCase):
         """
         with mock.patch.object(EntityReadMixin, 'read') as read:
             entities.AuthSourceLDAP(self.cfg).read(attrs={})
-        # read.call_args[0][2] is the `ignore` argument to read()
+        # `call_args` is a two-tupe of (positional, keyword) args.
         self.assertIn('account_password', read.call_args[0][2])
 
     def test_ignore_arg_v2(self):
@@ -707,16 +673,23 @@ class ReadTestCase(TestCase):
         """
         with mock.patch.object(EntityReadMixin, 'read') as read:
             entities.DockerComputeResource(self.cfg).read(attrs={'email': 1})
-        # read.call_args[0][2] is the `ignore` argument to read()
+        # `call_args` is a two-tupe of (positional, keyword) args.
         self.assertIn('password', read.call_args[0][2])
 
 
-class AbstractDockerTestCase(TestCase):
+# 2. Tests for entity-specific methods. ---------------------------------- {{{1
+
+
+class AbstractDockerContainerTestCase(TestCase):
     """Tests for :class:`nailgun.entities.AbstractDockerContainer`."""
 
     def setUp(self):
         """Set a server configuration at ``self.cfg``."""
         self.cfg = config.ServerConfig('http://example.com')
+        self.abstract_dc = entities.AbstractDockerContainer(
+            self.cfg,
+            id=gen_integer(min_value=1),
+        )
 
     def test_get_fields(self):
         """Call ``nailgun.entity_mixins.Entity.get_fields``.
@@ -744,138 +717,325 @@ class AbstractDockerTestCase(TestCase):
             self.assertIn(attr, docker_hub)
             self.assertNotIn(attr, abstract_docker)
 
+    def test_power(self):
+        """Call :meth:`nailgun.entities.AbstractDockerContainer.power`."""
+        for power_action in ('start', 'stop', 'status'):
+            with mock.patch.object(client, 'put') as client_put:
+                with mock.patch.object(
+                    entities,
+                    '_handle_response',
+                    return_value=gen_integer(),  # not realistic
+                ) as handler:
+                    response = self.abstract_dc.power(power_action)
+            self.assertEqual(client_put.call_count, 1)
+            self.assertEqual(handler.call_count, 1)
+            self.assertEqual(handler.return_value, response)
 
-class InitTestCase(TestCase):
-    """Tests for all of the ``__init__`` methods.
+            # `call_args` is a two-tupe of (positional, keyword) args.
+            self.assertEqual(
+                client_put.call_args[0][1],
+                {'power_action': power_action},
+            )
 
-    The tests in this class are a sanity check. They simply check to see if you
-    can instantiate each entity.
+    def test_power_error(self):
+        """Call :meth:`nailgun.entities.AbstractDockerContainer.power`.
 
-    """
+        Pass an inappropriate argument and assert ``ValueError`` is raised.
+
+        """
+        with self.assertRaises(ValueError):
+            self.abstract_dc.power('foo')
+
+    def test_logs(self):
+        """Call :meth:`nailgun.entities.AbstractDockerContainer.logs`."""
+        for kwargs in (
+                {},
+                {'stdout': gen_integer()},
+                {'stderr': gen_integer()},
+                {'tail': gen_integer()},
+                {
+                    'stderr': gen_integer(),
+                    'stdout': gen_integer(),
+                    'tail': gen_integer(),
+                },
+        ):
+            with mock.patch.object(client, 'get') as client_get:
+                with mock.patch.object(
+                    entities,
+                    '_handle_response',
+                    return_value=gen_integer(),  # not realistic
+                ) as handler:
+                    response = self.abstract_dc.logs(**kwargs)
+            self.assertEqual(client_get.call_count, 1)
+            self.assertEqual(handler.call_count, 1)
+            self.assertEqual(handler.return_value, response)
+
+            # `call_args` is a two-tupe of (positional, keyword) args.
+            self.assertEqual(client_get.call_args[1]['data'], kwargs)
+
+
+class ActivationKeyTestCase(TestCase):
+    """Tests for :class:`nailgun.entities.ActivationKey`."""
+
+    def setUp(self):
+        """Set ``self.activation_key``."""
+        self.activation_key = entities.ActivationKey(
+            config.ServerConfig('http://example.com'),
+            id=gen_integer(min_value=1),
+        )
+
+    def test_add_subscriptions(self):
+        """Call :meth:`nailgun.entities.ActivationKey.add_subscriptions`."""
+        with mock.patch.object(client, 'put') as client_put:
+            with mock.patch.object(
+                entities,
+                '_handle_response',
+                return_value=gen_integer(),  # not realistic
+            ) as handler:
+                response = self.activation_key.add_subscriptions({1: 2})
+        self.assertEqual(client_put.call_count, 1)
+        self.assertEqual(handler.call_count, 1)
+        self.assertEqual(handler.return_value, response)
+
+        # This was just executed: client_put(path='…', data={…}, …)
+        # `call_args` is a two-tupe of (positional, keyword) args.
+        self.assertEqual(client_put.call_args[0][1], {1: 2})
+
+    def test_content_override(self):
+        """Call :meth:`nailgun.entities.ActivationKey.content_override`."""
+        with mock.patch.object(client, 'put') as client_put:
+            with mock.patch.object(
+                entities,
+                '_handle_response',
+                return_value=gen_integer(),  # not realistic
+            ) as handler:
+                content_label = gen_integer()
+                value = gen_integer()
+                response = self.activation_key.content_override(
+                    content_label=content_label,
+                    value=value,
+                )
+        self.assertEqual(client_put.call_count, 1)
+        self.assertEqual(handler.call_count, 1)
+        self.assertEqual(handler.return_value, response)
+
+        # This was just executed: client_put(path='…', data={…}, …)
+        # `call_args` is a two-tupe of (positional, keyword) args.
+        self.assertEqual(
+            client_put.call_args[0][1]['content_override'],
+            {'content_label': content_label, 'value': value},
+        )
+
+
+class OrganizationTestCase(TestCase):
+    """Tests for :class:`nailgun.entities.Organization`."""
+
+    def setUp(self):
+        """Set ``self.org``."""
+        self.org = entities.Organization(
+            config.ServerConfig('http://example.com'),
+            id=gen_integer(min_value=1),
+        )
+
+    def test_subscriptions(self):
+        """Call :meth:`nailgun.entities.Organization.subscriptions`."""
+        with mock.patch.object(client, 'get') as client_get:
+            with mock.patch.object(
+                entities,
+                '_handle_response',
+                return_value={'results': gen_integer()},  # not realistic
+            ) as handler:
+                response = self.org.subscriptions()
+        self.assertEqual(client_get.call_count, 1)
+        self.assertEqual(handler.call_count, 1)
+        self.assertEqual(handler.return_value['results'], response)
+
+    def test_delete_manifest(self):
+        """Call :meth:`nailgun.entities.Organization.delete_manifest`."""
+        for synchronous in (True, False):
+            with mock.patch.object(client, 'post') as client_post:
+                with mock.patch.object(
+                    entities,
+                    '_handle_response',
+                    return_value=gen_integer(),  # not realistic
+                ) as handler:
+                    response = self.org.delete_manifest(synchronous)
+            self.assertEqual(client_post.call_count, 1)
+            self.assertEqual(handler.call_count, 1)
+            self.assertEqual(handler.return_value, response)
+
+    def test_refresh_manifest(self):
+        """Call :meth:`nailgun.entities.Organization.refresh_manifest`."""
+        with mock.patch.object(client, 'put') as client_put:
+            with mock.patch.object(
+                entities,
+                '_handle_response',
+                return_value=gen_integer(),  # not realistic
+            ) as handler:
+                response = self.org.refresh_manifest()
+        self.assertEqual(client_put.call_count, 1)
+        self.assertEqual(handler.call_count, 1)
+        self.assertEqual(handler.return_value, response)
+
+    def test_sync_plan(self):
+        """Call :meth:`nailgun.entities.Organization.sync_plan`."""
+        with mock.patch.object(client, 'post') as client_post:
+            with mock.patch.object(
+                entities,
+                '_handle_response',
+                return_value=gen_integer(),  # not realistic
+            ) as handler:
+                name = gen_integer()
+                interval = gen_integer()
+                response = self.org.sync_plan(name=name, interval=interval)
+        self.assertEqual(client_post.call_count, 1)
+        self.assertEqual(handler.call_count, 1)
+        self.assertEqual(handler.return_value, response)
+
+        # This was just executed: client_post(path='…', data={…}, …)
+        # `call_args` is a two-tupe of (positional, keyword) args.
+        data = client_post.call_args[0][1]
+        self.assertEqual(
+            set(('interval', 'name', 'sync_date')),
+            set(data.keys()),
+        )
+        self.assertEqual(data['interval'], interval)
+        self.assertEqual(data['name'], name)
+        self.assertIsInstance('sync_date', type(''))
+
+    def test_list_rhproducts(self):
+        """Call :meth:`nailgun.entities.Organization.list_rhproducts`."""
+        with mock.patch.object(client, 'get') as client_get:
+            with mock.patch.object(
+                entities,
+                '_handle_response',
+                return_value={'results': gen_integer()},  # not realistic
+            ) as handler:
+                response = self.org.list_rhproducts()
+        self.assertEqual(client_get.call_count, 1)
+        self.assertEqual(handler.call_count, 1)
+        self.assertEqual(handler.return_value['results'], response)
+
+
+class RHCIDeploymentTestCase(TestCase):
+    """Tests for :class:`nailgun.entities.RHCIDeployment`."""
+
+    def setUp(self):
+        """Set ``self.rhci_deployment``."""
+        self.rhci_deployment = entities.RHCIDeployment(
+            config.ServerConfig('http://example.com'),
+            id=gen_integer(min_value=1),
+        )
+
+    def test_add_hypervisors(self):
+        """Call :meth:`nailgun.entities.RHCIDeployment.add_hypervisors`."""
+        with mock.patch.object(client, 'put') as client_put:
+            with mock.patch.object(
+                entities,
+                '_handle_response',
+                return_value={'results': gen_integer()},  # not realistic
+            ) as handler:
+                hypervisor_ids = [gen_integer(), gen_integer(), gen_integer()]
+                response = self.rhci_deployment.add_hypervisors(hypervisor_ids)
+        self.assertEqual(client_put.call_count, 1)
+        self.assertEqual(handler.call_count, 1)
+        self.assertEqual(handler.return_value, response)
+
+        # `call_args` is a two-tupe of (positional, keyword) args.
+        self.assertEqual(
+            client_put.call_args[0][1],
+            {'discovered_host_ids': hypervisor_ids},
+        )
+
+    def test_deploy(self):
+        """Call :meth:`nailgun.entities.RHCIDeployment.deploy`."""
+        with mock.patch.object(client, 'put') as client_put:
+            with mock.patch.object(
+                entities,
+                '_handle_response',
+                return_value={'results': gen_integer()},  # not realistic
+            ) as handler:
+                params = {'foo': gen_integer()}
+                response = self.rhci_deployment.deploy(params)
+        self.assertEqual(client_put.call_count, 1)
+        self.assertEqual(handler.call_count, 1)
+        self.assertEqual(handler.return_value, response)
+
+        # `call_args` is a two-tupe of (positional, keyword) args.
+        self.assertEqual(client_put.call_args[0][1], params)
+
+    def test_update(self):
+        """Call :meth:`nailgun.entities.RHCIDeployment.update`."""
+        with mock.patch.object(client, 'put') as client_put:
+            with mock.patch.object(
+                entities,
+                '_handle_response',
+                return_value={'results': gen_integer()},  # not realistic
+            ) as handler:
+                params = {'foo': gen_integer()}
+                response = self.rhci_deployment.update(params)
+        self.assertEqual(client_put.call_count, 1)
+        self.assertEqual(handler.call_count, 1)
+        self.assertEqual(handler.return_value, response)
+
+        # `call_args` is a two-tupe of (positional, keyword) args.
+        self.assertEqual(client_put.call_args[0][1], params)
+
+
+# 3. Other tests. -------------------------------------------------------- {{{1
+
+
+class VersionTestCase(TestCase):
+    """Tests for entities that vary based on the server's software version."""
 
     @classmethod
     def setUpClass(cls):
-        """Set a server configuration at ``cls.cfg``."""
-        cls.cfg = config.ServerConfig('http://example.com')
+        """Create several server configs with different versions."""
+        super(VersionTestCase, cls).setUpClass()
+        cls.cfg_608 = config.ServerConfig('bogus url', version='6.0.8')
+        cls.cfg_610 = config.ServerConfig('bogus url', version='6.1.0')
 
-    def test_init_succeeds(self):
-        """Instantiate every entity.
+    def test_repository_fields(self):
+        """Check :class:`nailgun.entities.Repository`'s fields.
 
-        Assert that the returned object is an instance of the class that
-        produced it.
-
-        """
-        entities_ = [
-            (entity, {})
-            for entity in (
-                # entities.ContentViewFilterRule,  # see below
-                # entities.ContentViewPuppetModule,  # see below
-                # entities.OperatingSystemParameter,  # see below
-                # entities.SyncPlan,  # see below
-                entities.AbstractComputeResource,
-                entities.AbstractContentViewFilter,
-                entities.AbstractDockerContainer,
-                entities.ActivationKey,
-                entities.Architecture,
-                entities.AuthSourceLDAP,
-                entities.Bookmark,
-                entities.CommonParameter,
-                entities.ComputeAttribute,
-                entities.ComputeProfile,
-                entities.ConfigGroup,
-                entities.ConfigTemplate,
-                entities.ContentUpload,
-                entities.ContentView,
-                entities.ContentViewVersion,
-                entities.DockerComputeResource,
-                entities.DockerHubContainer,
-                entities.Domain,
-                entities.Environment,
-                entities.Errata,
-                entities.ErratumContentViewFilter,
-                entities.Filter,
-                entities.ForemanTask,
-                entities.GPGKey,
-                entities.Host,
-                entities.HostCollection,
-                entities.HostCollectionErrata,
-                entities.HostCollectionPackage,
-                entities.HostGroup,
-                entities.Image,
-                entities.Interface,
-                entities.LibvirtComputeResource,
-                entities.LifecycleEnvironment,
-                entities.Location,
-                entities.Media,
-                entities.Model,
-                entities.OSDefaultTemplate,
-                entities.OperatingSystem,
-                entities.Organization,
-                entities.OverrideValue,
-                entities.PackageGroupContentViewFilter,
-                entities.PartitionTable,
-                entities.Permission,
-                entities.Ping,
-                entities.Product,
-                entities.PuppetClass,
-                entities.PuppetModule,
-                entities.RPMContentViewFilter,
-                entities.Realm,
-                entities.Report,
-                entities.Repository,
-                entities.Role,
-                entities.RoleLDAPGroups,
-                entities.SmartProxy,
-                entities.SmartVariable,
-                entities.Status,
-                entities.Subnet,
-                entities.Subscription,
-                entities.System,
-                entities.SystemPackage,
-                entities.TemplateCombination,
-                entities.TemplateKind,
-                entities.User,
-                entities.UserGroup,
-            )
-        ]
-        entities_.extend([
-            (
-                entities.LibvirtComputeResource,
-                {'display_type': 'VNC', 'set_console_password': False},
-            ),
-            (
-                entities.DockerComputeResource,
-                {'email': 'nobody@example.com', 'url': 'http://example.com'},
-            ),
-            (entities.ContentViewFilterRule, {'content_view_filter': 1}),
-            (entities.ContentViewPuppetModule, {'content_view': 1}),
-            (entities.OperatingSystemParameter, {'operatingsystem': 1}),
-            (entities.SyncPlan, {'organization': 1}),
-        ])
-        for entity, params in entities_:
-            if version_info < (3, 4):  # subTest() introduced in Python 3.4
-                self.assertIsInstance(entity(self.cfg, **params), entity)
-            else:
-                with self.subTest(entity):  # pylint:disable=no-member
-                    self.assertIsInstance(entity(self.cfg, **params), entity)
-
-    def test_required_params(self):
-        """Instantiate entities that require extra parameters.
-
-        Assert that ``TypeError`` is raised if the required extra parameters
-        are not provided.
+        Assert that ``Repository`` has fields named "docker_upstream_name" and
+        "checksum_type", and that "docker" is a choice for the "content_type"
+        field starting with version 6.1.
 
         """
-        for entity in (
-                entities.ContentViewFilterRule,
-                entities.ContentViewPuppetModule,
-                entities.OperatingSystemParameter,
-                entities.SyncPlan,
-        ):
-            if version_info < (3, 4):  # subTest() introduced in Python 3.4
-                with self.assertRaises(TypeError):
-                    entity(self.cfg)
-            else:
-                with self.subTest(entity):  # pylint:disable=no-member
-                    with self.assertRaises(TypeError):
-                        entity(self.cfg)
+        repo_608 = entities.Repository(self.cfg_608)
+        repo_610 = entities.Repository(self.cfg_610)
+        for field_name in ('docker_upstream_name', 'checksum_type'):
+            self.assertNotIn(field_name, repo_608.get_fields())
+            self.assertIn(field_name, repo_610.get_fields())
+        self.assertNotIn(
+            'docker',
+            repo_608.get_fields()['content_type'].choices
+        )
+        self.assertIn('docker', repo_610.get_fields()['content_type'].choices)
+
+    def test_subnet_fields(self):
+        """Check :class:`nailgun.entities.Subnet`'s fields.
+
+        Assert that ``Subnet`` has the following fields starting in version
+        6.1:
+
+        * boot_mode
+        * dhcp
+        * dns
+        * location
+        * organization
+        * tftp
+
+        """
+        subnet_608 = entities.Subnet(self.cfg_608)
+        subnet_610 = entities.Subnet(self.cfg_610)
+        for field_name in (
+                'boot_mode',
+                'dhcp',
+                'dns',
+                'location',
+                'organization',
+                'tftp'):
+            self.assertNotIn(field_name, subnet_608.get_fields())
+            self.assertIn(field_name, subnet_610.get_fields())

--- a/tests/test_entity_fields.py
+++ b/tests/test_entity_fields.py
@@ -3,7 +3,7 @@
 from fauxfactory.constants import VALID_NETMASKS
 from nailgun import entity_fields
 from random import randint
-from unittest import TestCase
+from unittest2 import TestCase
 import datetime
 import socket
 
@@ -99,11 +99,7 @@ class GenValueTestCase(TestCase):
         http://stackoverflow.com/questions/7629643/how-do-i-validate-the-format-of-a-mac-address
 
         """
-        if version_info.major == 2:
-            validator = self.assertRegexpMatches
-        else:
-            validator = self.assertRegex  # pylint:disable=no-member
-        validator(
+        self.assertRegex(
             entity_fields.MACAddressField().gen_value().upper(),
             '^([0-9A-F]{2}[:]){5}[0-9A-F]{2}$'
         )
@@ -150,7 +146,7 @@ class StringFieldTestCase(TestCase):
     def test_str_is_returned(self):
         """Ensure a unicode string at least 1 char long is returned."""
         string = entity_fields.StringField().gen_value()
-        if version_info[0] == 2:
+        if version_info.major == 2:
             self.assertIsInstance(string, unicode)  # flake8:noqa pylint:disable=undefined-variable
         else:
             self.assertIsInstance(string, str)


### PR DESCRIPTION
Add "unittest2" as a dependency. This package backports many features to older
versions of Python. For example, it makes the `assertRegex` assertion and
`subTest` context manager available in older versions of Python. As a result:

* Drop "ddt" as a dependency.
* Drop some testing logic that makes use of versioning information.

Reorganize `tests/test_entities.py`:

> This file is divided in to three sets of test cases (`TestCase` subclasses):
>
> 1. Tests for inherited methods.
> 2. Tests for entity-specific methods.
> 3. Other tests.

Fiddle with a few methods in module `nailgun.entities` by replacing custom
response handling logic with calls to function
`nailgun.entities._handle_response`. Add some new unit tests for module
`nailgun.entities.`