### PR TITLE
Deal more robustly with server responses

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,11 @@ setup(
         'Programming Language :: Python :: 3.4',
     ],
     packages=find_packages(),
-    install_requires=['fauxfactory', 'pyxdg', 'requests>=2.7', 'setuptools'],
+    install_requires=[
+        'fauxfactory',
+        'inflector',
+        'pyxdg',
+        'requests>=2.7',
+        'setuptools',
+    ],
 )


### PR DESCRIPTION
Fix #110:

> Rather than hacking around the hash/ID discrepancies on an individual basis,
> NailGun should search for both IDs and hashes when trying to populate foreign
> key fields on entities. Doing so will let NailGun be more robust and let us
> remove much redundant code from module `nailgun.entities`.

Fix #114:

> NailGun should be capable of dealing with the pluralized version of a field
> name.

Test results against downstream:

    $ make test-foreman-api
    python -m cProfile -o test-foreman-api.pstats $(which nosetests) --logging-filter=nailgun,robottelo --with-xunit --xunit-file=foreman-results.xml tests/foreman/api
    ......SSS.....................S....................E......................SSSSSSSSSSSSSSSSSSSSSSSS........SSSSSSSSSSSSSSSSSSSSSSSSS..............SSSSSSSSSSSSS.............S.SSSSSSS.SSSSSS................................................S.........SSSSSSSSSSSSS...S..S...S..SSSSSSSSSS.SSSSSSSS.....S...S......S.....................................................................S...S.......................................................................................S.............................................................SSSSSS..S.SS.SSSSS.S..SSS.SSSSSSSSSSSSSSSSSSSSSSSSSSSSS.S..................S..S...........................................................SE.........................................................SSSSSSSS...SSSSSSSSSSSSSSSSSSSSSSSSSSSSSS..S.SSS.SSSSSSSSSSSSSSSSSSSSSS............................................
    ======================================================================
    ERROR: test suite for <class 'tests.foreman.api.test_contentview.CVRedHatContent'>
    ----------------------------------------------------------------------
    Traceback (most recent call last):
    File "/home/ichimonji10/.virtualenvs/robottelo/lib/python2.7/site-packages/nose/suite.py", line 209, in run
        self.setUp()
    File "/home/ichimonji10/.virtualenvs/robottelo/lib/python2.7/site-packages/nose/suite.py", line 292, in setUp
        self.setupContext(ancestor)
    File "/home/ichimonji10/.virtualenvs/robottelo/lib/python2.7/site-packages/nose/suite.py", line 315, in setupContext
        try_run(context, names)
    File "/home/ichimonji10/.virtualenvs/robottelo/lib/python2.7/site-packages/nose/util.py", line 471, in try_run
        return func()
    File "/home/ichimonji10/code/robottelo/tests/foreman/api/test_contentview.py", line 864, in setUpClass
        releasever='7Server',
    File "robottelo/api/utils.py", line 118, in enable_rhrepo_and_fetchid
        reposet_id = entities.Product(id=prd_id).fetch_reposet_id(name=reposet)
    File "/home/ichimonji10/code/nailgun/nailgun/entities.py", line 2620, in fetch_reposet_id
        "The length of the results is:", len(results))
    APIResponseError: ('The length of the results is:', 0)

    ======================================================================
    ERROR: @Test: Sync RedHat Repository.
    ----------------------------------------------------------------------
    Traceback (most recent call last):
    File "/home/ichimonji10/code/robottelo/tests/foreman/api/test_repository.py", line 257, in test_redhat_sync_1
        '7Server',
    File "robottelo/api/utils.py", line 118, in enable_rhrepo_and_fetchid
        reposet_id = entities.Product(id=prd_id).fetch_reposet_id(name=reposet)
    File "/home/ichimonji10/code/nailgun/nailgun/entities.py", line 2620, in fetch_reposet_id
        "The length of the results is:", len(results))
    APIResponseError: ('The length of the results is:', 0)

    ----------------------------------------------------------------------
    Ran 841 tests in 4704.321s

    FAILED (SKIP=236, errors=2)