### PR TITLE
Fix RHCIDeployment fields

### DIFF
--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -716,6 +716,7 @@ class ReadTestCase(TestCase):
                 entities.HostGroup,
                 entities.Media,
                 entities.Product,
+                entities.RHCIDeployment,
                 entities.System,
         ):
             with mock.patch.object(EntityReadMixin, 'read_json') as read_json:


### PR DESCRIPTION
Fix #112: "RHCIDeployment entity has bad fields". Change the following from
`IntegerField`s to `OneToOneField`s:

* lifecycle_environment_id
* organization_id
* rhev_engine_host_id

Also, extend the `read()` method and make it normalize the server's response.
Manual test results:

    >>> from nailgun import entities
    >>> rhci_deployment = entities.RHCIDeployment(id=1).read()