### PR TITLE
Added entities.Product.list_available_rhrepos() func

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2667,6 +2667,23 @@ class Product(
         )
         return _handle_response(response, self._server_config, synchronous)
 
+    # pylint:disable=C0103
+    def repository_sets_available_repositories(self, reposet_id):
+        """Lists available repositories for the repository set
+
+        :param reposet_id: The RepositorySet Id.
+        :returns: Returns list of available repositories for the repository set
+
+        """
+        response = client.get(
+            self.path(
+                'repository_sets/{0}/available_repositories'
+                .format(reposet_id)
+            ),
+            **self._server_config.get_client_kwargs()
+        )
+        return _handle_response(response, self._server_config)['results']
+
 
 class PartitionTable(
         Entity, EntityCreateMixin, EntityDeleteMixin, EntityReadMixin):

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -230,6 +230,8 @@ class PathTestCase(TestCase):
                 (entities.Product, 'repository_sets'),
                 (entities.Product, 'repository_sets/2396/disable'),
                 (entities.Product, 'repository_sets/2396/enable'),
+                (entities.Product,
+                 'repository_sets/2396/available_repositories'),
                 (entities.Repository, 'sync'),
                 (entities.Repository, 'upload_content'),
                 (entities.RHCIDeployment, 'deploy'),
@@ -1128,6 +1130,37 @@ class OrganizationTestCase(TestCase):
                 return_value={'results': gen_integer()},  # not realistic
             ) as handler:
                 response = self.org.list_rhproducts()
+        self.assertEqual(client_get.call_count, 1)
+        self.assertEqual(handler.call_count, 1)
+        self.assertEqual(handler.return_value['results'], response)
+
+
+class ProductTestCase(TestCase):
+    """Tests for :class:`nailgun.entities.Product`."""
+
+    def setUp(self):
+        """Set ``self.product``."""
+        self.product = entities.Product(
+            config.ServerConfig('http://example.com'),
+            id=gen_integer(min_value=1),
+        )
+
+    # pylint:disable=C0103
+    def test_repository_sets_available_repositories(self):
+        """Call
+        :meth:`nailgun.entities.Product.repository_sets_available_repositories`
+
+        """
+        with mock.patch.object(client, 'get') as client_get:
+            with mock.patch.object(
+                entities,
+                '_handle_response',
+                return_value={'results': gen_integer()},  # not realistic
+            ) as handler:
+                reposet_id = gen_integer(min_value=1)
+                response = self.product.repository_sets_available_repositories(
+                    reposet_id=reposet_id,
+                )
         self.assertEqual(client_get.call_count, 1)
         self.assertEqual(handler.call_count, 1)
         self.assertEqual(handler.return_value['results'], response)


### PR DESCRIPTION
Added ```entities.Product.list_available_rhrepos()``` func. Need it in tests to verify after ```enable_rhrepo()``` or ```disable_rhrepo()``` repository was actually enabled/disabled, not just by checking response status.
Tests results:
```
make test
python -m unittest discover --start-directory tests --top-level-directory .
.............................................................................................................................................
----------------------------------------------------------------------
Ran 141 tests in 0.247s

OK
```