### PR TITLE
Update documentation example

### DIFF
--- a/docs/create_organization_plain.py
+++ b/docs/create_organization_plain.py
@@ -15,6 +15,7 @@ def main():
     auth = ('admin', 'changeme')
     base_url = 'https://sat1.example.com'
     organization_name = 'junk org'
+    args = {'auth': auth, 'headers': {'content-type': 'application/json'}}
 
     response = requests.post(
         base_url + '/katello/api/v2/organizations',
@@ -22,8 +23,7 @@ def main():
             'name': organization_name,
             'organization': {'name': organization_name},
         }),
-        auth=auth,
-        headers={'content-type': 'application/json'},
+        **args
     )
     response.raise_for_status()
     PrettyPrinter().pprint(response.json())
@@ -32,8 +32,7 @@ def main():
             base_url,
             response.json()['id'],
         ),
-        auth=auth,
-        headers={'content-type': 'application/json'},
+        **args
     )
     response.raise_for_status()
 


### PR DESCRIPTION
After updating script with a correct URL and adding a param so that it ignores
SSL verification, it runs just fine:

    $ docs/create_organization_plain.py
    {'ancestry': None,
    'apply_info_task_id': None,
    'created_at': '2015-06-25T14:49:42Z',
    'default_info': {'distributor': [], 'system': []},
    'description': None,
    'id': 463,
    'ignore_types': [],
    'katello_default': True,
    'label': 'junk_org',
    'name': 'junk org',
    'service_level': None,
    'service_levels': [],
    'title': 'junk org',
    'updated_at': '2015-06-25T14:49:42Z'}