### PR TITLE
Fix a bug. Refactor for conciseness.

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -1588,9 +1588,11 @@ class HostGroup(
             attrs['parent'] = None
         else:
             attrs['parent'] = {'id': parent_id}
-        update_attrs = self.update_json([])
+        # We cannot call `self.update_json([])`, as an ID might not be present
+        # on self. However, `attrs` is guaranteed to have an ID.
+        attrs2 = HostGroup(self._server_config, id=attrs['id']).update_json([])
         for attr in ('content_view_id', 'lifecycle_environment_id'):
-            attrs[attr] = update_attrs[attr]
+            attrs[attr] = attrs2[attr]
         return super(HostGroup, self).read(entity, attrs, ignore)
 
     def update(self, fields=None):

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -1056,11 +1056,7 @@ class ContentViewPuppetModule(
             )
         if attrs is None:
             attrs = self.read_json()
-        uuid = attrs.pop('uuid')
-        if uuid is None:
-            attrs['puppet_module'] = None
-        else:
-            attrs['puppet_module'] = {'id': uuid}
+        attrs['puppet_module_id'] = attrs.pop('uuid')  # either an ID or None
         return super(ContentViewPuppetModule, self).read(entity, attrs, ignore)
 
     def create_payload(self):
@@ -1583,11 +1579,7 @@ class HostGroup(
         """
         if attrs is None:
             attrs = self.read_json()
-        parent_id = attrs.pop('ancestry')
-        if parent_id is None:
-            attrs['parent'] = None
-        else:
-            attrs['parent'] = {'id': parent_id}
+        attrs['parent_id'] = attrs.pop('ancestry')  # either an ID or None
         # We cannot call `self.update_json([])`, as an ID might not be present
         # on self. However, `attrs` is guaranteed to have an ID.
         attrs2 = HostGroup(self._server_config, id=attrs['id']).update_json([])

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -767,7 +767,7 @@ class ReadTestCase(TestCase):
             (
                 entities.ContentViewPuppetModule(self.cfg, content_view=1),
                 {'uuid': None},
-                {'puppet_module': None},
+                {'puppet_module_id': None},
             ),
             (
                 entities.Domain(self.cfg),
@@ -1084,7 +1084,7 @@ class HostGroupTestCase(TestCase):
                 'content_view_id': None,
                 'id': 641212,
                 'lifecycle_environment_id': None,
-                'parent': None,
+                'parent_id': None,
             },
         )
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1065,12 +1065,15 @@ class HostGroupTestCase(TestCase):
         """
         entity = entities.HostGroup(config.ServerConfig('some url'))
         with mock.patch.object(entity, 'read_json') as read_json:
-            read_json.return_value = {'ancestry': None}
-            with mock.patch.object(entity, 'update_json') as update_json:
-                update_json.return_value = {
+            read_json.return_value = {'ancestry': None, 'id': 641212}  # random
+            with mock.patch.object(
+                entities.HostGroup,
+                'update_json',
+                return_value={
                     'content_view_id': None,
                     'lifecycle_environment_id': None,
-                }
+                },
+            ) as update_json:
                 with mock.patch.object(EntityReadMixin, 'read') as read:
                     entity.read()
         for meth in (read_json, update_json, read):
@@ -1079,6 +1082,7 @@ class HostGroupTestCase(TestCase):
             read.call_args[0][1],
             {
                 'content_view_id': None,
+                'id': 641212,
                 'lifecycle_environment_id': None,
                 'parent': None,
             },


### PR DESCRIPTION
These two commits are logically separate, but I'm bundling them together for convenience's sake. They touch the same bits of code, so it'd be a pain to submit separate PRs due to the resultant merge conflicts. For full details, see the individual commit messages. Summary of changes:

1. Fix a bug in `HostGroup.read` caused by c420ab6e1ecbe2b7b802a8b9114bb1a87f2f8529. (And this is why we have releases and no longer make Robottelo clone the repo fresh for each test run.)
2. Make some code much more concise by taking advantage of #110.