### PR TITLE
Add fields to `HostGroup` entity

### DIFF
--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1404,6 +1404,19 @@ class VersionTestCase(TestCase):
         self.assertNotIn('prior', payload)
         self.assertIn('prior_id', payload)
 
+    def test_hostgroup_fields(self):
+        """Check :class:`nailgun.entities.HostGroup`'s fields.
+
+        Assert that version 6.1.0 adds the ``content_view`` and
+        ``lifecycle_environment`` fields.
+
+        """
+        entity_608 = entities.HostGroup(self.cfg_608)
+        entity_610 = entities.HostGroup(self.cfg_610)
+        for field_name in ('content_view', 'lifecycle_environment'):
+            self.assertNotIn(field_name, entity_608.get_fields())
+            self.assertIn(field_name, entity_610.get_fields())
+
     def test_repository_fields(self):
         """Check :class:`nailgun.entities.Repository`'s fields.
 


### PR DESCRIPTION
Add the `content_view` and `lifecycle_environment` fields to the `HostGroup`
entity for Satellite 6.1.0 and beyond. Make `HostGroup.read` deal with BZ
1235377 [1]:

> A hostgroup has at least the following attributes:
>
> […]
>
> GET /api/v2/hostgroups/:id returns the following attributes:
>
> […]
>
> The following attributes are not mentioned in the response:
>
> * content_view
> * lifecycle_environment

Doing this allows the `HostGroup` entity to make use of features available in
Satellite 6.1.0 while retaining backward compatibility with Satellite 6.0.8. Add
unit tests and perform manual testing:

    >>> cfg_608 = ServerConfig.get('sat608-rhel6')
    >>> cfg_610 = ServerConfig.get('sat6-rhel71')
    >>> hg_608 = entities.HostGroup(cfg_608, id=1).read()
    >>> hg_610 = entities.HostGroup(cfg_610, id=1).read()
    >>> 'content_view' in hg_608.get_values() or 'lifecycle_environment' in hg_608.get_values()
    False
    >>> 'content_view' in hg_610.get_values() and 'lifecycle_environment' in hg_610.get_values()
    True

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1235377