### PR TITLE
Added support to update content view filters

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -979,7 +979,11 @@ class ContentViewFilterRule(
 
 
 class AbstractContentViewFilter(
-        Entity, EntityCreateMixin, EntityDeleteMixin, EntityReadMixin):
+        Entity,
+        EntityCreateMixin,
+        EntityDeleteMixin,
+        EntityReadMixin,
+        EntityUpdateMixin):
     """A representation of a Content View Filter entity."""
 
     def __init__(self, server_config=None, **kwargs):


### PR DESCRIPTION
Added support to update content view filters, need it for SatelliteQE/robottelo#2463.
No bugs/workarounds for ```update()```, CVF are updating just fine.
```
make test 
python -m unittest discover --start-directory tests --top-level-directory .
..................................................................................................................................................
----------------------------------------------------------------------
Ran 146 tests in 0.180s

OK
```