### PR TITLE
Move a pylint directive

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2803,8 +2803,7 @@ class Product(
         )
         return _handle_response(response, self._server_config, synchronous)
 
-    # pylint:disable=C0103
-    def repository_sets_available_repositories(self, reposet_id):
+    def repository_sets_available_repositories(self, reposet_id):  # noqa pylint:disable=C0103
         """Lists available repositories for the repository set
 
         :param reposet_id: The RepositorySet Id.


### PR DESCRIPTION
Place a `pylint:disable` directive at the end of a line. Doing so causes pylint
to ignore the named warning for that one line, rather than for all following
code at the same indentation level — in this case, almost a thousand lines of
code.