### PR TITLE
Rearrange documentation

### DIFF
--- a/docs/create_organization_nailgun.py
+++ b/docs/create_organization_nailgun.py
@@ -7,7 +7,7 @@ Use NailGun to accomplish this task.
 """
 from nailgun.config import ServerConfig
 from nailgun.entities import Organization
-from pprint import PrettyPrinter
+from pprint import pprint
 
 
 def main():
@@ -17,7 +17,7 @@ def main():
         url='https://sat1.example.com',  # …to talk to this server.
     )
     org = Organization(server_config, name='junk org').create()
-    PrettyPrinter().pprint(org.get_values())
+    pprint(org.get_values())  # e.g. {'name': 'junk org', …}
     org.delete()
 
 

--- a/docs/create_organization_nailgun_v2.py
+++ b/docs/create_organization_nailgun_v2.py
@@ -2,13 +2,13 @@
 # -*- coding: utf-8 -*-
 """Create an organization, print out its attributes and delete it."""
 from nailgun.entities import Organization
-from pprint import PrettyPrinter
+from pprint import pprint
 
 
 def main():
     """Create an organization, print out its attributes and delete it."""
     org = Organization(name='junk org').create()
-    PrettyPrinter().pprint(org.get_values())
+    pprint(org.get_values())  # e.g. {'name': 'junk org', …}
     org.delete()
 
 

--- a/docs/create_organization_plain.py
+++ b/docs/create_organization_plain.py
@@ -5,7 +5,7 @@
 Use Requests and standard library modules to accomplish this task.
 
 """
-from pprint import PrettyPrinter
+from pprint import pprint
 import json
 import requests
 
@@ -26,7 +26,7 @@ def main():
         **args
     )
     response.raise_for_status()
-    PrettyPrinter().pprint(response.json())
+    pprint(response.json())
     response = requests.delete(
         '{0}/katello/api/v2/organizations/{1}'.format(
             base_url,

--- a/docs/create_user_nailgun.py
+++ b/docs/create_user_nailgun.py
@@ -5,7 +5,7 @@ from __future__ import print_function
 from nailgun import client
 from nailgun.config import ServerConfig
 from nailgun.entities import Organization, User
-from pprint import PrettyPrinter
+from pprint import pprint
 
 
 def main():
@@ -18,7 +18,7 @@ def main():
     for server_config in server_configs:
         # The LDAP authentication source with an ID of 1 is internal. It is
         # nearly guaranteed to exist and be functioning.
-        PrettyPrinter().pprint(User(
+        user = User(
             server_config,
             auth_source=1,  # or: AuthSourceLDAP(server_config, id=1),
             login='Alice',
@@ -27,7 +27,8 @@ def main():
                 get_organization(server_config, 'Default_Organization')
             ],
             password='hackme',
-        ).create_json())  # create_json returns a dict of attributes
+        )
+        pprint(user.get_values())  # e.g. {'login': 'Alice', …}
 
 
 def get_organization(server_config, label):

--- a/docs/create_user_plain.py
+++ b/docs/create_user_plain.py
@@ -12,7 +12,7 @@ like so::
 
 """
 from __future__ import print_function
-from pprint import PrettyPrinter
+from pprint import pprint
 import requests
 import json
 
@@ -44,7 +44,7 @@ def main():
             verify=server_config['verify'],
         )
         response.raise_for_status()
-        PrettyPrinter().pprint(response.json())
+        pprint(response.json())
 
 
 def get_organization_id(server_config, label):

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,16 +2,42 @@ NailGun
 =======
 
 NailGun is a GPL-licensed Python library that facilitates easy usage of the
-Satellite 6 API.
+Satellite 6 API. It lets you write code like this::
 
-This page provides a summary of information about NailGun. You can find more
-in-depth information by visiting one of the other sections:
+    >>> org = Organization(id=1).read()
+
+This page provides a summary of information about NailGun.
+
+.. contents::
+
+More in-depth coverage is provided in other sections.
 
 .. toctree::
     :maxdepth: 1
 
     examples
     api/index
+
+Quick Start
+-----------
+
+This script demonstrates how to create and delete an organization, and how to
+save some of our work for later re-use::
+
+    >>> from nailgun.config import ServerConfig
+    >>> from nailgun.entities import Organization
+    >>> server_config = ServerConfig(
+    ...     auth=('admin', 'changeme'),      # Use these credentials…
+    ...     url='https://sat1.example.com',  # …to talk to this server.
+    ... )  # More options are available, e.g. disabling SSL verification.
+    >>> org = Organization(server_config, name='junk org').create()
+    >>> org.name == 'junk org'  # Access all attrs likewise, e.g. `org.label`
+    True
+    >>> org.delete()
+    >>> server_config.save()  # Save to disk w/label 'default'. Read with get()
+
+This example glosses over *many* features. The :doc:`examples` and :doc:`API
+documentation </api/index>` sections provide more in-depth documentation.
 
 Why NailGun?
 ------------
@@ -58,16 +84,15 @@ an independently useful library.
 Resources
 ---------
 
-If you'd like to chat with a human, please join the #robottelo channel on the
-`freenode`_ IRC network.
+The :doc:`examples` and :doc:`API documentation </api/index>` sections provide
+more in-depth documentation.
 
-For examples of how to use NailGun, see :doc:`examples`. For even more examples,
-see the `Robottelo source code`_, especially the `tests/foreman/api/
+Join the #robottelo channel on the `freenode`_ IRC network to chat with a
+human. The `Robottelo source code`_ contains many real-world examples how
+NailGun is used, especially the `tests/foreman/api/
 <https://github.com/SatelliteQE/robottelo/tree/master/tests/foreman/api>`_
-directory. For a glimpse into the design of NailGun, see `this blog post`_.
-
-For information on the internals of NailGun itself, see the :doc:`API
-documentation </api/index>`.
+directory. `This blog post`_ provides a glimpse in to the challenges that
+NailGun is designed to overcome.
 
 Contributing
 ------------


### PR DESCRIPTION
Add brief examples of how to use NailGun to the beginning of the documentation.
This should serve as a simple reference that will help new-comers on-board.

Fiddle with existing documentation. Make the calls to `pprint` more concise and
add a few explanatory comments.