### PR TITLE
Fix a OneToOneField

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -176,7 +176,7 @@ class ActivationKey(
             'auto_attach': entity_fields.BooleanField(),
             'content_view': entity_fields.OneToOneField(ContentView),
             'description': entity_fields.StringField(),
-            'environment': entity_fields.OneToOneField(Environment),
+            'environment': entity_fields.OneToOneField(LifecycleEnvironment),
             'host_collection': entity_fields.OneToManyField(HostCollection),
             'max_content_hosts': entity_fields.IntegerField(),
             'name': entity_fields.StringField(required=True),


### PR DESCRIPTION
Fix #105. The `ActivationKey` entity's `environment` field is incorrectly
defined as referencing an `Environment` entity. It should reference a
`LifecycleEnvironment` entity.

Before fix:

```python
>>> from nailgun import entities
>>> env = entities.Environment(id=1)
>>> lce = entities.LifecycleEnvironment(id=1)
>>> entities.ActivationKey(environment=env).create_payload()
{'environment_id': 1}
>>> entities.ActivationKey(environment=lce).create_payload()
{'environment_id': nailgun.entities.LifecycleEnvironment(…)}  # uh oh!
```

After fix:

```python
>>> from nailgun import entities
>>> env = entities.Environment(id=1)
>>> lce = entities.LifecycleEnvironment(id=1)
>>> entities.ActivationKey(environment=env).create_payload()
{'environment_id': nailgun.entities.Environment(…)}
>>> entities.ActivationKey(environment=lce).create_payload()
{'environment_id': 1}  # much better
```