### PR TITLE
Fix a System OneToOneField

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -3560,7 +3560,7 @@ class System(
         self._fields = {
             'content_view': entity_fields.OneToOneField(ContentView),
             'description': entity_fields.StringField(),
-            'environment': entity_fields.OneToOneField(Environment),
+            'environment': entity_fields.OneToOneField(LifecycleEnvironment),
             'facts': entity_fields.DictField(
                 default={u'uname.machine': u'unknown'},
                 null=True,


### PR DESCRIPTION
The `System` entity's `environment` field is incorrectly defined as referencing
an `Environment` entity. It should reference a `LifecycleEnvironment` entity.

Before fix:

    >>> from nailgun import entities
    >>> env = entities.Environment(id=1)
    >>> lce = entities.LifecycleEnvironment(id=1)
    >>> entities.System(environment=env).create_payload()
    {'environment_id': 1}
    >>> entities.System(environment=lce).create_payload()
    {'environment_id': nailgun.entities.LifecycleEnvironment(…)}

After fix:

    >>> from nailgun import entities
    >>> env = entities.Environment(id=1)
    >>> lce = entities.LifecycleEnvironment(id=1)
    >>> entities.System(environment=env).create_payload()
    {'environment_id': nailgun.entities.Environment(…)}
    >>> entities.System(environment=lce).create_payload()
    {'environment_id': 1}