### PR TITLE
Fix for a random ptable.name bug

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2841,12 +2841,18 @@ class PartitionTable(
         EntityDeleteMixin,
         EntityReadMixin,
         EntityUpdateMixin):
-    """A representation of a Partition Table entity."""
+    """A representation of a Partition Table entity.
+
+    Currently a Partition Table with one character in name cannot be created.
+    For more information, see `Bugzilla #1229384
+    <https://bugzilla.redhat.com/show_bug.cgi?id=1229384>`_.
+
+    """
 
     def __init__(self, server_config=None, **kwargs):
         self._fields = {
             'layout': entity_fields.StringField(required=True),
-            'name': entity_fields.StringField(required=True),
+            'name': entity_fields.StringField(required=True, length=(2, 30)),
             'os_family': entity_fields.StringField(
                 choices=_OPERATING_SYSTEMS,
                 null=True,


### PR DESCRIPTION
Got tired of random test [failures](https://github.com/SatelliteQE/robottelo/issues/2211) [because](https://github.com/SatelliteQE/robottelo/issues/2319) [of](https://github.com/SatelliteQE/robottelo/issues/2318) [partition](https://github.com/SatelliteQE/robottelo/issues/2291) [tables](https://github.com/SatelliteQE/robottelo/issues/2229) [bug (BZ1229384)](https://bugzilla.redhat.com/show_bug.cgi?id=1229384).
This one-line PR should get rid of it.

**Pros**:
+ Tests will stop failing
+ Bug is pretty annoying, as failures are random (only when randint(1,30) throws 1), short failure log contains just common '422' error. As a result it's always time-consuming to detect the issue for each new build. 
+ We're not decreasing coverage, as there already [is](https://github.com/SatelliteQE/robottelo/blob/master/tests/foreman/api/test_partitiontable.py#L30) a test to verify that specific case
+ [BZ](https://bugzilla.redhat.com/show_bug.cgi?id=1229384) is already moved out of this release, so without the fix we will see random failures for a long time.

**Cons**:
- It's not a good approach to avoid existing bugs. If bug exists - test should fail.
- After bug is fixed, this PR should be manually reverted, there's no ```skip_if_bug_open``` func for nailgun :(

Please, share your thoughts on this.