### PR TITLE
Fixes an api unicode issue for partition table names.

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2859,12 +2859,15 @@ class PartitionTable(
     For more information, see `Bugzilla #1229384
     <https://bugzilla.redhat.com/show_bug.cgi?id=1229384>`_.
 
+    Note: Having a name length of 2 had failures again.  Updating the length to
+    4.
+
     """
 
     def __init__(self, server_config=None, **kwargs):
         self._fields = {
             'layout': entity_fields.StringField(required=True),
-            'name': entity_fields.StringField(required=True, length=(2, 30)),
+            'name': entity_fields.StringField(required=True, length=(4, 30)),
             'os_family': entity_fields.StringField(
                 choices=_OPERATING_SYSTEMS,
                 null=True,


### PR DESCRIPTION
- Previously the partition table name length was defined to be a minimum of 2 characters.  But sometimes when the name is decoded from bytes to a logical character, the name of 2 characters length becomes one character long which causes the failure again.  To fix this, the partition table name minimum length will be 4 characters now.