### PR TITLE
Make `read`'s `ignore` argument easier to manipulate

### DIFF
--- a/nailgun/entity_mixins.py
+++ b/nailgun/entity_mixins.py
@@ -624,7 +624,7 @@ class EntityReadMixin(object):
         response.raise_for_status()
         return response.json()
 
-    def read(self, entity=None, attrs=None, ignore=()):
+    def read(self, entity=None, attrs=None, ignore=None):
         """Get information about the current entity.
 
         1. Create a new entity of type ``type(self)``.
@@ -660,7 +660,7 @@ class EntityReadMixin(object):
         :param attrs: A dict. Data used to populate the object's attributes.
             The response from
             :meth:`nailgun.entity_mixins.EntityReadMixin.read_json` by default.
-        :param ignore: A tuple of attributes which should not be read from the
+        :param ignore: A set of attributes which should not be read from the
             server. This is mainly useful for attributes like a password which
             are not returned.
         :return: An instance of type ``type(self)``.
@@ -671,6 +671,8 @@ class EntityReadMixin(object):
             entity = type(self)(self._server_config)
         if attrs is None:
             attrs = self.read_json()
+        if ignore is None:
+            ignore = set()
 
         for field_name, field in entity.get_fields().items():
             if field_name in ignore:


### PR DESCRIPTION
As per #134 discussion, together with @oshtaier made `read`'s `ignore` argument to be instance of set instead of tuple. Default value for `ignore` changed to `None`.
This will retain the two advantages:
- None is immutable
- Field should default to an empty iterable
And introduce a new one:
- Sets are much easier to manipulate, e.g. no need to use type castings to add/remove some elements

Closes #134

`[DO NOT MERGE]` prefix till i get test run results and validate everything's OK (~ 1 hour)