### PR TITLE
Tweak `make lint`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,11 @@ lint:
 	pylint --reports=n --disable=I --ignore-imports=y \
 		nailgun tests setup.py docs/conf.py
 	pylint --reports=n --disable=I --ignore-imports=y --disable=similarities \
-		docs/create_organization_nailgun.py docs/create_organization_plain.py \
-		docs/create_user_nailgun.py docs/create_user_plain.py
+		docs/create_organization_nailgun.py \
+		docs/create_organization_nailgun_v2.py \
+		docs/create_organization_plain.py \
+		docs/create_user_nailgun.py \
+		docs/create_user_plain.py
 
 test:
 	python $(TEST_OPTIONS)


### PR DESCRIPTION
Lint `docs/create_organization_nailgun_v2.py`. List each script one its own line
in the makefile, thus improving readability.