### PR TITLE
Only require unittest 2 for Python 3.3 and below

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 # For `make test`
 mock
-unittest2
+unittest2 ; python_version < '3.4'
 
 # For `make lint`
 flake8

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,10 +2,15 @@
 """Unit tests for :mod:`nailgun.client`."""
 from fauxfactory import gen_alpha
 from nailgun import client
-from unittest import TestCase
 import inspect
 import mock
 import requests
+
+from sys import version_info
+if version_info < (3, 4):
+    from unittest2 import TestCase  # pylint:disable=import-error
+else:
+    from unittest import TestCase
 
 
 class ContentTypeIsJsonTestCase(TestCase):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,6 @@
 from mock import call, mock_open, patch
 from nailgun.config import BaseServerConfig, ServerConfig
 from packaging.version import parse
-from unittest import TestCase
 import json
 
 from sys import version_info
@@ -13,6 +12,10 @@ if version_info.major == 2:
     import __builtin__ as builtins  # pylint:disable=import-error
 else:
     import builtins  # pylint:disable=import-error
+if version_info < (3, 4):
+    from unittest2 import TestCase  # pylint:disable=import-error
+else:
+    from unittest import TestCase
 
 
 FILE_PATH = '/tmp/bogus.json'

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -10,7 +10,6 @@ from nailgun.entity_mixins import (
     EntityUpdateMixin,
     NoSuchPathError,
 )
-from unittest2 import TestCase
 import mock
 
 from sys import version_info
@@ -18,6 +17,10 @@ if version_info.major == 2:
     from httplib import ACCEPTED, NO_CONTENT  # pylint:disable=import-error
 else:
     from http.client import ACCEPTED, NO_CONTENT  # pylint:disable=import-error
+if version_info < (3, 4):
+    from unittest2 import TestCase  # pylint:disable=import-error
+else:
+    from unittest import TestCase
 
 # pylint:disable=too-many-lines
 # The size of this file is a direct reflection of the size of module

--- a/tests/test_entity_fields.py
+++ b/tests/test_entity_fields.py
@@ -3,7 +3,6 @@
 from fauxfactory.constants import VALID_NETMASKS
 from nailgun import entity_fields
 from random import randint
-from unittest2 import TestCase
 import datetime
 import socket
 
@@ -12,10 +11,14 @@ if version_info.major == 2:
     from urlparse import urlparse  # pylint:disable=import-error
 else:
     from urllib.parse import urlparse  # pylint:disable=E0611,F0401
+if version_info < (3, 4):
+    from unittest2 import TestCase  # pylint:disable=import-error
+else:
+    from unittest import TestCase
 
 
-# It is OK that this class has no public methods. It just needs to exist for use
-# by other tests, not be independently useful.
+# It is OK that this class has no public methods. It just needs to exist for
+# use by other tests, not be independently useful.
 class TestClass(object):  # pylint:disable=too-few-public-methods
     """A class that is used when testing the OneTo{One,Many}Field classes."""
 
@@ -66,10 +69,7 @@ class GenValueTestCase(TestCase):
 
         """
         email = entity_fields.EmailField().gen_value()
-        if version_info.major == 2:
-            self.assertIsInstance(email, unicode)  # flake8:noqa pylint:disable=undefined-variable
-        else:
-            self.assertIsInstance(email, str)
+        self.assertIsInstance(email, type(u''))
         self.assertIn('@', email)
 
     def test_float_field(self):
@@ -146,10 +146,7 @@ class StringFieldTestCase(TestCase):
     def test_str_is_returned(self):
         """Ensure a unicode string at least 1 char long is returned."""
         string = entity_fields.StringField().gen_value()
-        if version_info.major == 2:
-            self.assertIsInstance(string, unicode)  # flake8:noqa pylint:disable=undefined-variable
-        else:
-            self.assertIsInstance(string, str)
+        self.assertIsInstance(string, type(u''))
         self.assertGreater(len(string), 0)
 
     def test_length_arg(self):

--- a/tests/test_entity_mixins.py
+++ b/tests/test_entity_mixins.py
@@ -12,7 +12,6 @@ from nailgun.entity_fields import (
     StringField,
 )
 from requests.exceptions import HTTPError
-from unittest2 import TestCase
 import mock
 
 from sys import version_info
@@ -20,6 +19,10 @@ if version_info.major == 2:
     import httplib as http_client  # pylint:disable=import-error
 else:
     import http.client as http_client  # pylint:disable=import-error
+if version_info < (3, 4):
+    from unittest2 import TestCase  # pylint:disable=import-error
+else:
+    from unittest import TestCase
 
 # pylint:disable=too-many-lines
 # The size of this module is a direct reflection of the size of module


### PR DESCRIPTION
Adjust the `requirements-dev.txt` file so that unittest2 is only installed if
Python 3.3 or below is being used. Adjust test modules to only import unittest2
if Python 3.3 or below is being used.

unittest2 is used on Python 3.3 and below so that the `subTest` context manager
can be used in unit tests. There is no need to use unittest2 on Python 3.4 and
above, as this feature has been added to the standard library.

Bonus: refactor out some unnecessary version-checking code.