### PR TITLE
Fixing 'payload' part for 17 methods from #41 list.

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -242,10 +242,10 @@ class ActivationKey(
             )
         return super(ActivationKey, self).path(which)
 
-    def add_subscriptions(self, params):
+    def add_subscriptions(self, payload):
         """Helper for adding subscriptions to activation key.
 
-        :param params: Parameters that are encoded to JSON and passed in
+        :param payload: Parameters that are encoded to JSON and passed in
             with the request. See the API documentation page for a list of
             parameters and their descriptions.
         :returns: The server's response, with all JSON decoded.
@@ -255,16 +255,17 @@ class ActivationKey(
         """
         response = client.put(
             self.path('add_subscriptions'),
-            params,
+            payload,
             **self._server_config.get_client_kwargs()
         )
         return _handle_response(response, self._server_config)
 
-    def content_override(self, content_label, value):
+    def content_override(self, payload):
         """Override the content of an activation key.
 
-        :param content_label: Label for the new content.
-        :param value: The new content for this activation key.
+        :param payload: Parameters that are encoded to JSON and passed in
+            with the request. See the API documentation page for a list of
+            parameters and their descriptions.
         :returns: The server's response, with all JSON decoded.
         :raises: ``requests.exceptions.HTTPError`` If the server responds with
             an HTTP 4XX or 5XX message.
@@ -272,10 +273,7 @@ class ActivationKey(
         """
         response = client.put(
             self.path('content_override'),
-            {'content_override': {
-                'content_label': content_label,
-                'value': value,
-            }},
+            {'content_override': payload},
             **self._server_config.get_client_kwargs()
         )
         return _handle_response(response, self._server_config)
@@ -793,45 +791,34 @@ class AbstractDockerContainer(
             id=self.create_json(create_missing)['id'],
         ).read()
 
-    def power(self, power_action):
+    def power(self, payload):
         """Run a power operation on a container.
 
-        :param power_action: One of 'start', 'stop' or 'status'.
+        :param payload: Parameters that are encoded to JSON and passed in
+            with the request. See the API documentation page for a list of
+            parameters and their descriptions.
         :returns: Information about the current state of the container.
 
         """
-        power_actions = ('start', 'stop', 'status')
-        if power_action not in power_actions:
-            raise ValueError('Received {0} but expected one of {1}'.format(
-                power_action, power_actions
-            ))
         response = client.put(
             self.path(which='power'),
-            {u'power_action': power_action},
+            payload,
             **self._server_config.get_client_kwargs()
         )
         return _handle_response(response, self._server_config)
 
-    def logs(self, stdout=None, stderr=None, tail=None):
+    def logs(self, payload=None):
         """Get logs from this container.
 
-        :param stdout: ???
-        :param stderr: ???
-        :param tail: How many lines should be tailed? Server does 100 by
-            default.
+        :param payload: Parameters that are encoded to JSON and passed in
+            with the request. See the API documentation page for a list of
+            parameters and their descriptions.
         :returns: The server's response, with all JSON decoded.
 
         """
-        data = {}
-        if stdout is not None:
-            data['stdout'] = stdout
-        if stderr is not None:
-            data['stderr'] = stderr
-        if tail is not None:
-            data['tail'] = tail
         response = client.get(
             self.path(which='logs'),
-            data=data,
+            data=payload if payload else {},
             **self._server_config.get_client_kwargs()
         )
         return _handle_response(response, self._server_config)
@@ -905,10 +892,12 @@ class ContentViewVersion(Entity, EntityReadMixin, EntityDeleteMixin):
             )
         return super(ContentViewVersion, self).path(which)
 
-    def promote(self, environment_id, synchronous=True):
+    def promote(self, payload, synchronous=True):
         """Helper for promoting an existing published content view.
 
-        :param environment_id: The environment Id to promote to.
+        :param payload: Parameters that are encoded to JSON and passed in
+            with the request. See the API documentation page for a list of
+            parameters and their descriptions.
         :param synchronous: What should happen if the server returns an HTTP
             202 (accepted) status code? Wait for the task to complete if
             ``True``. Immediately return a task ID otherwise.
@@ -919,7 +908,7 @@ class ContentViewVersion(Entity, EntityReadMixin, EntityDeleteMixin):
         """
         response = client.post(
             self.path('promote'),
-            {u'environment_id': environment_id},
+            payload,
             **self._server_config.get_client_kwargs()
         )
         return _handle_response(response, self._server_config, synchronous)
@@ -1198,7 +1187,7 @@ class ContentView(
             )
         return super(ContentView, self).path(which)
 
-    def publish(self, synchronous=True):
+    def publish(self, payload=None, synchronous=True):
         """Helper for publishing an existing content view.
 
         :param synchronous: What should happen if the server returns an HTTP
@@ -1209,23 +1198,28 @@ class ContentView(
             JSON response otherwise.
 
         """
+        if payload is None:
+            payload = {}
+        payload['id'] = self.id  # pylint:disable=no-member
         response = client.post(
             self.path('publish'),
-            {u'id': self.id},  # pylint:disable=no-member
+            payload,
             **self._server_config.get_client_kwargs()
         )
         return _handle_response(response, self._server_config, synchronous)
 
-    def set_repository_ids(self, repo_ids):
+    def set_repository_ids(self, payload):
         """Give this content view some repositories.
 
-        :param repo_ids: A list of repository IDs.
+        :param payload: Parameters that are encoded to JSON and passed in
+            with the request. See the API documentation page for a list of
+            parameters and their descriptions.
         :returns: The server's response, with all JSON decoded.
 
         """
         response = client.put(
             self.path(which='self'),
-            {u'repository_ids': repo_ids},
+            payload,
             **self._server_config.get_client_kwargs()
         )
         return _handle_response(response, self._server_config)
@@ -1242,31 +1236,35 @@ class ContentView(
         )
         return _handle_response(response, self._server_config)
 
-    def add_puppet_module(self, author, name):
+    def add_puppet_module(self, payload):
         """Add a puppet module to the content view.
 
-        :param author: The author of the puppet module.
-        :param name: The name of the puppet module.
+        :param payload: Parameters that are encoded to JSON and passed in
+            with the request. See the API documentation page for a list of
+            parameters and their descriptions.
         :returns: The server's response, with all JSON decoded.
 
         """
         response = client.post(
             self.path('content_view_puppet_modules'),
-            {u'author': author, u'name': name},
+            payload,
             **self._server_config.get_client_kwargs()
         )
         return _handle_response(response, self._server_config)
 
-    def copy(self, name):
+    def copy(self, payload):
         """Clone provided content view.
 
-        :param name: The name for new cloned content view.
+        :param payload: Parameters that are encoded to JSON and passed in
+            with the request. See the API documentation page for a list of
+            parameters and their descriptions.
         :returns: The server's response, with all JSON decoded.
 
         """
+        payload['id'] = self.id  # pylint:disable=no-member
         response = client.post(
             self.path('copy'),
-            {u'id': self.id, u'name': name},  # pylint:disable=no-member
+            payload,
             **self._server_config.get_client_kwargs()
         )
         return _handle_response(response, self._server_config)
@@ -2286,8 +2284,6 @@ class Organization(
             /organizations/<id>/subscriptions/refresh_manifest
         sync_plans
             /organizations/<id>/sync_plans
-        products
-            /organizations/<id>/products
         subscriptions
             /organizations/<id>/subscriptions
 
@@ -2295,7 +2291,6 @@ class Organization(
 
         """
         if which in (
-                'products',
                 'subscriptions/delete_manifest',
                 'subscriptions/refresh_manifest',
                 'subscriptions/upload',
@@ -2323,11 +2318,12 @@ class Organization(
         )
         return _handle_response(response, self._server_config)['results']
 
-    def upload_manifest(self, path, repository_url=None, synchronous=True):
+    def upload_manifest(self, payload, synchronous=True):
         """Helper method that uploads a subscription manifest file
 
-        :param path: Local path of the manifest file
-        :param repository_url: Optional repository URL
+        :param payload: Parameters that are encoded to JSON and passed in
+            with the request. See the API documentation page for a list of
+            parameters and their descriptions.
         :param synchronous: What should happen if the server returns an HTTP
             202 (accepted) status code? Wait for the task to complete if
             ``True``. Immediately return JSON response otherwise.
@@ -2342,13 +2338,11 @@ class Organization(
             completes with any result other than "success".
 
         """
-        data = None
-        if repository_url is not None:
-            data = {u'repository_url': repository_url}
+        path = payload.pop('content')
         with open(path, 'rb') as manifest:
             response = client.post(
                 self.path('subscriptions/upload'),
-                data,
+                payload,
                 files={'content': manifest},
                 **self._server_config.get_client_kwargs()
             )
@@ -2400,37 +2394,24 @@ class Organization(
         )
         return _handle_response(response, self._server_config, synchronous)
 
-    def sync_plan(self, name, interval):
+    def sync_plan(self, payload):
         """Helper for creating a sync_plan.
 
+        :param payload: Parameters that are encoded to JSON and passed in
+            with the request. See the API documentation page for a list of
+            parameters and their descriptions.
         :returns: The server's response, with all JSON decoded.
         :raises: ``requests.exceptions.HTTPError`` If the server responds with
             an HTTP 4XX or 5XX message.
 
         """
+        payload['sync_date'] = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
         response = client.post(
             self.path('sync_plans'),
-            {
-                u'interval': interval,
-                u'name': name,
-                u'sync_date': datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
-            },
+            payload,
             **self._server_config.get_client_kwargs()
         )
         return _handle_response(response, self._server_config)
-
-    def list_rhproducts(self, per_page=None):
-        """Lists all the RedHat Products after the importing of a manifest.
-
-        :param per_page: The no.of results to be shown per page.
-
-        """
-        response = client.get(
-            self.path('products'),
-            data={u'per_page': per_page},
-            **self._server_config.get_client_kwargs()
-        )
-        return _handle_response(response, self._server_config)['results']
 
     def create(self, create_missing=None):
         """Do extra work to fetch a complete set of attributes for this entity.

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -223,7 +223,6 @@ class PathTestCase(TestCase):
                 (entities.ContentView, 'copy'),
                 (entities.ContentView, 'publish'),
                 (entities.ContentViewVersion, 'promote'),
-                (entities.Organization, 'products'),
                 (entities.Organization, 'subscriptions'),
                 (entities.Organization, 'subscriptions/delete_manifest'),
                 (entities.Organization, 'subscriptions/refresh_manifest'),
@@ -1009,21 +1008,13 @@ class AbstractDockerContainerTestCase(TestCase):
             # `call_args` is a two-tuple of (positional, keyword) args.
             self.assertEqual(
                 client_put.call_args[0][1],
-                {'power_action': power_action},
+                power_action,
             )
-
-    def test_power_error(self):
-        """Call :meth:`nailgun.entities.AbstractDockerContainer.power`.
-
-        Pass an inappropriate argument and assert ``ValueError`` is raised.
-
-        """
-        with self.assertRaises(ValueError):
-            self.abstract_dc.power('foo')
 
     def test_logs(self):
         """Call :meth:`nailgun.entities.AbstractDockerContainer.logs`."""
-        for kwargs in (
+        for payload in (
+                None,
                 {},
                 {'stdout': gen_integer()},
                 {'stderr': gen_integer()},
@@ -1040,13 +1031,16 @@ class AbstractDockerContainerTestCase(TestCase):
                     '_handle_response',
                     return_value=gen_integer(),  # not realistic
                 ) as handler:
-                    response = self.abstract_dc.logs(**kwargs)
+                    response = self.abstract_dc.logs(payload)
             self.assertEqual(client_get.call_count, 1)
             self.assertEqual(handler.call_count, 1)
             self.assertEqual(handler.return_value, response)
 
             # `call_args` is a two-tuple of (positional, keyword) args.
-            self.assertEqual(client_get.call_args[1]['data'], kwargs)
+            self.assertEqual(
+                client_get.call_args[1]['data'],
+                payload if payload else {},
+            )
 
 
 class ActivationKeyTestCase(TestCase):
@@ -1086,10 +1080,10 @@ class ActivationKeyTestCase(TestCase):
             ) as handler:
                 content_label = gen_integer()
                 value = gen_integer()
-                response = self.activation_key.content_override(
-                    content_label=content_label,
-                    value=value,
-                )
+                response = self.activation_key.content_override({
+                    'content_label': content_label,
+                    'value': value,
+                })
         self.assertEqual(client_put.call_count, 1)
         self.assertEqual(handler.call_count, 1)
         self.assertEqual(handler.return_value, response)
@@ -1099,6 +1093,90 @@ class ActivationKeyTestCase(TestCase):
         self.assertEqual(
             client_put.call_args[0][1]['content_override'],
             {'content_label': content_label, 'value': value},
+        )
+
+
+class ContentViewVersion(TestCase):
+    """Tests for :class:`nailgun.entities.ContentViewVersion`."""
+
+    def setUp(self):
+        """Set ``self.cvv``."""
+        self.cvv = entities.ContentViewVersion(
+            config.ServerConfig('http://example.com'),
+            id=gen_integer(min_value=1),
+        )
+
+    def test_promote(self):
+        """Call :meth:`nailgun.entities.ContentViewVersion.promote`."""
+        with mock.patch.object(client, 'post') as client_post:
+            with mock.patch.object(
+                entities,
+                '_handle_response',
+                return_value=gen_integer(),  # not realistic
+            ) as handler:
+                response = self.cvv.promote({1: 2})
+        self.assertEqual(client_post.call_count, 1)
+        self.assertEqual(handler.call_count, 1)
+        self.assertEqual(handler.return_value, response)
+
+        # This was just executed: client_post(path='…', data={…}, …)
+        # `call_args` is a two-tuple of (positional, keyword) args.
+        self.assertEqual(client_post.call_args[0][1], {1: 2})
+
+
+class ContentView(TestCase):
+    """Tests for :class:`nailgun.entities.ContentView`."""
+
+    def setUp(self):
+        """Set ``self.content_view``."""
+        self.content_view = entities.ContentView(
+            config.ServerConfig('http://example.com'),
+            id=gen_integer(min_value=1),
+        )
+
+    def test_publish(self):
+        """Call :meth:`nailgun.entities.ContentView.publish`."""
+        for payload in (
+                None,
+                {},
+                {1: 2},
+        ):
+            with mock.patch.object(client, 'post') as client_post:
+                with mock.patch.object(
+                    entities,
+                    '_handle_response',
+                    return_value=gen_integer(),  # not realistic
+                ) as handler:
+                    response = self.content_view.publish(payload)
+            self.assertEqual(client_post.call_count, 1)
+            self.assertEqual(handler.call_count, 1)
+            self.assertEqual(handler.return_value, response)
+
+        # This was just executed: client_post(path='…', data={…}, …)
+        # `call_args` is a two-tuple of (positional, keyword) args.
+        self.assertEqual(
+            client_post.call_args[0][1],
+            {1: 2, 'id': self.content_view.id}  # pylint:disable=no-member
+        )
+
+    def test_copy(self):
+        """Call :meth:`nailgun.entities.ContentView.copy`."""
+        with mock.patch.object(client, 'post') as client_post:
+            with mock.patch.object(
+                entities,
+                '_handle_response',
+                return_value=gen_integer(),  # not realistic
+            ) as handler:
+                response = self.content_view.copy({1: 2})
+        self.assertEqual(client_post.call_count, 1)
+        self.assertEqual(handler.call_count, 1)
+        self.assertEqual(handler.return_value, response)
+
+        # This was just executed: client_post(path='…', data={…}, …)
+        # `call_args` is a two-tuple of (positional, keyword) args.
+        self.assertEqual(
+            client_post.call_args[0][1],
+            {1: 2, 'id': self.content_view.id}  # pylint:disable=no-member
         )
 
 
@@ -1198,7 +1276,10 @@ class OrganizationTestCase(TestCase):
             ) as handler:
                 name = gen_integer()
                 interval = gen_integer()
-                response = self.org.sync_plan(name=name, interval=interval)
+                response = self.org.sync_plan({
+                    'name': name,
+                    'interval': interval,
+                })
         self.assertEqual(client_post.call_count, 1)
         self.assertEqual(handler.call_count, 1)
         self.assertEqual(handler.return_value, response)
@@ -1213,19 +1294,6 @@ class OrganizationTestCase(TestCase):
         self.assertEqual(data['interval'], interval)
         self.assertEqual(data['name'], name)
         self.assertIsInstance('sync_date', type(''))
-
-    def test_list_rhproducts(self):
-        """Call :meth:`nailgun.entities.Organization.list_rhproducts`."""
-        with mock.patch.object(client, 'get') as client_get:
-            with mock.patch.object(
-                entities,
-                '_handle_response',
-                return_value={'results': gen_integer()},  # not realistic
-            ) as handler:
-                response = self.org.list_rhproducts()
-        self.assertEqual(client_get.call_count, 1)
-        self.assertEqual(handler.call_count, 1)
-        self.assertEqual(handler.return_value['results'], response)
 
 
 class ProductTestCase(TestCase):


### PR DESCRIPTION
Robottelo part will be provided in separate PRs

Progress:

| Method    | Fix payload   | Fix path      | Transform to search |
| --------- | ------------- | ------------- | ------------------- |
| ActivationKey.add_subscriptions  | Done  | Not needed  | Not needed        |
| ActivationKey.content_override  | Done  | Not needed  | Not needed        |
| AbstractDockerContainer.power  | Done  | Already using best one  | Not needed        |
| AbstractDockerContainer.logs  | Done  | Already using best one  | Not needed        |
| ContentViewVersion.promote  | Done  | Not needed  | Not needed        |
| ContentView.publish  | Done  | Not needed  | Not needed        |
| ContentView.set_repository_ids  | Done  | Seems good enough  | Not needed        |
| ContentView.available_puppet_modules  | Not needed  | Not needed  | Not needed        |
| ContentView.add_puppet_module  | Done  | Doesn't make sense to create module like 'Content view puppet modules' as it will make path even worse  | Not needed        |
| ContentView.copy  | Done  | Not needed  | Not needed        |
| ForemanTask.poll  | Seems as internal method that shouldn't be changed  | Doesn't have  | Not needed        |
| Organization.subscriptions  | Not needed  | **Required**, but we don't have proper API paths for all subscription methods  | Doesn't seem as redundant method        |
| Organization.upload_manifest  | Done  | **Required**, but we don't have proper API paths for all subscription methods  | Not needed        |
| Organization.delete_manifest  | Not needed  | **Required**, but we don't have proper API paths for all subscription methods  | Not needed        |
| Organization.refresh_manifest  | Not needed  | **Required**, but we don't have proper API paths for all subscription methods  | Not needed        |
| Organization.sync_plan  | Done  | **Required**, but we don't have proper API paths for all subscription methods  | Not needed        |
| Organization.list_rhproducts  | Should be removed entirely  | Should be removed entirely  | Done        |