### PR TITLE
Review entity methods, part 2

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2579,20 +2579,13 @@ class Product(
 
         The format of the returned path depends on the value of ``which``:
 
-        repository_sets
-            /products/<product_id>/repository_sets
-        repository_sets/<id>/enable
-            /products/<product_id>/repository_sets/<id>/enable
-        repository_sets/<id>/disable
-            /products/<product_id>/repository_sets/<id>/disable
         sync
             /products/<product_id>/sync
 
         ``super`` is called otherwise.
 
         """
-        if which is not None and (
-                which.startswith('repository_sets') or which == 'sync'):
+        if which == 'sync':
             return '{0}/{1}'.format(
                 super(Product, self).path(which='self'),
                 which,
@@ -2613,131 +2606,6 @@ class Product(
             org = _get_org(self._server_config, attrs['organization']['label'])
             attrs['organization'] = org.get_values()
         return super(Product, self).read(entity, attrs, ignore)
-
-    def list_repositorysets(self, per_page=None):
-        """Lists all the RepositorySets in a Product.
-
-        :param per_page: The no.of results to be shown per page.
-
-        """
-        response = client.get(
-            self.path('repository_sets'),
-            data={u'per_page': per_page},
-            **self._server_config.get_client_kwargs()
-        )
-        response.raise_for_status()
-        return response.json()['results']
-
-    def fetch_rhproduct_id(self, name, org_id):
-        """Fetches the RedHat Product Id for a given Product name.
-
-        To be used for the Products created when manifest is imported.
-        RedHat Product Id could vary depending upon other custom products.
-        So, we use the product name to fetch the RedHat Product Id.
-
-        :param org_id: The Organization Id.
-        :param name: The RedHat product's name who's ID is to be fetched.
-        :returns: The RedHat Product Id is returned.
-
-        """
-        response = client.get(
-            self.path(which='base'),
-            data={u'organization_id': org_id, u'name': name},
-            **self._server_config.get_client_kwargs()
-        )
-        response.raise_for_status()
-        results = response.json()['results']
-        if len(results) != 1:
-            raise APIResponseError(
-                "The length of the results is:", len(results))
-        return results[0]['id']
-
-    def fetch_reposet_id(self, name):
-        """Fetches the RepositorySet Id for a given name.
-
-        RedHat Products do not directly contain Repositories.
-        Product first contains many RepositorySets and each
-        RepositorySet contains many Repositories.
-        RepositorySet Id could vary. So, we use the reposet name
-        to fetch the RepositorySet Id.
-
-        :param name: The RepositorySet's name.
-        :returns: The RepositorySet's Id is returned.
-
-        """
-        response = client.get(
-            self.path('repository_sets'),
-            data={u'name': name},
-            **self._server_config.get_client_kwargs()
-        )
-        response.raise_for_status()
-        results = response.json()['results']
-        if len(results) != 1:
-            raise APIResponseError(
-                "The length of the results is:", len(results))
-        return results[0]['id']
-
-    def enable_rhrepo(self, base_arch,
-                      release_ver, reposet_id, synchronous=True):
-        """Enables the RedHat Repository
-
-        RedHat Repos needs to be enabled first, so that we can sync it.
-
-        :param reposet_id: The RepositorySet Id.
-        :param base_arch: The architecture type of the repo to enable.
-        :param release_ver: The release version type of the repo to enable.
-        :param synchronous: What should happen if the server returns an HTTP
-            202 (accepted) status code? Wait for the task to complete if
-            ``True``. Immediately return JSON response otherwise.
-        :returns: Returns information of the async task if an HTTP
-            202 response was received and synchronus set to ``True``.
-            Return JSON response otherwise.
-
-        """
-        response = client.put(
-            self.path('repository_sets/{0}/enable'.format(reposet_id)),
-            {u'basearch': base_arch, u'releasever': release_ver},
-            **self._server_config.get_client_kwargs()
-        )
-        return _handle_response(response, self._server_config, synchronous)
-
-    def disable_rhrepo(self, base_arch,
-                       release_ver, reposet_id, synchronous=True):
-        """Disables the RedHat Repository
-
-        :param reposet_id: The RepositorySet Id.
-        :param base_arch: The architecture type of the repo to disable.
-        :param release_ver: The release version type of the repo to disable.
-        :param synchronous: What should happen if the server returns an HTTP
-            202 (accepted) status code? Wait for the task to complete if
-            ``True``. Immediately return JSON response otherwise.
-        :returns: Returns information of the async task if an HTTP
-            202 response was received and synchronus set to ``True``.
-            Return JSON response otherwise.
-
-        """
-        response = client.put(
-            self.path('repository_sets/{0}/disable'.format(reposet_id)),
-            {u'basearch': base_arch, u'releasever': release_ver},
-            **self._server_config.get_client_kwargs()
-        )
-        return _handle_response(response, self._server_config, synchronous)
-
-    def repository_sets_available_repositories(self, reposet_id):  # noqa pylint:disable=C0103
-        """Lists available repositories for the repository set
-
-        :param reposet_id: The RepositorySet Id.
-        :returns: Returns list of available repositories for the repository set
-
-        """
-        response = client.get(
-            self.path(
-                'repository_sets/{0}/available_repositories'
-                .format(reposet_id)
-            ),
-            **self._server_config.get_client_kwargs()
-        )
-        return _handle_response(response, self._server_config)['results']
 
     def sync(self):
         """Synchronize :class:`repositories <Repository>` in this product."""
@@ -2868,6 +2736,7 @@ class Repository(
         EntityCreateMixin,
         EntityDeleteMixin,
         EntityReadMixin,
+        EntitySearchMixin,
         EntityUpdateMixin):
     """A representation of a Repository entity."""
 
@@ -2957,42 +2826,12 @@ class Repository(
         )
         return _handle_response(response, self._server_config, synchronous)
 
-    def fetch_repoid(self, org_id, name):
-        """Fetch the repository Id.
-
-        This is required for RedHat Repositories, as products, reposets
-        and repositories get automatically populated upon the manifest import.
-
-        :param org_id: The org Id for which repository listing is required.
-        :param name: The repository name who's ID has to be searched.
-        :return: Returns the repository ID.
-        :raises: ``APIResponseError`` If the API does not return any results.
-
-        """
-        for _ in range(5):
-            response = client.get(
-                self.path(which=None),
-                data={u'organization_id': org_id, u'name': name},
-                **self._server_config.get_client_kwargs()
-            )
-            response.raise_for_status()
-            results = response.json()['results']
-            if len(results) == 0:
-                sleep(5)
-            else:
-                break
-        if len(results) != 1:
-            raise APIResponseError(
-                'Found {0} repositories named {1} in organization {2}: {3} '
-                .format(len(results), name, org_id, results)
-            )
-        return results[0]['id']
-
-    def upload_content(self, handle):
+    def upload_content(self, payload):
         """Upload a file to the current repository.
 
-        :param handle: A file object, such as the one returned by
-            ``open('path', 'rb')``.
+        :param payload: Parameters that are encoded to JSON and passed in
+            with the request. See the API documentation page for a list of
+            parameters and their descriptions.
         :returns: The JSON-decoded response.
         :raises nailgun.entities.APIResponseError: If the response has a status
             other than "success".
@@ -3000,17 +2839,179 @@ class Repository(
         """
         response = client.post(
             self.path('upload_content'),
-            files={'content': handle},
+            files=payload,
             **self._server_config.get_client_kwargs()
         )
-        response.raise_for_status()
-        response_json = response.json()
+        response_json = _handle_response(response, self._server_config)
         if response_json['status'] != 'success':
             raise APIResponseError(
+                # pylint:disable=E1101
                 'Received error when uploading file {0} to repository {1}: {2}'
-                .format(handle, self.id, response_json)  # pylint:disable=E1101
+                .format(payload, self.id, response_json)
             )
         return response_json
+
+
+class RepositorySet(
+        Entity,
+        EntityReadMixin,
+        EntitySearchMixin):
+    """ A representation of a Repository Set entity"""
+    def __init__(self, server_config=None, **kwargs):
+        _check_for_value('product', kwargs)
+        self._fields = {
+            'contentUrl': entity_fields.URLField(required=True),
+            'gpgUrl': entity_fields.URLField(required=True),
+            'label': entity_fields.StringField(required=True),
+            'name': entity_fields.StringField(required=True),
+            'product': entity_fields.OneToOneField(Product, required=True),
+            'repositories': entity_fields.OneToManyField(Repository),
+            'type': entity_fields.StringField(
+                choices=('kickstart', 'yum', 'file'),
+                default='yum',
+                required=True,
+            ),
+            'vendor': entity_fields.StringField(required=True),
+        }
+        super(RepositorySet, self).__init__(server_config, **kwargs)
+        self._meta = {
+            # pylint:disable=no-member
+            'api_path': '{0}/repository_sets'.format(self.product.path()),
+        }
+
+    def available_repositories(self):
+        """Lists available repositories for the repository set
+
+        :returns: Returns list of available repositories for the repository set
+
+        """
+        response = client.get(
+            self.path('available_repositories'),
+            **self._server_config.get_client_kwargs()
+        )
+        return _handle_response(response, self._server_config)['results']
+
+    def enable(self, payload, synchronous=True):
+        """Enables the RedHat Repository
+
+        RedHat Repos needs to be enabled first, so that we can sync it.
+
+        :param payload: Parameters that are encoded to JSON and passed in
+            with the request. See the API documentation page for a list of
+            parameters and their descriptions.
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return JSON response otherwise.
+        :returns: Returns information of the async task if an HTTP
+            202 response was received and synchronus set to ``True``.
+            Return JSON response otherwise.
+
+        """
+        response = client.put(
+            self.path('enable'),
+            payload,
+            **self._server_config.get_client_kwargs()
+        )
+        return _handle_response(response, self._server_config, synchronous)
+
+    def disable(self, payload, synchronous=True):
+        """Disables the RedHat Repository
+
+        :param payload: Parameters that are encoded to JSON and passed in
+            with the request. See the API documentation page for a list of
+            parameters and their descriptions.
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return JSON response otherwise.
+        :returns: Returns information of the async task if an HTTP
+            202 response was received and synchronus set to ``True``.
+            Return JSON response otherwise.
+
+        """
+        response = client.put(
+            self.path('disable'),
+            payload,
+            **self._server_config.get_client_kwargs()
+        )
+        return _handle_response(response, self._server_config, synchronous)
+
+    def list_all(self, per_page=None):
+        """Lists all the RepositorySets in a Product.
+
+        :param per_page: The no.of results to be shown per page.
+
+        """
+        response = client.get(
+            self.path('base'),
+            data={u'per_page': per_page},
+            **self._server_config.get_client_kwargs()
+        )
+        return _handle_response(response, self._server_config)['results']
+
+    def path(self, which=None):
+        """Extend ``nailgun.entity_mixins.Entity.path``.
+
+        The format of the returned path depends on the value of ``which``:
+
+        available_repositories
+            /products/<product_id>/repository_sets/<id>/available_repositories
+        enable
+            /products/<product_id>/repository_sets/<id>/enable
+        disable
+            /products/<product_id>/repository_sets/<id>/disable
+
+        ``super`` is called otherwise.
+
+        """
+        if which in (
+                'available_repositories',
+                'enable',
+                'disable',
+        ):
+            return '{0}/{1}'.format(
+                super(RepositorySet, self).path(which='self'),
+                which
+            )
+        return super(RepositorySet, self).path(which)
+
+    def read(self, entity=None, attrs=None, ignore=None):
+        """Provide a default value for ``entity``.
+
+        By default, ``nailgun.entity_mixins.EntityReadMixin.read`` provides a
+        default value for ``entity`` like so::
+
+            entity = type(self)()
+
+        However, :class:`RepositorySet` requires that a ``product`` be
+        provided, so this technique will not work. Do this instead::
+
+            entity = type(self)(product=self.product.id)
+
+        """
+        # read() should not change the state of the object it's called on, but
+        # super() alters the attributes of any entity passed in. Creating a new
+        # object and passing it to super() lets this one avoid changing state.
+        if entity is None:
+            entity = type(self)(
+                self._server_config,
+                product=self.product,  # pylint:disable=no-member
+            )
+        if ignore is None:
+            ignore = set()
+        ignore.add('product')
+        return super(RepositorySet, self).read(entity, attrs, ignore)
+
+    def search_normalize(self, results):
+        """Provide a value for `product` field.
+
+        Method ``search`` will create entities from search results. Search
+        results do not contain `product` field, which is required for
+        ``RepositorySet`` entity initialization.
+
+        """
+        for result in results:
+            result['product_id'] = self.product.id  # pylint:disable=no-member
+        return super(RepositorySet, self).search_normalize(results)
 
 
 class RHCIDeployment(
@@ -3089,11 +3090,11 @@ class RHCIDeployment(
             )
         return super(RHCIDeployment, self).path(which)
 
-    def add_hypervisors(self, hypervisor_ids):
+    def add_hypervisors(self, payload):
         """Helper for creating an RHCI deployment.
 
-        :param hypervisor_ids: A list of RHEV hypervisor ids to be added to the
-            deployment.
+        :param payload: Parameters that are encoded to JSON and passed in
+            with the request.
         :returns: The server's response, with all JSON decoded.
         :raises: ``requests.exceptions.HTTPError`` If the server responds with
             an HTTP 4XX or 5XX message.
@@ -3101,15 +3102,15 @@ class RHCIDeployment(
         """
         response = client.put(
             self.path(),
-            {'discovered_host_ids': hypervisor_ids},
+            payload,
             **self._server_config.get_client_kwargs()
         )
         return _handle_response(response, self._server_config)
 
-    def deploy(self, params):
+    def deploy(self, payload):
         """Kickoff the RHCI deployment.
 
-        :param params: Parameters that are encoded to JSON and passed in
+        :param payload: Parameters that are encoded to JSON and passed in
             with the request. See the API documentation page for a list of
             parameters and their descriptions.
         :returns: The server's response, with all JSON decoded.
@@ -3119,7 +3120,7 @@ class RHCIDeployment(
         """
         response = client.put(
             self.path('deploy'),
-            params,
+            payload,
             **self._server_config.get_client_kwargs()
         )
         return _handle_response(response, self._server_config)
@@ -3420,14 +3421,16 @@ class SyncPlan(
             )
         return super(SyncPlan, self).path(which)
 
-    def add_products(self, product_ids, synchronous=True):
+    def add_products(self, payload, synchronous=True):
         """Add products to this sync plan.
 
         .. NOTE:: The ``synchronous`` argument has no effect in certain
             versions of Satellite. See `Bugzilla #1199150
             <https://bugzilla.redhat.com/show_bug.cgi?id=1199150>`_.
 
-        :param product_ids: A list of product IDs to add to this sync plan.
+        :param payload: Parameters that are encoded to JSON and passed in
+            with the request. See the API documentation page for a list of
+            parameters and their descriptions.
         :param synchronous: What should happen if the server returns an HTTP
             202 (accepted) status code? Wait for the task to complete if
             ``True``. Immediately return the server's reponse otherwise.
@@ -3436,19 +3439,21 @@ class SyncPlan(
         """
         response = client.put(
             self.path('add_products'),
-            {'product_ids': product_ids},
+            payload,
             **self._server_config.get_client_kwargs()
         )
         return _handle_response(response, self._server_config, synchronous)
 
-    def remove_products(self, product_ids, synchronous=True):
+    def remove_products(self, payload, synchronous=True):
         """Remove products from this sync plan.
 
         .. NOTE:: The ``synchronous`` argument has no effect in certain
             versions of Satellite. See `Bugzilla #1199150
             <https://bugzilla.redhat.com/show_bug.cgi?id=1199150>`_.
 
-        :param product_ids: A list of product IDs to remove from this syn plan.
+        :param payload: Parameters that are encoded to JSON and passed in
+            with the request. See the API documentation page for a list of
+            parameters and their descriptions.
         :param synchronous: What should happen if the server returns an HTTP
             202 (accepted) status code? Wait for the task to complete if
             ``True``. Immediately return the server's reponse otherwise.
@@ -3457,7 +3462,7 @@ class SyncPlan(
         """
         response = client.put(
             self.path('remove_products'),
-            {'product_ids': product_ids},
+            payload,
             **self._server_config.get_client_kwargs()
         )
         return _handle_response(response, self._server_config, synchronous)

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -153,6 +153,7 @@ class InitTestCase(TestCase):
             (entities.ContentViewFilterRule, {'content_view_filter': 1}),
             (entities.ContentViewPuppetModule, {'content_view': 1}),
             (entities.OperatingSystemParameter, {'operatingsystem': 1}),
+            (entities.RepositorySet, {'product': 1}),
             (entities.SyncPlan, {'organization': 1}),
         ])
         for entity, params in entities_:
@@ -170,6 +171,7 @@ class InitTestCase(TestCase):
                 entities.ContentViewFilterRule,
                 entities.ContentViewPuppetModule,
                 entities.OperatingSystemParameter,
+                entities.RepositorySet,
                 entities.SyncPlan,
         ):
             with self.subTest():
@@ -229,11 +231,6 @@ class PathTestCase(TestCase):
                 (entities.Organization, 'subscriptions/refresh_manifest'),
                 (entities.Organization, 'subscriptions/upload'),
                 (entities.Organization, 'sync_plans'),
-                (entities.Product, 'repository_sets'),
-                (entities.Product, 'repository_sets/2396/disable'),
-                (entities.Product, 'repository_sets/2396/enable'),
-                (entities.Product,
-                 'repository_sets/2396/available_repositories'),
                 (entities.Product, 'sync'),
                 (entities.Repository, 'sync'),
                 (entities.Repository, 'upload_content'),
@@ -306,15 +303,44 @@ class PathTestCase(TestCase):
         ):
             self.assertIn('/foreman_tasks/api/tasks/bulk_search', path)
 
+    def test_repository_set(self):
+        """Test :meth:`nailgun.entities.RepositorySet.path`.
+
+        Assert that the following return appropriate paths:
+
+        * ``RepositorySet(id=…).path()``
+        * ``RepositorySet(id=…).path('available_repositories')``
+        * ``RepositorySet(id=…).path('disable')``
+        * ``RepositorySet(id=…).path('enable')``
+
+        """
+        self.assertIn(
+            'products/1/repository_sets/2',
+            entities.RepositorySet(self.cfg, id=2, product=1).path()
+        )
+        for which in ('available_repositories', 'disable', 'enable'):
+            path = entities.RepositorySet(
+                self.cfg,
+                id=2,
+                product=1,
+            ).path(which)
+            self.assertIn('products/1/repository_sets/2/' + which, path)
+            self.assertRegex(path, '{}$'.format(which))
+
     def test_sync_plan(self):
         """Test :meth:`nailgun.entities.SyncPlan.path`.
 
         Assert that the following return appropriate paths:
 
+        * ``SyncPlan(id=…).path()``
         * ``SyncPlan(id=…).path('add_products')``
         * ``SyncPlan(id=…).path('remove_products')``
 
         """
+        self.assertIn(
+            'organizations/1/sync_plans/2',
+            entities.SyncPlan(self.cfg, id=2, organization=1).path()
+        )
         for which in ('add_products', 'remove_products'):
             path = entities.SyncPlan(
                 self.cfg,
@@ -694,6 +720,7 @@ class ReadTestCase(TestCase):
                 ),
                 entities.ContentViewPuppetModule(self.cfg, content_view=2),
                 entities.OperatingSystemParameter(self.cfg, operatingsystem=2),
+                entities.RepositorySet(self.cfg, product=2),
                 entities.SyncPlan(self.cfg, organization=2),
         ):
             # We mock read_json() because it may be called by read().
@@ -1238,26 +1265,6 @@ class ProductTestCase(TestCase):
             id=gen_integer(min_value=1),
         )
 
-    # pylint:disable=C0103
-    def test_repository_sets_available_repositories(self):
-        """Call
-        :meth:`nailgun.entities.Product.repository_sets_available_repositories`
-
-        """
-        with mock.patch.object(client, 'get') as client_get:
-            with mock.patch.object(
-                entities,
-                '_handle_response',
-                return_value={'results': gen_integer()},  # not realistic
-            ) as handler:
-                reposet_id = gen_integer(min_value=1)
-                response = self.product.repository_sets_available_repositories(
-                    reposet_id=reposet_id,
-                )
-        self.assertEqual(client_get.call_count, 1)
-        self.assertEqual(handler.call_count, 1)
-        self.assertEqual(handler.return_value['results'], response)
-
     def test_sync(self):
         """Call :meth:`nailgun.entities.Product.sync`."""
         with mock.patch.object(client, 'post') as client_post:
@@ -1269,6 +1276,134 @@ class ProductTestCase(TestCase):
                 self.product.sync()
         self.assertEqual(client_post.call_count, 1)
         self.assertEqual(handler.call_count, 1)
+
+
+class RepositoryTestCase(TestCase):
+    """Tests for :class:`nailgun.entities.Repository`."""
+
+    def setUp(self):
+        """Set ``self.repo``."""
+        self.repo = entities.Repository(
+            config.ServerConfig('http://example.com'),
+            id=gen_integer(min_value=1),
+        )
+
+    def test_sync(self):
+        """Call :meth:`nailgun.entities.Repository.sync`."""
+        with mock.patch.object(client, 'post') as client_post:
+            with mock.patch.object(
+                entities,
+                '_handle_response',
+                return_value={'results': gen_integer()},  # not realistic
+            ) as handler:
+                self.repo.sync()
+        self.assertEqual(client_post.call_count, 1)
+        self.assertEqual(handler.call_count, 1)
+
+    def test_upload_content(self):
+        """Call :meth:`nailgun.entities.Repository.upload_content`."""
+        with mock.patch.object(client, 'post') as client_post:
+            with mock.patch.object(
+                entities,
+                '_handle_response',
+                return_value={'status': 'success'},
+            ) as handler:
+                self.repo.upload_content({1: 2})
+        self.assertEqual(client_post.call_count, 1)
+        self.assertEqual(handler.call_count, 1)
+
+    def test_upload_content_error(self):
+        """Trigger an :class:`nailgun.entities.APIResponseError`."""
+        with mock.patch.object(client, 'post') as client_post:
+            with mock.patch.object(
+                entities,
+                '_handle_response',
+                return_value={'status': 'failure'},
+            ) as handler:
+                with self.assertRaises(entities.APIResponseError):
+                    self.repo.upload_content({1: 2})
+        self.assertEqual(client_post.call_count, 1)
+        self.assertEqual(handler.call_count, 1)
+
+
+class RepositorySetTestCase(TestCase):
+    """Tests for :class:`nailgun.entities.RepositorySet`."""
+
+    def setUp(self):
+        """Set ``self.product``."""
+        self.product = entities.Product(
+            config.ServerConfig('http://example.com'),
+            id=gen_integer(min_value=1),
+        )
+        self.reposet = entities.RepositorySet(
+            config.ServerConfig('http://example.com'),
+            id=gen_integer(min_value=1),
+            product=self.product,
+        )
+
+    def test_available_repositories(self):
+        """Call
+        :meth:`nailgun.entities.RepositorySet.available_repositories`
+
+        """
+        with mock.patch.object(client, 'get') as client_get:
+            with mock.patch.object(
+                entities,
+                '_handle_response',
+                return_value={'results': gen_integer()},  # not realistic
+            ) as handler:
+                response = self.reposet.available_repositories()
+        self.assertEqual(client_get.call_count, 1)
+        self.assertEqual(handler.call_count, 1)
+        self.assertEqual(handler.return_value['results'], response)
+
+    def test_enable(self):
+        """Call :meth:`nailgun.entities.RepositorySet.enable`"""
+        with mock.patch.object(client, 'put') as client_put:
+            with mock.patch.object(
+                entities,
+                '_handle_response',
+                return_value={'results': gen_integer()},  # not realistic
+            ) as handler:
+                response = self.reposet.enable({1: 2})
+        self.assertEqual(client_put.call_count, 1)
+        self.assertEqual(handler.call_count, 1)
+        self.assertEqual(handler.return_value, response)
+
+    def test_disable(self):
+        """Call :meth:`nailgun.entities.RepositorySet.disable`"""
+        with mock.patch.object(client, 'put') as client_put:
+            with mock.patch.object(
+                entities,
+                '_handle_response',
+                return_value={'results': gen_integer()},  # not realistic
+            ) as handler:
+                response = self.reposet.disable({1: 2})
+        self.assertEqual(client_put.call_count, 1)
+        self.assertEqual(handler.call_count, 1)
+        self.assertEqual(handler.return_value, response)
+
+    def test_list_all(self):
+        """Call :meth:`nailgun.entities.RepositorySet.list_all`"""
+        with mock.patch.object(client, 'get') as client_get:
+            with mock.patch.object(
+                entities,
+                '_handle_response',
+                return_value={'results': gen_integer()},  # not realistic
+            ) as handler:
+                response = self.reposet.list_all()
+        self.assertEqual(client_get.call_count, 1)
+        self.assertEqual(handler.call_count, 1)
+        self.assertEqual(handler.return_value['results'], response)
+
+    def test_search_normalize(self):
+        """Call :meth:`nailgun.entities.RepositorySet.search_normalize`"""
+        with mock.patch.object(EntitySearchMixin, 'search_normalize') as s_n:
+            self.reposet.search_normalize([{}, {}])
+        self.assertEqual(s_n.call_count, 1)
+        for result in s_n.call_args[0][0]:
+            # pylint:disable=no-member
+            self.assertEqual(result['product_id'], self.product.id)
 
 
 class RHCIDeploymentTestCase(TestCase):
@@ -1290,7 +1425,9 @@ class RHCIDeploymentTestCase(TestCase):
                 return_value={'results': gen_integer()},  # not realistic
             ) as handler:
                 hypervisor_ids = [gen_integer(), gen_integer(), gen_integer()]
-                response = self.rhci_deployment.add_hypervisors(hypervisor_ids)
+                response = self.rhci_deployment.add_hypervisors({
+                    'discovered_host_ids': hypervisor_ids,
+                })
         self.assertEqual(client_put.call_count, 1)
         self.assertEqual(handler.call_count, 1)
         self.assertEqual(handler.return_value, response)
@@ -1309,14 +1446,76 @@ class RHCIDeploymentTestCase(TestCase):
                 '_handle_response',
                 return_value={'results': gen_integer()},  # not realistic
             ) as handler:
-                params = {'foo': gen_integer()}
-                response = self.rhci_deployment.deploy(params)
+                payload = {'foo': gen_integer()}
+                response = self.rhci_deployment.deploy(payload)
         self.assertEqual(client_put.call_count, 1)
         self.assertEqual(handler.call_count, 1)
         self.assertEqual(handler.return_value, response)
 
         # `call_args` is a two-tuple of (positional, keyword) args.
-        self.assertEqual(client_put.call_args[0][1], params)
+        self.assertEqual(client_put.call_args[0][1], payload)
+
+
+class SmartProxyTestCase(TestCase):
+    """Tests for :class:`nailgun.entities.SmartProxy`."""
+
+    def setUp(self):
+        """Set ``self.proxy``."""
+        self.proxy = entities.SmartProxy(
+            config.ServerConfig('http://example.com'),
+            id=gen_integer(min_value=1),
+        )
+
+    def test_refresh(self):
+        """Call :meth:`nailgun.entities.SmartProxy.refresh`."""
+        with mock.patch.object(client, 'put') as client_put:
+            with mock.patch.object(
+                entities,
+                '_handle_response',
+                return_value=gen_integer(),  # not realistic
+            ) as handler:
+                response = self.proxy.refresh()
+        self.assertEqual(client_put.call_count, 1)
+        self.assertEqual(handler.call_count, 1)
+        self.assertEqual(handler.return_value, response)
+
+
+class SyncPlanTestCase(TestCase):
+    """Tests for :class:`nailgun.entities.SyncPlan`."""
+
+    def setUp(self):
+        """Set ``self.sync_plan``."""
+        self.sync_plan = entities.SyncPlan(
+            config.ServerConfig('http://example.com'),
+            id=gen_integer(min_value=1),
+            organization=gen_integer(min_value=1),
+        )
+
+    def test_add_products(self):
+        """Call :meth:`nailgun.entities.SyncPlan.add_products`."""
+        with mock.patch.object(client, 'put') as client_put:
+            with mock.patch.object(
+                entities,
+                '_handle_response',
+                return_value=gen_integer(),  # not realistic
+            ) as handler:
+                response = self.sync_plan.add_products({1: 2})
+        self.assertEqual(client_put.call_count, 1)
+        self.assertEqual(handler.call_count, 1)
+        self.assertEqual(handler.return_value, response)
+
+    def test_remove_products(self):
+        """Call :meth:`nailgun.entities.SyncPlan.remove_products`."""
+        with mock.patch.object(client, 'put') as client_put:
+            with mock.patch.object(
+                entities,
+                '_handle_response',
+                return_value=gen_integer(),  # not realistic
+            ) as handler:
+                response = self.sync_plan.remove_products({1: 2})
+        self.assertEqual(client_put.call_count, 1)
+        self.assertEqual(handler.call_count, 1)
+        self.assertEqual(handler.return_value, response)
 
 
 # 3. Other tests. -------------------------------------------------------- {{{1


### PR DESCRIPTION
`Product`:
* `list_repositorysets()` moved to `RepositorySet.list_all()`
* removed `fetch_rhproduct_id()` (use `Product.search()` instead)
* removed `fetch_reposet_id()` (use `RepositorySet.search()` instead)
* `enable_rhrepo()` now accepts `payload` dict instead of explicit parameters
* `enable_rhrepo()` moved to `RepositorySet.enable()`
* `disable_rhrepo()` now accepts `payload` dict instead of explicit parameters
* `disable_rhrepo()` moved to `RepositorySet.disable()`
* `repository_sets_available_repositories()` moved to `RepositorySet.available_repositories()`

`Repository`:
* Added ability to use `search()`
* removed `fetch_repoid` (use `Repository.search()` instead)
* `upload_content()` now accepts `payload` dict instead of explicit parameters

`RepositorySet`:
* Added new entity `RepositorySet`

`RHCIDeployment`:
* `add_hypervisors()` now accepts `payload` dict instead of explicit parameters
* `deploy()` now accepts `payload` dict instead of explicit parameters

`SyncPlan`:
* `add_products()` now accepts `payload` dict instead of explicit parameters
* `remove_products()` now accepts `payload` dict instead of explicit parameters

Updated unit tests with changes described above. Added tests for new `RepositorySet` entity.
