### PR TITLE
Added discovered_host entity

### DIFF
--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -93,6 +93,7 @@ class InitTestCase(TestCase):
                 entities.ContentUpload,
                 entities.ContentView,
                 entities.ContentViewVersion,
+                entities.DiscoveredHosts,
                 entities.DockerComputeResource,
                 entities.DockerHubContainer,
                 entities.Domain,
@@ -197,6 +198,7 @@ class PathTestCase(TestCase):
                 (entities.ConfigTemplate, '/config_templates'),
                 (entities.ContentView, '/content_views'),
                 (entities.ContentViewVersion, '/content_view_versions'),
+                (entities.DiscoveredHosts, '/discovered_hosts'),
                 (entities.Organization, '/organizations'),
                 (entities.Product, '/products'),
                 (entities.RHCIDeployment, '/deployments'),
@@ -252,6 +254,7 @@ class PathTestCase(TestCase):
         for entity, which in (
                 (entities.ConfigTemplate, 'build_pxe_default'),
                 (entities.ConfigTemplate, 'revision'),
+                (entities.DiscoveredHosts, 'facts'),
         ):
             with self.subTest():
                 path = entity(self.cfg).path(which=which)
@@ -413,6 +416,7 @@ class CreatePayloadTestCase(TestCase):
                 entities.AbstractDockerContainer,
                 entities.Architecture,
                 entities.ConfigTemplate,
+                entities.DiscoveredHosts,
                 entities.Domain,
                 entities.Environment,
                 entities.Host,
@@ -1103,6 +1107,33 @@ class ActivationKeyTestCase(TestCase):
             client_put.call_args[0][1]['content_override'],
             {'content_label': content_label, 'value': value},
         )
+
+
+class DiscoveredHostsTestCase(TestCase):
+    """Tests for :class:`nailgun.entities.DiscoveredHosts`."""
+
+    def setUp(self):
+        """Set ``self.discovered_hosts``."""
+        self.discovered_hosts = entities.DiscoveredHosts(
+            config.ServerConfig('http://example.com'),
+            id=gen_integer(min_value=1),
+        )
+
+    def test_upload_facts(self):
+        """Call :meth:`nailgun.entities.DiscoveredHosts.upload_facts`."""
+        with mock.patch.object(client, 'post') as client_post:
+            with mock.patch.object(
+                entities,
+                '_handle_response',
+                return_value={'results': gen_integer()},  # not realistic
+            ) as handler:
+                params = {'facts': {'name': gen_integer(),
+                                    'ipaddress': gen_integer(),
+                                    'discovery_bootif': gen_integer()}}
+                response = self.discovered_hosts.upload_facts(params)
+        self.assertEqual(client_post.call_count, 1)
+        self.assertEqual(handler.call_count, 1)
+        self.assertEqual(handler.return_value, response)
 
 
 class HostGroupTestCase(TestCase):


### PR DESCRIPTION
I would like to add tests around discovery feature. But for this, we need infrastructure along with provisioning where we can boot a unknown host via PXE and it gets IP from configured DHCP server on specific subnet on Foreman server. We don't have such infra for now though I really wanted to have one.

So, here I'm trying to discover a dummy  host via api to add basic tests. We have two api's to create discovered host.

```
POST /api/v2/discovered_hosts 
Create a discovered host
```
Unfortunately, this api doesn't work. I filed an issue in upstream after discussing with dev: http://projects.theforeman.org/issues/11277

The other api is to upload facts for discovered host and it creates the host as well. So I'm trying to create the dummy discovered host using this.

```
POST /api/v2/discovered_hosts/facts 
Upload facts for a host, creating the host if required
```

