### PR TITLE
Normalize Helper Methods

### DIFF
--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -206,9 +206,10 @@ class PathTestCase(TestCase):
                 (entities.RHCIDeployment, '/deployments'),
                 (entities.Repository, '/repositories'),
                 (entities.SmartProxy, '/smart_proxies'),
+                (entities.Subscription, '/subscriptions'),
                 (entities.System, '/systems'),
         ):
-            with self.subTest():
+            with self.subTest((entity, path)):
                 self.assertIn(path, entity(self.cfg).path())
                 self.assertIn(
                     '{}/{}'.format(path, self.id_),
@@ -240,7 +241,7 @@ class PathTestCase(TestCase):
                 (entities.Repository, 'upload_content'),
                 (entities.RHCIDeployment, 'deploy'),
         ):
-            with self.subTest():
+            with self.subTest((entity, which)):
                 path = entity(self.cfg, id=self.id_).path(which=which)
                 self.assertIn('{}/{}'.format(self.id_, which), path)
                 self.assertRegex(path, which + '$')
@@ -252,7 +253,7 @@ class PathTestCase(TestCase):
                 (entities.ConfigTemplate, 'revision'),
                 (entities.DiscoveredHosts, 'facts'),
         ):
-            with self.subTest():
+            with self.subTest((entity, which)):
                 path = entity(self.cfg).path(which=which)
                 self.assertIn(which, path)
                 self.assertRegex(path, which + '$')
@@ -285,8 +286,9 @@ class PathTestCase(TestCase):
                 (entities.SmartProxy, 'refresh'),
                 (entities.System, 'self'),
         ):
-            with self.assertRaises(NoSuchPathError):
-                entity(self.cfg).path(which=which)
+            with self.subTest((entity, which)):
+                with self.assertRaises(NoSuchPathError):
+                    entity(self.cfg).path(which=which)
 
     def test_foreman_task(self):
         """Test :meth:`nailgun.entities.ForemanTask.path`.
@@ -379,6 +381,34 @@ class PathTestCase(TestCase):
             self.assertIn('/systems/{}'.format(self.id_), path)
             self.assertRegex(path, '{}$'.format(self.id_))
 
+    def test_subscription(self):
+        """Test :meth:`nailgun.entities.Subscription.path`.
+
+        Assert that the following return appropriate paths:
+
+        * ``Subscription(organization=…).path('delete_manifest')``
+        * ``Subscription(organization=…).path('manifest_history')``
+        * ``Subscription(organization=…).path('refresh_manifest')``
+        * ``Subscription(organization=…).path('upload')``
+
+        """
+        sub = entities.Subscription(self.cfg, organization=gen_integer(1, 100))
+        for which in (
+                'delete_manifest',
+                'manifest_history',
+                'refresh_manifest',
+                'upload'):
+            with self.subTest(which):
+                path = sub.path(which)
+                self.assertIn(
+                    'organizations/{}/subscriptions/{}'.format(
+                        sub.organization.id,  # pylint:disable=no-member
+                        which,
+                    ),
+                    path
+                )
+                self.assertRegex(path, '{}$'.format(which))
+
 
 class CreateTestCase(TestCase):
     """Tests for :meth:`nailgun.entity_mixins.EntityCreateMixin.create`."""
@@ -401,12 +431,8 @@ class CreateTestCase(TestCase):
         )
         for entity in entities_:
             with self.subTest(entity):
-
-                # Call create()
                 with mock.patch.object(entity, 'create_json') as create_json:
-                    create_json.return_value = {'id': gen_integer()}
                     with mock.patch.object(type(entity), 'read') as read:
-                        read.return_value = gen_integer()
                         entity.create()
                 self.assertEqual(create_json.call_count, 1)
                 self.assertEqual(create_json.call_args[0], (None,))
@@ -915,7 +941,6 @@ class UpdateTestCase(TestCase):
                 # Call update()
                 with mock.patch.object(entity, 'update_json') as update_json:
                     with mock.patch.object(entity, 'read') as read:
-                        read.return_value = gen_integer()
                         self.assertEqual(entity.update(), read.return_value)
                 self.assertEqual(update_json.call_count, 1)
                 self.assertEqual(update_json.call_args[0], (None,))
@@ -926,7 +951,6 @@ class UpdateTestCase(TestCase):
                 fields = gen_integer()
                 with mock.patch.object(entity, 'update_json') as update_json:
                     with mock.patch.object(entity, 'read') as read:
-                        read.return_value = gen_integer()
                         self.assertEqual(
                             entity.update(fields),
                             read.return_value,
@@ -1031,12 +1055,8 @@ class AbstractDockerContainerTestCase(TestCase):
     def test_power(self):
         """Call :meth:`nailgun.entities.AbstractDockerContainer.power`."""
         for power_action in ('start', 'stop', 'status'):
-            with mock.patch.object(client, 'put') as client_put:
-                with mock.patch.object(
-                    entities,
-                    '_handle_response',
-                    return_value=gen_integer(),  # not realistic
-                ) as handler:
+            with mock.patch.object(entities, '_handle_response') as handler:
+                with mock.patch.object(client, 'put') as client_put:
                     response = self.abstract_dc.power(power_action)
             self.assertEqual(client_put.call_count, 1)
             self.assertEqual(handler.call_count, 1)
@@ -1062,12 +1082,8 @@ class AbstractDockerContainerTestCase(TestCase):
                     'tail': gen_integer(),
                 },
         ):
-            with mock.patch.object(client, 'get') as client_get:
-                with mock.patch.object(
-                    entities,
-                    '_handle_response',
-                    return_value=gen_integer(),  # not realistic
-                ) as handler:
+            with mock.patch.object(entities, '_handle_response') as handler:
+                with mock.patch.object(client, 'get') as client_get:
                     response = self.abstract_dc.logs(payload)
             self.assertEqual(client_get.call_count, 1)
             self.assertEqual(handler.call_count, 1)
@@ -1093,11 +1109,7 @@ class ActivationKeyTestCase(TestCase):
     def test_add_subscriptions(self):
         """Call :meth:`nailgun.entities.ActivationKey.add_subscriptions`."""
         with mock.patch.object(client, 'put') as client_put:
-            with mock.patch.object(
-                entities,
-                '_handle_response',
-                return_value=gen_integer(),  # not realistic
-            ) as handler:
+            with mock.patch.object(entities, '_handle_response') as handler:
                 response = self.activation_key.add_subscriptions({1: 2})
         self.assertEqual(client_put.call_count, 1)
         self.assertEqual(handler.call_count, 1)
@@ -1110,27 +1122,16 @@ class ActivationKeyTestCase(TestCase):
     def test_content_override(self):
         """Call :meth:`nailgun.entities.ActivationKey.content_override`."""
         with mock.patch.object(client, 'put') as client_put:
-            with mock.patch.object(
-                entities,
-                '_handle_response',
-                return_value=gen_integer(),  # not realistic
-            ) as handler:
-                content_label = gen_integer()
-                value = gen_integer()
-                response = self.activation_key.content_override({
-                    'content_label': content_label,
-                    'value': value,
-                })
+            with mock.patch.object(entities, '_handle_response') as handler:
+                payload = gen_integer()
+                response = self.activation_key.content_override(payload)
         self.assertEqual(client_put.call_count, 1)
         self.assertEqual(handler.call_count, 1)
         self.assertEqual(handler.return_value, response)
 
         # This was just executed: client_put(path='…', data={…}, …)
         # `call_args` is a two-tuple of (positional, keyword) args.
-        self.assertEqual(
-            client_put.call_args[0][1]['content_override'],
-            {'content_label': content_label, 'value': value},
-        )
+        self.assertEqual(client_put.call_args[0][1], payload)
 
 
 class DiscoveredHostsTestCase(TestCase):
@@ -1155,7 +1156,7 @@ class DiscoveredHostsTestCase(TestCase):
         self.assertEqual(handler.return_value, response)
 
 
-class ContentViewVersion(TestCase):
+class ContentViewVersionTestCase(TestCase):
     """Tests for :class:`nailgun.entities.ContentViewVersion`."""
 
     def setUp(self):
@@ -1168,11 +1169,7 @@ class ContentViewVersion(TestCase):
     def test_promote(self):
         """Call :meth:`nailgun.entities.ContentViewVersion.promote`."""
         with mock.patch.object(client, 'post') as client_post:
-            with mock.patch.object(
-                entities,
-                '_handle_response',
-                return_value=gen_integer(),  # not realistic
-            ) as handler:
+            with mock.patch.object(entities, '_handle_response') as handler:
                 response = self.cvv.promote({1: 2})
         self.assertEqual(client_post.call_count, 1)
         self.assertEqual(handler.call_count, 1)
@@ -1183,7 +1180,7 @@ class ContentViewVersion(TestCase):
         self.assertEqual(client_post.call_args[0][1], {1: 2})
 
 
-class ContentView(TestCase):
+class ContentViewTestCase(TestCase):
     """Tests for :class:`nailgun.entities.ContentView`."""
 
     def setUp(self):
@@ -1200,12 +1197,8 @@ class ContentView(TestCase):
                 {},
                 {1: 2},
         ):
-            with mock.patch.object(client, 'post') as client_post:
-                with mock.patch.object(
-                    entities,
-                    '_handle_response',
-                    return_value=gen_integer(),  # not realistic
-                ) as handler:
+            with mock.patch.object(entities, '_handle_response') as handler:
+                with mock.patch.object(client, 'post') as client_post:
                     response = self.content_view.publish(payload)
             self.assertEqual(client_post.call_count, 1)
             self.assertEqual(handler.call_count, 1)
@@ -1218,14 +1211,19 @@ class ContentView(TestCase):
             {1: 2, 'id': self.content_view.id}  # pylint:disable=no-member
         )
 
+    def test_available_puppet_modules(self):
+        """Run :meth:`nailgun.entities.ContentView.available_puppet_modules`"""
+        with mock.patch.object(client, 'get') as client_get:
+            with mock.patch.object(entities, '_handle_response') as handler:
+                response = self.content_view.available_puppet_modules()
+        self.assertEqual(client_get.call_count, 1)
+        self.assertEqual(handler.call_count, 1)
+        self.assertEqual(handler.return_value, response)
+
     def test_copy(self):
         """Call :meth:`nailgun.entities.ContentView.copy`."""
         with mock.patch.object(client, 'post') as client_post:
-            with mock.patch.object(
-                entities,
-                '_handle_response',
-                return_value=gen_integer(),  # not realistic
-            ) as handler:
+            with mock.patch.object(entities, '_handle_response') as handler:
                 response = self.content_view.copy({1: 2})
         self.assertEqual(client_post.call_count, 1)
         self.assertEqual(handler.call_count, 1)
@@ -1237,6 +1235,38 @@ class ContentView(TestCase):
             client_post.call_args[0][1],
             {1: 2, 'id': self.content_view.id}  # pylint:disable=no-member
         )
+
+
+class ForemanTaskTestCase(TestCase):
+    """Tests for :class:`nailgun.entities.ForemanTask`."""
+
+    def setUp(self):
+        """Set ``self.foreman_task``."""
+        self.foreman_task = entities.ForemanTask(
+            config.ServerConfig('http://example.com'),
+            id=gen_integer(min_value=1),
+        )
+
+    def test_poll(self):
+        """Call :meth:`nailgun.entities.ForemanTask.poll`."""
+        for kwargs in (
+                {},
+                {'poll_rate': gen_integer()},
+                {'timeout': gen_integer()},
+                {'poll_rate': gen_integer(), 'timeout': gen_integer()}
+        ):
+            with self.subTest(kwargs):
+                with mock.patch.object(entities, '_poll_task') as poll_task:
+                    self.foreman_task.poll(**kwargs)
+                self.assertEqual(poll_task.call_count, 1)
+                self.assertEqual(
+                    poll_task.call_args[0][2],
+                    kwargs.get('poll_rate', None),
+                )
+                self.assertEqual(
+                    poll_task.call_args[0][3],
+                    kwargs.get('timeout', None),
+                )
 
 
 class HostGroupTestCase(TestCase):
@@ -1275,86 +1305,6 @@ class HostGroupTestCase(TestCase):
         )
 
 
-class OrganizationTestCase(TestCase):
-    """Tests for :class:`nailgun.entities.Organization`."""
-
-    def setUp(self):
-        """Set ``self.org``."""
-        self.org = entities.Organization(
-            config.ServerConfig('http://example.com'),
-            id=gen_integer(min_value=1),
-        )
-
-    def test_subscriptions(self):
-        """Call :meth:`nailgun.entities.Organization.subscriptions`."""
-        with mock.patch.object(client, 'get') as client_get:
-            with mock.patch.object(
-                entities,
-                '_handle_response',
-                return_value={'results': gen_integer()},  # not realistic
-            ) as handler:
-                response = self.org.subscriptions()
-        self.assertEqual(client_get.call_count, 1)
-        self.assertEqual(handler.call_count, 1)
-        self.assertEqual(handler.return_value['results'], response)
-
-    def test_delete_manifest(self):
-        """Call :meth:`nailgun.entities.Organization.delete_manifest`."""
-        for synchronous in (True, False):
-            with mock.patch.object(client, 'post') as client_post:
-                with mock.patch.object(
-                    entities,
-                    '_handle_response',
-                    return_value=gen_integer(),  # not realistic
-                ) as handler:
-                    response = self.org.delete_manifest(synchronous)
-            self.assertEqual(client_post.call_count, 1)
-            self.assertEqual(handler.call_count, 1)
-            self.assertEqual(handler.return_value, response)
-
-    def test_refresh_manifest(self):
-        """Call :meth:`nailgun.entities.Organization.refresh_manifest`."""
-        with mock.patch.object(client, 'put') as client_put:
-            with mock.patch.object(
-                entities,
-                '_handle_response',
-                return_value=gen_integer(),  # not realistic
-            ) as handler:
-                response = self.org.refresh_manifest()
-        self.assertEqual(client_put.call_count, 1)
-        self.assertEqual(handler.call_count, 1)
-        self.assertEqual(handler.return_value, response)
-
-    def test_sync_plan(self):
-        """Call :meth:`nailgun.entities.Organization.sync_plan`."""
-        with mock.patch.object(client, 'post') as client_post:
-            with mock.patch.object(
-                entities,
-                '_handle_response',
-                return_value=gen_integer(),  # not realistic
-            ) as handler:
-                name = gen_integer()
-                interval = gen_integer()
-                response = self.org.sync_plan({
-                    'name': name,
-                    'interval': interval,
-                })
-        self.assertEqual(client_post.call_count, 1)
-        self.assertEqual(handler.call_count, 1)
-        self.assertEqual(handler.return_value, response)
-
-        # This was just executed: client_post(path='…', data={…}, …)
-        # `call_args` is a two-tuple of (positional, keyword) args.
-        data = client_post.call_args[0][1]
-        self.assertEqual(
-            set(('interval', 'name', 'sync_date')),
-            set(data.keys()),
-        )
-        self.assertEqual(data['interval'], interval)
-        self.assertEqual(data['name'], name)
-        self.assertIsInstance('sync_date', type(''))
-
-
 class ProductTestCase(TestCase):
     """Tests for :class:`nailgun.entities.Product`."""
 
@@ -1368,14 +1318,11 @@ class ProductTestCase(TestCase):
     def test_sync(self):
         """Call :meth:`nailgun.entities.Product.sync`."""
         with mock.patch.object(client, 'post') as client_post:
-            with mock.patch.object(
-                entities,
-                '_handle_response',
-                return_value={'results': gen_integer()},  # not realistic
-            ) as handler:
-                self.product.sync()
+            with mock.patch.object(entities, '_handle_response') as handler:
+                response = self.product.sync()
         self.assertEqual(client_post.call_count, 1)
         self.assertEqual(handler.call_count, 1)
+        self.assertEqual(response, handler.return_value)
 
 
 class RepositoryTestCase(TestCase):
@@ -1390,39 +1337,68 @@ class RepositoryTestCase(TestCase):
 
     def test_sync(self):
         """Call :meth:`nailgun.entities.Repository.sync`."""
-        with mock.patch.object(client, 'post') as client_post:
-            with mock.patch.object(
-                entities,
-                '_handle_response',
-                return_value={'results': gen_integer()},  # not realistic
-            ) as handler:
+        with mock.patch.object(client, 'post') as post:
+            with mock.patch.object(entities, '_handle_response') as handler:
                 self.repo.sync()
-        self.assertEqual(client_post.call_count, 1)
+        self.assertEqual(post.call_count, 1)
         self.assertEqual(handler.call_count, 1)
 
-    def test_upload_content(self):
-        """Call :meth:`nailgun.entities.Repository.upload_content`."""
-        with mock.patch.object(client, 'post') as client_post:
+    def test_upload_content_v1(self):
+        """Call :meth:`nailgun.entities.Repository.upload_content`.
+
+        Assert that the ``content`` argument is wrapped in a dict before being
+        passed to the server.
+
+        """
+        content = gen_integer()
+        with mock.patch.object(client, 'post') as post:
             with mock.patch.object(
                 entities,
                 '_handle_response',
                 return_value={'status': 'success'},
             ) as handler:
-                self.repo.upload_content({1: 2})
-        self.assertEqual(client_post.call_count, 1)
+                response = self.repo.upload_content(content)
+        self.assertEqual(post.call_count, 1)
+        self.assertEqual(post.call_args[1]['files'], {'content': content})
         self.assertEqual(handler.call_count, 1)
+        self.assertEqual(handler.return_value, response)
 
-    def test_upload_content_error(self):
-        """Trigger an :class:`nailgun.entities.APIResponseError`."""
-        with mock.patch.object(client, 'post') as client_post:
+    def test_upload_content_v2(self):
+        """Call :meth:`nailgun.entities.Repository.upload_content`.
+
+        Assert that the ``content`` argument is passed directly to the server
+        if it is a list.
+
+        """
+        content = [gen_integer()]
+        with mock.patch.object(client, 'post') as post:
+            with mock.patch.object(
+                entities,
+                '_handle_response',
+                return_value={'status': 'success'},
+            ) as handler:
+                response = self.repo.upload_content(content)
+        self.assertEqual(post.call_count, 1)
+        self.assertEqual(post.call_args[1]['files'], content)
+        self.assertEqual(handler.call_count, 1)
+        self.assertEqual(handler.return_value, response)
+
+    def test_upload_content_v3(self):
+        """Trigger an :class:`nailgun.entities.APIResponseError`.
+
+        Assert that an ``APIResponseError`` is raised if the server's response
+        has a status of "failure".
+
+        """
+        with mock.patch.object(client, 'post') as post:
             with mock.patch.object(
                 entities,
                 '_handle_response',
                 return_value={'status': 'failure'},
             ) as handler:
                 with self.assertRaises(entities.APIResponseError):
-                    self.repo.upload_content({1: 2})
-        self.assertEqual(client_post.call_count, 1)
+                    self.repo.upload_content('content')
+        self.assertEqual(post.call_count, 1)
         self.assertEqual(handler.call_count, 1)
 
 
@@ -1447,11 +1423,7 @@ class RepositorySetTestCase(TestCase):
 
         """
         with mock.patch.object(client, 'get') as client_get:
-            with mock.patch.object(
-                entities,
-                '_handle_response',
-                return_value={'results': gen_integer()},  # not realistic
-            ) as handler:
+            with mock.patch.object(entities, '_handle_response') as handler:
                 response = self.reposet.available_repositories()
         self.assertEqual(client_get.call_count, 1)
         self.assertEqual(handler.call_count, 1)
@@ -1460,11 +1432,7 @@ class RepositorySetTestCase(TestCase):
     def test_enable(self):
         """Call :meth:`nailgun.entities.RepositorySet.enable`"""
         with mock.patch.object(client, 'put') as client_put:
-            with mock.patch.object(
-                entities,
-                '_handle_response',
-                return_value={'results': gen_integer()},  # not realistic
-            ) as handler:
+            with mock.patch.object(entities, '_handle_response') as handler:
                 response = self.reposet.enable({1: 2})
         self.assertEqual(client_put.call_count, 1)
         self.assertEqual(handler.call_count, 1)
@@ -1473,28 +1441,11 @@ class RepositorySetTestCase(TestCase):
     def test_disable(self):
         """Call :meth:`nailgun.entities.RepositorySet.disable`"""
         with mock.patch.object(client, 'put') as client_put:
-            with mock.patch.object(
-                entities,
-                '_handle_response',
-                return_value={'results': gen_integer()},  # not realistic
-            ) as handler:
+            with mock.patch.object(entities, '_handle_response') as handler:
                 response = self.reposet.disable({1: 2})
         self.assertEqual(client_put.call_count, 1)
         self.assertEqual(handler.call_count, 1)
         self.assertEqual(handler.return_value, response)
-
-    def test_list_all(self):
-        """Call :meth:`nailgun.entities.RepositorySet.list_all`"""
-        with mock.patch.object(client, 'get') as client_get:
-            with mock.patch.object(
-                entities,
-                '_handle_response',
-                return_value={'results': gen_integer()},  # not realistic
-            ) as handler:
-                response = self.reposet.list_all()
-        self.assertEqual(client_get.call_count, 1)
-        self.assertEqual(handler.call_count, 1)
-        self.assertEqual(handler.return_value['results'], response)
 
     def test_search_normalize(self):
         """Call :meth:`nailgun.entities.RepositorySet.search_normalize`"""
@@ -1516,36 +1467,10 @@ class RHCIDeploymentTestCase(TestCase):
             id=gen_integer(min_value=1),
         )
 
-    def test_add_hypervisors(self):
-        """Call :meth:`nailgun.entities.RHCIDeployment.add_hypervisors`."""
-        with mock.patch.object(client, 'put') as client_put:
-            with mock.patch.object(
-                entities,
-                '_handle_response',
-                return_value={'results': gen_integer()},  # not realistic
-            ) as handler:
-                hypervisor_ids = [gen_integer(), gen_integer(), gen_integer()]
-                response = self.rhci_deployment.add_hypervisors({
-                    'discovered_host_ids': hypervisor_ids,
-                })
-        self.assertEqual(client_put.call_count, 1)
-        self.assertEqual(handler.call_count, 1)
-        self.assertEqual(handler.return_value, response)
-
-        # `call_args` is a two-tuple of (positional, keyword) args.
-        self.assertEqual(
-            client_put.call_args[0][1],
-            {'discovered_host_ids': hypervisor_ids},
-        )
-
     def test_deploy(self):
         """Call :meth:`nailgun.entities.RHCIDeployment.deploy`."""
         with mock.patch.object(client, 'put') as client_put:
-            with mock.patch.object(
-                entities,
-                '_handle_response',
-                return_value={'results': gen_integer()},  # not realistic
-            ) as handler:
+            with mock.patch.object(entities, '_handle_response') as handler:
                 payload = {'foo': gen_integer()}
                 response = self.rhci_deployment.deploy(payload)
         self.assertEqual(client_put.call_count, 1)
@@ -1569,14 +1494,92 @@ class SmartProxyTestCase(TestCase):
     def test_refresh(self):
         """Call :meth:`nailgun.entities.SmartProxy.refresh`."""
         with mock.patch.object(client, 'put') as client_put:
-            with mock.patch.object(
-                entities,
-                '_handle_response',
-                return_value=gen_integer(),  # not realistic
-            ) as handler:
+            with mock.patch.object(entities, '_handle_response') as handler:
                 response = self.proxy.refresh()
         self.assertEqual(client_put.call_count, 1)
         self.assertEqual(handler.call_count, 1)
+        self.assertEqual(handler.return_value, response)
+
+
+class SubscriptionTestCase(TestCase):
+    """Tests for :class:`nailgun.entities.Subscription`."""
+
+    def setUp(self):
+        """Set ``self.subscription``."""
+        self.subscription = entities.Subscription(
+            config.ServerConfig('http://example.com'),
+        )
+        self.payload = gen_integer()
+
+    def test__org_path(self):
+        """Call ``nailgun.entities.Subscription._org_path``."""
+        which = gen_integer()
+        payload = {'organization_id': gen_integer()}
+        with mock.patch.object(entities.Subscription, 'path') as path:
+            # pylint:disable=protected-access
+            response = self.subscription._org_path(which, payload)
+        self.assertEqual(path.call_count, 1)
+        self.assertEqual(path.call_args[0], (which,))
+        self.assertEqual(path.return_value, response)
+        self.assertFalse(hasattr(self.subscription, 'organization'))
+
+    def test_delete_manifest(self):
+        """Call :meth:`nailgun.entities.Subscription.delete_manifest`."""
+        with mock.patch.object(self.subscription, '_org_path') as org_path:
+            with mock.patch.object(entities, '_handle_response') as handler:
+                with mock.patch.object(client, 'post') as post:
+                    response = self.subscription.delete_manifest(self.payload)
+        self.assertEqual(org_path.call_count, 1)
+        self.assertEqual(post.call_count, 1)
+        self.assertEqual(handler.call_count, 1)
+        self.assertEqual(
+            org_path.call_args[0],
+            ('delete_manifest', self.payload),
+        )
+        self.assertEqual(handler.return_value, response)
+
+    def test_manifest_history(self):
+        """Call :meth:`nailgun.entities.Subscription.manifest_history`."""
+        with mock.patch.object(self.subscription, '_org_path') as org_path:
+            with mock.patch.object(entities, '_handle_response') as handler:
+                with mock.patch.object(client, 'get') as get:
+                    response = self.subscription.manifest_history(self.payload)
+        self.assertEqual(org_path.call_count, 1)
+        self.assertEqual(get.call_count, 1)
+        self.assertEqual(handler.call_count, 1)
+        self.assertEqual(
+            org_path.call_args[0],
+            ('manifest_history', self.payload),
+        )
+        self.assertEqual(handler.return_value, response)
+
+    def test_refresh_manifest(self):
+        """Call :meth:`nailgun.entities.Subscription.refresh_manifest`."""
+        with mock.patch.object(self.subscription, '_org_path') as org_path:
+            with mock.patch.object(entities, '_handle_response') as handler:
+                with mock.patch.object(client, 'put') as put:
+                    response = self.subscription.refresh_manifest(self.payload)
+        self.assertEqual(org_path.call_count, 1)
+        self.assertEqual(put.call_count, 1)
+        self.assertEqual(handler.call_count, 1)
+        self.assertEqual(
+            org_path.call_args[0],
+            ('refresh_manifest', self.payload),
+        )
+        self.assertEqual(handler.return_value, response)
+
+    def test_upload(self):
+        """Call :meth:`nailgun.entities.Subscription.upload`."""
+        manifest = gen_integer()
+        with mock.patch.object(self.subscription, '_org_path') as org_path:
+            with mock.patch.object(entities, '_handle_response') as handler:
+                with mock.patch.object(client, 'put') as put:
+                    response = self.subscription.upload(self.payload, manifest)
+        self.assertEqual(org_path.call_count, 1)
+        self.assertEqual(put.call_count, 1)
+        self.assertEqual(handler.call_count, 1)
+        self.assertEqual(org_path.call_args[0], ('upload', self.payload))
+        self.assertEqual(put.call_args[1]['files'], {'content': manifest})
         self.assertEqual(handler.return_value, response)
 
 
@@ -1594,11 +1597,7 @@ class SyncPlanTestCase(TestCase):
     def test_add_products(self):
         """Call :meth:`nailgun.entities.SyncPlan.add_products`."""
         with mock.patch.object(client, 'put') as client_put:
-            with mock.patch.object(
-                entities,
-                '_handle_response',
-                return_value=gen_integer(),  # not realistic
-            ) as handler:
+            with mock.patch.object(entities, '_handle_response') as handler:
                 response = self.sync_plan.add_products({1: 2})
         self.assertEqual(client_put.call_count, 1)
         self.assertEqual(handler.call_count, 1)
@@ -1607,11 +1606,7 @@ class SyncPlanTestCase(TestCase):
     def test_remove_products(self):
         """Call :meth:`nailgun.entities.SyncPlan.remove_products`."""
         with mock.patch.object(client, 'put') as client_put:
-            with mock.patch.object(
-                entities,
-                '_handle_response',
-                return_value=gen_integer(),  # not realistic
-            ) as handler:
+            with mock.patch.object(entities, '_handle_response') as handler:
                 response = self.sync_plan.remove_products({1: 2})
         self.assertEqual(client_put.call_count, 1)
         self.assertEqual(handler.call_count, 1)
@@ -1655,7 +1650,6 @@ class HandleResponseTestCase(TestCase):
     def test_default(self):
         """Don't give the response any special status code."""
         response = mock.Mock()
-        response.json.return_value = gen_integer()  # not realistic
         self.assertEqual(
             entities._handle_response(response, 'foo'),  # pylint:disable=W0212
             response.json.return_value,
@@ -1686,7 +1680,6 @@ class HandleResponseTestCase(TestCase):
         """
         response = mock.Mock()
         response.status_code = ACCEPTED
-        response.json.return_value = gen_integer()  # not realistic
         for args in [response, 'foo'], [response, 'foo', False]:
             self.assertEqual(
                 entities._handle_response(*args),  # pylint:disable=W0212
@@ -1708,7 +1701,6 @@ class HandleResponseTestCase(TestCase):
         response.status_code = ACCEPTED
         response.json.return_value = {'id': gen_integer()}
         with mock.patch.object(entities, 'ForemanTask') as foreman_task:
-            foreman_task.return_value.poll.return_value = gen_integer()
             self.assertEqual(
                 foreman_task.return_value.poll.return_value,
                 # pylint:disable=protected-access


### PR DESCRIPTION
<ins>What follows is the contents  of the third commit message.</ins>

Fix #41:

> Several methods in module `nailgun.entities` do not map nicely to an
> underlying path. In addition, several methods do not have appropriate
> arguments. The methods exposed by the entity classes should be reviewed to
> make sure that they are appropriately named and placed on the most appropriate
> class.

Though many actions can be performed with the mixins, some do not map nicely to
one of the CRUD verbs. For example, publishing a content view or uploading
content to a repository are actions that cannot be described by the CRUD verbs.

NailGun must be able to carry out actions such as publishing or uploading. But
how? NailGun has thus far addressed these needs by simply adding methods on an
ad-hoc basis. This works, but it comes with costs:

* The helper methods must be learned one-by-one, as there is no guarantee of
  consistency among them.
* Some helper methods will require ongoing maintenance. For example, the
  `AbstractDockerContainer.power` method only accepts the strings "start,"
  "stop" and "status," and it will need to be updated when Satellite changes.
  NailGun already commits to creating entity classes for each resource and
  describing each available field — describing the logic of each helper method
  raises the cost of maintenance even higher.

Address these issues. Give each helper method a highly similar signature. Do not
attempt to interpret the messages sent from clients to the server, but instead
let the server validate the contents of each message.

The previous two commits in this chain of commits already make some head-way on
this front. This commit makes the following changes:

* Add the `Subscription` entity.
* Change the signature of `ActivationKey.content_override`.
* Change the signature of `Repository.upload_content`.
* Drop `ContentView.add_puppet_module`. (Use `ContentViewPuppetModule.create`
  instead.)
* Drop `ContentView.set_repository_ids`. (Use `ContentView.update` instead.)
* Drop `Organization.delete_manifest`. (Use `Subscription.delete_manifest`
  instead.)
* Drop `Organization.refresh_manifest`. (Use `Subscription.refresh_manifest`
  instead.)
* Drop `Organization.subscriptions`. (Use `Subscription.search` instead.)
* Drop `Organization.sync_plan`. (Use `SyncPlan.create` instead.)
* Drop `Organization.upload_manifest`. (Use `Subscription.upload` instead.)
* Drop `RHCIDeployment.add_hypervisors`. (Use RHCIDeployment.update` instead.)
* Drop `RepositorySet.list_all`. (Use `RepositorySet.search` instead.)
* Update unit tests.

Some of these methods may be re-added in some form or another. For example, it
would be useful to add a helper method `Organization.subscriptions_upload` that
maps to the `/katello/api/v2/organizations/:id/subscriptions/upload` path.
However, at this point in time, the focus is on making NailGun's API stable.
Developers should be able to write code against NailGun and be confident that it
will not break. These changes add stability, and future changes may build upon
them.