### PR TITLE
Re-work helper methods, again

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2872,60 +2872,57 @@ class RepositorySet(
             'api_path': '{0}/repository_sets'.format(self.product.path()),
         }
 
-    def available_repositories(self):
+    def available_repositories(self, synchronous=True, **kwargs):
         """Lists available repositories for the repository set
 
-        :returns: Returns list of available repositories for the repository set
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
 
         """
-        response = client.get(
-            self.path('available_repositories'),
-            **self._server_config.get_client_kwargs()
-        )
-        return _handle_response(response, self._server_config)['results']
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.get(self.path('available_repositories'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous)
 
-    def enable(self, payload, synchronous=True):
+    def enable(self, synchronous=True, **kwargs):
         """Enables the RedHat Repository
 
         RedHat Repos needs to be enabled first, so that we can sync it.
 
-        :param payload: Parameters that are encoded to JSON and passed in
-            with the request. See the API documentation page for a list of
-            parameters and their descriptions.
         :param synchronous: What should happen if the server returns an HTTP
             202 (accepted) status code? Wait for the task to complete if
-            ``True``. Immediately return JSON response otherwise.
-        :returns: Returns information of the async task if an HTTP
-            202 response was received and synchronus set to ``True``.
-            Return JSON response otherwise.
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
 
         """
-        response = client.put(
-            self.path('enable'),
-            payload,
-            **self._server_config.get_client_kwargs()
-        )
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.put(self.path('enable'), **kwargs)
         return _handle_response(response, self._server_config, synchronous)
 
-    def disable(self, payload, synchronous=True):
+    def disable(self, synchronous=True, **kwargs):
         """Disables the RedHat Repository
 
-        :param payload: Parameters that are encoded to JSON and passed in
-            with the request. See the API documentation page for a list of
-            parameters and their descriptions.
         :param synchronous: What should happen if the server returns an HTTP
             202 (accepted) status code? Wait for the task to complete if
-            ``True``. Immediately return JSON response otherwise.
-        :returns: Returns information of the async task if an HTTP
-            202 response was received and synchronus set to ``True``.
-            Return JSON response otherwise.
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
 
         """
-        response = client.put(
-            self.path('disable'),
-            payload,
-            **self._server_config.get_client_kwargs()
-        )
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.put(self.path('disable'), **kwargs)
         return _handle_response(response, self._server_config, synchronous)
 
     def path(self, which=None):

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2575,14 +2575,22 @@ class Product(
             attrs['organization'] = org.get_values()
         return super(Product, self).read(entity, attrs, ignore)
 
-    def sync(self):
-        """Synchronize :class:`repositories <Repository>` in this product."""
-        response = client.post(
-            self.path('sync'),
-            {},
-            **self._server_config.get_client_kwargs()
-        )
-        return _handle_response(response, self._server_config)
+    def sync(self, synchronous=True, **kwargs):
+        """Synchronize :class:`repositories <Repository>` in this product.
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+
+        """
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.post(self.path('sync'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous)
 
 
 class PartitionTable(

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -1014,25 +1014,21 @@ class ContentViewVersion(Entity, EntityReadMixin, EntityDeleteMixin):
             )
         return super(ContentViewVersion, self).path(which)
 
-    def promote(self, payload, synchronous=True):
+    def promote(self, synchronous=True, **kwargs):
         """Helper for promoting an existing published content view.
 
-        :param payload: Parameters that are encoded to JSON and passed in
-            with the request. See the API documentation page for a list of
-            parameters and their descriptions.
         :param synchronous: What should happen if the server returns an HTTP
             202 (accepted) status code? Wait for the task to complete if
-            ``True``. Immediately return a task ID otherwise.
-        :return: Return information about the completed foreman task if an HTTP
-            202 response is received and ``synchronous`` is true. Return the
-            JSON response otherwise.
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
 
         """
-        response = client.post(
-            self.path('promote'),
-            payload,
-            **self._server_config.get_client_kwargs()
-        )
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.post(self.path('promote'), **kwargs)
         return _handle_response(response, self._server_config, synchronous)
 
 

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -625,22 +625,22 @@ class DiscoveredHosts(
             ).update_payload(fields)
         }
 
-    def facts(self, payload):
+    def facts(self, synchronous=True, **kwargs):
         """Helper to update facts for discovered host, and create the host.
 
-        :param payload: Parameters that are encoded to JSON and passed in
-            with the request.
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
         :returns: The server's response, with all JSON decoded.
         :raises: ``requests.exceptions.HTTPError`` If the server responds with
             an HTTP 4XX or 5XX message.
 
         """
-        response = client.post(
-            self.path('facts'),
-            payload,
-            **self._server_config.get_client_kwargs()
-        )
-        return _handle_response(response, self._server_config)
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.post(self.path('facts'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous)
 
 
 class DockerComputeResource(AbstractComputeResource):

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -3067,23 +3067,22 @@ class RHCIDeployment(
             )
         return super(RHCIDeployment, self).path(which)
 
-    def deploy(self, payload):
+    def deploy(self, synchronous=True, **kwargs):
         """Kickoff the RHCI deployment.
 
-        :param payload: Parameters that are encoded to JSON and passed in
-            with the request. See the API documentation page for a list of
-            parameters and their descriptions.
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
         :returns: The server's response, with all JSON decoded.
         :raises: ``requests.exceptions.HTTPError`` If the server responds with
             an HTTP 4XX or 5XX message.
 
         """
-        response = client.put(
-            self.path('deploy'),
-            payload,
-            **self._server_config.get_client_kwargs()
-        )
-        return _handle_response(response, self._server_config)
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.put(self.path('deploy'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous)
 
 
 class RoleLDAPGroups(Entity):

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -3541,50 +3541,46 @@ class SyncPlan(
             )
         return super(SyncPlan, self).path(which)
 
-    def add_products(self, payload, synchronous=True):
+    def add_products(self, synchronous=True, **kwargs):
         """Add products to this sync plan.
 
         .. NOTE:: The ``synchronous`` argument has no effect in certain
             versions of Satellite. See `Bugzilla #1199150
             <https://bugzilla.redhat.com/show_bug.cgi?id=1199150>`_.
 
-        :param payload: Parameters that are encoded to JSON and passed in
-            with the request. See the API documentation page for a list of
-            parameters and their descriptions.
         :param synchronous: What should happen if the server returns an HTTP
             202 (accepted) status code? Wait for the task to complete if
-            ``True``. Immediately return the server's reponse otherwise.
-        :returns: The server's JSON-decoded response.
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
 
         """
-        response = client.put(
-            self.path('add_products'),
-            payload,
-            **self._server_config.get_client_kwargs()
-        )
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.put(self.path('add_products'), **kwargs)
         return _handle_response(response, self._server_config, synchronous)
 
-    def remove_products(self, payload, synchronous=True):
+    def remove_products(self, synchronous=True, **kwargs):
         """Remove products from this sync plan.
 
         .. NOTE:: The ``synchronous`` argument has no effect in certain
             versions of Satellite. See `Bugzilla #1199150
             <https://bugzilla.redhat.com/show_bug.cgi?id=1199150>`_.
 
-        :param payload: Parameters that are encoded to JSON and passed in
-            with the request. See the API documentation page for a list of
-            parameters and their descriptions.
         :param synchronous: What should happen if the server returns an HTTP
             202 (accepted) status code? Wait for the task to complete if
-            ``True``. Immediately return the server's reponse otherwise.
-        :returns: The server's JSON-decoded response.
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
 
         """
-        response = client.put(
-            self.path('remove_products'),
-            payload,
-            **self._server_config.get_client_kwargs()
-        )
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.put(self.path('remove_products'), **kwargs)
         return _handle_response(response, self._server_config, synchronous)
 
     def update_payload(self, fields=None):

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -194,7 +194,7 @@ class ActivationKey(
         EntityDeleteMixin,
         EntityReadMixin,
         EntityUpdateMixin):
-    """A representation of a Activtion Key entity."""
+    """A representation of a Activation Key entity."""
 
     def __init__(self, server_config=None, **kwargs):
         self._fields = {
@@ -267,41 +267,39 @@ class ActivationKey(
             )
         return super(ActivationKey, self).path(which)
 
-    def add_subscriptions(self, payload):
+    def add_subscriptions(self, synchronous=True, **kwargs):
         """Helper for adding subscriptions to activation key.
 
-        :param payload: Parameters that are encoded to JSON and passed in
-            with the request. See the API documentation page for a list of
-            parameters and their descriptions.
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
         :returns: The server's response, with all JSON decoded.
         :raises: ``requests.exceptions.HTTPError`` If the server responds with
             an HTTP 4XX or 5XX message.
 
         """
-        response = client.put(
-            self.path('add_subscriptions'),
-            payload,
-            **self._server_config.get_client_kwargs()
-        )
-        return _handle_response(response, self._server_config)
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.put(self.path('add_subscriptions'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous)
 
-    def content_override(self, payload):
+    def content_override(self, synchronous=True, **kwargs):
         """Override the content of an activation key.
 
-        :param payload: Parameters that are encoded to JSON and passed in
-            with the request. See the API documentation page for a list of
-            parameters and their descriptions.
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
         :returns: The server's response, with all JSON decoded.
         :raises: ``requests.exceptions.HTTPError`` If the server responds with
             an HTTP 4XX or 5XX message.
 
         """
-        response = client.put(
-            self.path('content_override'),
-            payload,
-            **self._server_config.get_client_kwargs()
-        )
-        return _handle_response(response, self._server_config)
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.put(self.path('content_override'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous)
 
 
 class Architecture(

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -1306,55 +1306,60 @@ class ContentView(
             )
         return super(ContentView, self).path(which)
 
-    def publish(self, payload=None, synchronous=True):
+    def publish(self, synchronous=True, **kwargs):
         """Helper for publishing an existing content view.
 
         :param synchronous: What should happen if the server returns an HTTP
             202 (accepted) status code? Wait for the task to complete if
-            ``True``. Immediately return a task ID otherwise.
-        :return: Return information about the completed foreman task if an HTTP
-            202 response is received and ``synchronous`` is true. Return the
-            JSON response otherwise.
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
 
         """
-        if payload is None:
-            payload = {}
-        payload['id'] = self.id  # pylint:disable=no-member
-        response = client.post(
-            self.path('publish'),
-            payload,
-            **self._server_config.get_client_kwargs()
-        )
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        if 'data' in kwargs and 'id' not in kwargs['data']:
+            kwargs['data']['id'] = self.id  # pylint:disable=no-member
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.post(self.path('publish'), **kwargs)
         return _handle_response(response, self._server_config, synchronous)
 
-    def available_puppet_modules(self):
+    def available_puppet_modules(self, synchronous=True, **kwargs):
         """Get puppet modules available to be added to the content view.
 
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
         :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
 
         """
-        response = client.get(
-            self.path('available_puppet_modules'),
-            **self._server_config.get_client_kwargs()
-        )
-        return _handle_response(response, self._server_config)
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.get(self.path('available_puppet_modules'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous)
 
-    def copy(self, payload):
+    def copy(self, synchronous=True, **kwargs):
         """Clone provided content view.
 
-        :param payload: Parameters that are encoded to JSON and passed in
-            with the request. See the API documentation page for a list of
-            parameters and their descriptions.
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
         :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
 
         """
-        payload['id'] = self.id  # pylint:disable=no-member
-        response = client.post(
-            self.path('copy'),
-            payload,
-            **self._server_config.get_client_kwargs()
-        )
-        return _handle_response(response, self._server_config)
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        if 'data' in kwargs and 'id' not in kwargs['data']:
+            kwargs['data']['id'] = self.id  # pylint:disable=no-member
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.post(self.path('copy'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous)
 
     def delete_from_environment(self, environment, synchronous=True):
         """Delete this content view version from an environment.

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -913,37 +913,39 @@ class AbstractDockerContainer(
             id=self.create_json(create_missing)['id'],
         ).read()
 
-    def power(self, payload):
+    def power(self, synchronous=True, **kwargs):
         """Run a power operation on a container.
 
-        :param payload: Parameters that are encoded to JSON and passed in
-            with the request. See the API documentation page for a list of
-            parameters and their descriptions.
-        :returns: Information about the current state of the container.
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
 
         """
-        response = client.put(
-            self.path(which='power'),
-            payload,
-            **self._server_config.get_client_kwargs()
-        )
-        return _handle_response(response, self._server_config)
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.put(self.path('power'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous)
 
-    def logs(self, payload=None):
+    def logs(self, synchronous=True, **kwargs):
         """Get logs from this container.
 
-        :param payload: Parameters that are encoded to JSON and passed in
-            with the request. See the API documentation page for a list of
-            parameters and their descriptions.
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
         :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
 
         """
-        response = client.get(
-            self.path(which='logs'),
-            data=payload if payload else {},
-            **self._server_config.get_client_kwargs()
-        )
-        return _handle_response(response, self._server_config)
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.get(self.path('logs'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous)
 
 
 class DockerHubContainer(AbstractDockerContainer):

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -3153,20 +3153,21 @@ class SmartProxy(Entity, EntityReadMixin):
             )
         return super(SmartProxy, self).path(which)
 
-    def refresh(self, synchronous=True):
+    def refresh(self, synchronous=True, **kwargs):
         """Refresh Capsule features
 
         :param synchronous: What should happen if the server returns an HTTP
             202 (accepted) status code? Wait for the task to complete if
-            ``True``. Immediately return the server's reponse otherwise.
-        :returns: The server's JSON-decoded response.
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
 
         """
-        response = client.put(
-            self.path('refresh'),
-            {},
-            **self._server_config.get_client_kwargs()
-        )
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.put(self.path('refresh'), **kwargs)
         return _handle_response(response, self._server_config, synchronous)
 
 

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -3360,61 +3360,67 @@ class Subscription(
             organization=payload['organization_id'],
         ).path(which)
 
-    def delete_manifest(self, payload, synchronous=True):
+    def delete_manifest(self, synchronous=True, **kwargs):
         """Delete manifest from Red Hat provider.
 
-        :param payload: Parameters that are encoded to JSON and passed in
-            with the request. See the API documentation page for a list of
-            parameters and their descriptions.
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
         :returns: The server's response, with all JSON decoded.
         :raises: ``requests.exceptions.HTTPError`` If the server responds with
             an HTTP 4XX or 5XX message.
 
         """
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
         response = client.post(
-            self._org_path('delete_manifest', payload),
-            payload,
-            **self._server_config.get_client_kwargs()
+            self._org_path('delete_manifest', kwargs['data']),
+            **kwargs
         )
         return _handle_response(response, self._server_config, synchronous)
 
-    def manifest_history(self, payload, synchronous=True):
+    def manifest_history(self, synchronous=True, **kwargs):
         """Obtain manifest history for subscriptions.
 
-        :param payload: Parameters that are encoded to JSON and passed in
-            with the request. See the API documentation page for a list of
-            parameters and their descriptions.
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
         :returns: The server's response, with all JSON decoded.
         :raises: ``requests.exceptions.HTTPError`` If the server responds with
             an HTTP 4XX or 5XX message.
 
         """
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
         response = client.get(
-            self._org_path('manifest_history', payload),
-            payload,
-            **self._server_config.get_client_kwargs()
+            self._org_path('manifest_history', kwargs['data']),
+            **kwargs
         )
         return _handle_response(response, self._server_config, synchronous)
 
-    def refresh_manifest(self, payload, synchronous=True):
+    def refresh_manifest(self, synchronous=True, **kwargs):
         """Refresh previously imported manifest for Red Hat provider.
 
-        :param payload: Parameters that are encoded to JSON and passed in
-            with the request. See the API documentation page for a list of
-            parameters and their descriptions.
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
         :returns: The server's response, with all JSON decoded.
         :raises: ``requests.exceptions.HTTPError`` If the server responds with
             an HTTP 4XX or 5XX message.
 
         """
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
         response = client.put(
-            self._org_path('refresh_manifest', payload),
-            payload,
-            **self._server_config.get_client_kwargs()
+            self._org_path('refresh_manifest', kwargs['data']),
+            **kwargs
         )
         return _handle_response(response, self._server_config, synchronous)
 
-    def upload(self, payload, manifest, synchronous=True):
+    def upload(self, synchronous=True, **kwargs):
         """Upload a subscription manifest.
 
         Here is an example of how to use this method::
@@ -3422,20 +3428,20 @@ class Subscription(
             with open('my_manifest.zip') as manifest:
                 sub.upload({'organization_id': org.id}, manifest)
 
-        :param payload: Parameters that are encoded to JSON and passed in
-            with the request. See the API documentation page for a list of
-            parameters and their descriptions.
-        :param manifest: A file-like object. The manifest file to upload.
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
         :returns: The server's response, with all JSON decoded.
         :raises: ``requests.exceptions.HTTPError`` If the server responds with
             an HTTP 4XX or 5XX message.
 
         """
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
         response = client.post(
-            self._org_path('upload', payload),
-            payload,
-            files={'content': manifest},
-            **self._server_config.get_client_kwargs()
+            self._org_path('upload', kwargs['data']),
+            **kwargs
         )
         return _handle_response(response, self._server_config, synchronous)
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1082,6 +1082,7 @@ class GenericTestCase(TestCase):
         cls.methods_requests = (
             (entities.ActivationKey(**generic).add_subscriptions, 'put'),
             (entities.ActivationKey(**generic).content_override, 'put'),
+            (entities.ContentViewVersion(**generic).promote, 'post'),
             (entities.DiscoveredHosts(cfg).facts, 'post'),
         )
 
@@ -1193,30 +1194,6 @@ class AbstractDockerContainerTestCase(TestCase):
                 client_get.call_args[1]['data'],
                 payload if payload else {},
             )
-
-
-class ContentViewVersionTestCase(TestCase):
-    """Tests for :class:`nailgun.entities.ContentViewVersion`."""
-
-    def setUp(self):
-        """Set ``self.cvv``."""
-        self.cvv = entities.ContentViewVersion(
-            config.ServerConfig('http://example.com'),
-            id=gen_integer(min_value=1),
-        )
-
-    def test_promote(self):
-        """Call :meth:`nailgun.entities.ContentViewVersion.promote`."""
-        with mock.patch.object(client, 'post') as client_post:
-            with mock.patch.object(entities, '_handle_response') as handler:
-                response = self.cvv.promote({1: 2})
-        self.assertEqual(client_post.call_count, 1)
-        self.assertEqual(handler.call_count, 1)
-        self.assertEqual(handler.return_value, response)
-
-        # This was just executed: client_post(path='…', data={…}, …)
-        # `call_args` is a two-tuple of (positional, keyword) args.
-        self.assertEqual(client_post.call_args[0][1], {1: 2})
 
 
 class ContentViewTestCase(TestCase):

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1089,6 +1089,7 @@ class GenericTestCase(TestCase):
             (entities.ContentView(**generic).publish, 'post'),
             (entities.ContentViewVersion(**generic).promote, 'post'),
             (entities.DiscoveredHosts(cfg).facts, 'post'),
+            (entities.Product(**generic).sync, 'post'),
         )
 
     def test_generic(self):
@@ -1224,26 +1225,6 @@ class HostGroupTestCase(TestCase):
                 'parent_id': None,
             },
         )
-
-
-class ProductTestCase(TestCase):
-    """Tests for :class:`nailgun.entities.Product`."""
-
-    def setUp(self):
-        """Set ``self.product``."""
-        self.product = entities.Product(
-            config.ServerConfig('http://example.com'),
-            id=gen_integer(min_value=1),
-        )
-
-    def test_sync(self):
-        """Call :meth:`nailgun.entities.Product.sync`."""
-        with mock.patch.object(client, 'post') as client_post:
-            with mock.patch.object(entities, '_handle_response') as handler:
-                response = self.product.sync()
-        self.assertEqual(client_post.call_count, 1)
-        self.assertEqual(handler.call_count, 1)
-        self.assertEqual(response, handler.return_value)
 
 
 class RepositoryTestCase(TestCase):

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1096,6 +1096,7 @@ class GenericTestCase(TestCase):
             (entities.RepositorySet(**repo_set).available_repositories, 'get'),
             (entities.RepositorySet(**repo_set).disable, 'put'),
             (entities.RepositorySet(**repo_set).enable, 'put'),
+            (entities.SmartProxy(**generic).refresh, 'put'),
         )
 
     def test_generic(self):
@@ -1310,26 +1311,6 @@ class RepositorySetTestCase(TestCase):
         for result in s_n.call_args[0][0]:
             # pylint:disable=no-member
             self.assertEqual(result['product_id'], self.product.id)
-
-
-class SmartProxyTestCase(TestCase):
-    """Tests for :class:`nailgun.entities.SmartProxy`."""
-
-    def setUp(self):
-        """Set ``self.proxy``."""
-        self.proxy = entities.SmartProxy(
-            config.ServerConfig('http://example.com'),
-            id=gen_integer(min_value=1),
-        )
-
-    def test_refresh(self):
-        """Call :meth:`nailgun.entities.SmartProxy.refresh`."""
-        with mock.patch.object(client, 'put') as client_put:
-            with mock.patch.object(entities, '_handle_response') as handler:
-                response = self.proxy.refresh()
-        self.assertEqual(client_put.call_count, 1)
-        self.assertEqual(handler.call_count, 1)
-        self.assertEqual(handler.return_value, response)
 
 
 class SubscriptionTestCase(TestCase):

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1091,6 +1091,7 @@ class GenericTestCase(TestCase):
             (entities.ContentViewVersion(**generic).promote, 'post'),
             (entities.DiscoveredHosts(cfg).facts, 'post'),
             (entities.Product(**generic).sync, 'post'),
+            (entities.RHCIDeployment(**generic).deploy, 'put'),
             (entities.Repository(**generic).sync, 'post'),
             (entities.RepositorySet(**repo_set).available_repositories, 'get'),
             (entities.RepositorySet(**repo_set).disable, 'put'),
@@ -1309,30 +1310,6 @@ class RepositorySetTestCase(TestCase):
         for result in s_n.call_args[0][0]:
             # pylint:disable=no-member
             self.assertEqual(result['product_id'], self.product.id)
-
-
-class RHCIDeploymentTestCase(TestCase):
-    """Tests for :class:`nailgun.entities.RHCIDeployment`."""
-
-    def setUp(self):
-        """Set ``self.rhci_deployment``."""
-        self.rhci_deployment = entities.RHCIDeployment(
-            config.ServerConfig('http://example.com'),
-            id=gen_integer(min_value=1),
-        )
-
-    def test_deploy(self):
-        """Call :meth:`nailgun.entities.RHCIDeployment.deploy`."""
-        with mock.patch.object(client, 'put') as client_put:
-            with mock.patch.object(entities, '_handle_response') as handler:
-                payload = {'foo': gen_integer()}
-                response = self.rhci_deployment.deploy(payload)
-        self.assertEqual(client_put.call_count, 1)
-        self.assertEqual(handler.call_count, 1)
-        self.assertEqual(handler.return_value, response)
-
-        # `call_args` is a two-tuple of (positional, keyword) args.
-        self.assertEqual(client_put.call_args[0][1], payload)
 
 
 class SmartProxyTestCase(TestCase):

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1084,6 +1084,9 @@ class GenericTestCase(TestCase):
             (entities.AbstractDockerContainer(**generic).power, 'put'),
             (entities.ActivationKey(**generic).add_subscriptions, 'put'),
             (entities.ActivationKey(**generic).content_override, 'put'),
+            (entities.ContentView(**generic).available_puppet_modules, 'get'),
+            (entities.ContentView(**generic).copy, 'post'),
+            (entities.ContentView(**generic).publish, 'post'),
             (entities.ContentViewVersion(**generic).promote, 'post'),
             (entities.DiscoveredHosts(cfg).facts, 'post'),
         )
@@ -1153,63 +1156,6 @@ class AbstractDockerContainerTestCase(TestCase):
         for attr in ['repository_name', 'tag']:
             self.assertIn(attr, docker_hub)
             self.assertNotIn(attr, abstract_docker)
-
-
-class ContentViewTestCase(TestCase):
-    """Tests for :class:`nailgun.entities.ContentView`."""
-
-    def setUp(self):
-        """Set ``self.content_view``."""
-        self.content_view = entities.ContentView(
-            config.ServerConfig('http://example.com'),
-            id=gen_integer(min_value=1),
-        )
-
-    def test_publish(self):
-        """Call :meth:`nailgun.entities.ContentView.publish`."""
-        for payload in (
-                None,
-                {},
-                {1: 2},
-        ):
-            with mock.patch.object(entities, '_handle_response') as handler:
-                with mock.patch.object(client, 'post') as client_post:
-                    response = self.content_view.publish(payload)
-            self.assertEqual(client_post.call_count, 1)
-            self.assertEqual(handler.call_count, 1)
-            self.assertEqual(handler.return_value, response)
-
-        # This was just executed: client_post(path='…', data={…}, …)
-        # `call_args` is a two-tuple of (positional, keyword) args.
-        self.assertEqual(
-            client_post.call_args[0][1],
-            {1: 2, 'id': self.content_view.id}  # pylint:disable=no-member
-        )
-
-    def test_available_puppet_modules(self):
-        """Run :meth:`nailgun.entities.ContentView.available_puppet_modules`"""
-        with mock.patch.object(client, 'get') as client_get:
-            with mock.patch.object(entities, '_handle_response') as handler:
-                response = self.content_view.available_puppet_modules()
-        self.assertEqual(client_get.call_count, 1)
-        self.assertEqual(handler.call_count, 1)
-        self.assertEqual(handler.return_value, response)
-
-    def test_copy(self):
-        """Call :meth:`nailgun.entities.ContentView.copy`."""
-        with mock.patch.object(client, 'post') as client_post:
-            with mock.patch.object(entities, '_handle_response') as handler:
-                response = self.content_view.copy({1: 2})
-        self.assertEqual(client_post.call_count, 1)
-        self.assertEqual(handler.call_count, 1)
-        self.assertEqual(handler.return_value, response)
-
-        # This was just executed: client_post(path='…', data={…}, …)
-        # `call_args` is a two-tuple of (positional, keyword) args.
-        self.assertEqual(
-            client_post.call_args[0][1],
-            {1: 2, 'id': self.content_view.id}  # pylint:disable=no-member
-        )
 
 
 class ForemanTaskTestCase(TestCase):

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1080,6 +1080,8 @@ class GenericTestCase(TestCase):
         cfg = config.ServerConfig('http://example.com')
         generic = {'server_config': cfg, 'id': 1}
         cls.methods_requests = (
+            (entities.ActivationKey(**generic).add_subscriptions, 'put'),
+            (entities.ActivationKey(**generic).content_override, 'put'),
         )
 
     def test_generic(self):
@@ -1109,6 +1111,7 @@ class GenericTestCase(TestCase):
                 self.assertEqual(client_request.call_args[1], kwargs)
                 self.assertEqual(handlr.call_count, 1)
                 self.assertEqual(handlr.return_value, response)
+
 
 class AbstractDockerContainerTestCase(TestCase):
     """Tests for :class:`nailgun.entities.AbstractDockerContainer`."""
@@ -1189,44 +1192,6 @@ class AbstractDockerContainerTestCase(TestCase):
                 client_get.call_args[1]['data'],
                 payload if payload else {},
             )
-
-
-class ActivationKeyTestCase(TestCase):
-    """Tests for :class:`nailgun.entities.ActivationKey`."""
-
-    def setUp(self):
-        """Set ``self.activation_key``."""
-        self.activation_key = entities.ActivationKey(
-            config.ServerConfig('http://example.com'),
-            id=gen_integer(min_value=1),
-        )
-
-    def test_add_subscriptions(self):
-        """Call :meth:`nailgun.entities.ActivationKey.add_subscriptions`."""
-        with mock.patch.object(client, 'put') as client_put:
-            with mock.patch.object(entities, '_handle_response') as handler:
-                response = self.activation_key.add_subscriptions({1: 2})
-        self.assertEqual(client_put.call_count, 1)
-        self.assertEqual(handler.call_count, 1)
-        self.assertEqual(handler.return_value, response)
-
-        # This was just executed: client_put(path='…', data={…}, …)
-        # `call_args` is a two-tuple of (positional, keyword) args.
-        self.assertEqual(client_put.call_args[0][1], {1: 2})
-
-    def test_content_override(self):
-        """Call :meth:`nailgun.entities.ActivationKey.content_override`."""
-        with mock.patch.object(client, 'put') as client_put:
-            with mock.patch.object(entities, '_handle_response') as handler:
-                payload = gen_integer()
-                response = self.activation_key.content_override(payload)
-        self.assertEqual(client_put.call_count, 1)
-        self.assertEqual(handler.call_count, 1)
-        self.assertEqual(handler.return_value, response)
-
-        # This was just executed: client_put(path='…', data={…}, …)
-        # `call_args` is a two-tuple of (positional, keyword) args.
-        self.assertEqual(client_put.call_args[0][1], payload)
 
 
 class DiscoveredHostsTestCase(TestCase):

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1080,6 +1080,7 @@ class GenericTestCase(TestCase):
         cfg = config.ServerConfig('http://example.com')
         generic = {'server_config': cfg, 'id': 1}
         repo_set = {'server_config': cfg, 'id': 1, 'product': 2}
+        sync_plan = {'server_config': cfg, 'id': 1, 'organization': 2}
         cls.methods_requests = (
             (entities.AbstractDockerContainer(**generic).logs, 'get'),
             (entities.AbstractDockerContainer(**generic).power, 'put'),
@@ -1097,6 +1098,8 @@ class GenericTestCase(TestCase):
             (entities.RepositorySet(**repo_set).disable, 'put'),
             (entities.RepositorySet(**repo_set).enable, 'put'),
             (entities.SmartProxy(**generic).refresh, 'put'),
+            (entities.SyncPlan(**sync_plan).add_products, 'put'),
+            (entities.SyncPlan(**sync_plan).remove_products, 'put'),
         )
 
     def test_generic(self):
@@ -1380,36 +1383,6 @@ class SubscriptionTestCase(TestCase):
                 self.assertEqual(handlr.return_value, response)
                 self.assertEqual(org_path.call_count, 1)
                 self.assertEqual(org_path.call_args[0][1], kwargs['data'])
-
-
-class SyncPlanTestCase(TestCase):
-    """Tests for :class:`nailgun.entities.SyncPlan`."""
-
-    def setUp(self):
-        """Set ``self.sync_plan``."""
-        self.sync_plan = entities.SyncPlan(
-            config.ServerConfig('http://example.com'),
-            id=gen_integer(min_value=1),
-            organization=gen_integer(min_value=1),
-        )
-
-    def test_add_products(self):
-        """Call :meth:`nailgun.entities.SyncPlan.add_products`."""
-        with mock.patch.object(client, 'put') as client_put:
-            with mock.patch.object(entities, '_handle_response') as handler:
-                response = self.sync_plan.add_products({1: 2})
-        self.assertEqual(client_put.call_count, 1)
-        self.assertEqual(handler.call_count, 1)
-        self.assertEqual(handler.return_value, response)
-
-    def test_remove_products(self):
-        """Call :meth:`nailgun.entities.SyncPlan.remove_products`."""
-        with mock.patch.object(client, 'put') as client_put:
-            with mock.patch.object(entities, '_handle_response') as handler:
-                response = self.sync_plan.remove_products({1: 2})
-        self.assertEqual(client_put.call_count, 1)
-        self.assertEqual(handler.call_count, 1)
-        self.assertEqual(handler.return_value, response)
 
 
 # 3. Other tests. -------------------------------------------------------- {{{1

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1079,6 +1079,7 @@ class GenericTestCase(TestCase):
         """
         cfg = config.ServerConfig('http://example.com')
         generic = {'server_config': cfg, 'id': 1}
+        repo_set = {'server_config': cfg, 'id': 1, 'product': 2}
         cls.methods_requests = (
             (entities.AbstractDockerContainer(**generic).logs, 'get'),
             (entities.AbstractDockerContainer(**generic).power, 'put'),
@@ -1091,6 +1092,9 @@ class GenericTestCase(TestCase):
             (entities.DiscoveredHosts(cfg).facts, 'post'),
             (entities.Product(**generic).sync, 'post'),
             (entities.Repository(**generic).sync, 'post'),
+            (entities.RepositorySet(**repo_set).available_repositories, 'get'),
+            (entities.RepositorySet(**repo_set).disable, 'put'),
+            (entities.RepositorySet(**repo_set).enable, 'put'),
         )
 
     def test_generic(self):
@@ -1296,36 +1300,6 @@ class RepositorySetTestCase(TestCase):
             id=gen_integer(min_value=1),
             product=self.product,
         )
-
-    def test_available_repositories(self):
-        """Call
-        :meth:`nailgun.entities.RepositorySet.available_repositories`
-
-        """
-        with mock.patch.object(client, 'get') as client_get:
-            with mock.patch.object(entities, '_handle_response') as handler:
-                response = self.reposet.available_repositories()
-        self.assertEqual(client_get.call_count, 1)
-        self.assertEqual(handler.call_count, 1)
-        self.assertEqual(handler.return_value['results'], response)
-
-    def test_enable(self):
-        """Call :meth:`nailgun.entities.RepositorySet.enable`"""
-        with mock.patch.object(client, 'put') as client_put:
-            with mock.patch.object(entities, '_handle_response') as handler:
-                response = self.reposet.enable({1: 2})
-        self.assertEqual(client_put.call_count, 1)
-        self.assertEqual(handler.call_count, 1)
-        self.assertEqual(handler.return_value, response)
-
-    def test_disable(self):
-        """Call :meth:`nailgun.entities.RepositorySet.disable`"""
-        with mock.patch.object(client, 'put') as client_put:
-            with mock.patch.object(entities, '_handle_response') as handler:
-                response = self.reposet.disable({1: 2})
-        self.assertEqual(client_put.call_count, 1)
-        self.assertEqual(handler.call_count, 1)
-        self.assertEqual(handler.return_value, response)
 
     def test_search_normalize(self):
         """Call :meth:`nailgun.entities.RepositorySet.search_normalize`"""

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -14,14 +14,14 @@ from nailgun.entity_mixins import (
 import mock
 
 from sys import version_info
-if version_info.major == 2:
-    from httplib import ACCEPTED, NO_CONTENT  # pylint:disable=import-error
-else:
-    from http.client import ACCEPTED, NO_CONTENT  # pylint:disable=import-error
 if version_info < (3, 4):
     from unittest2 import TestCase  # pylint:disable=import-error
 else:
     from unittest import TestCase
+if version_info.major == 2:
+    from httplib import ACCEPTED, NO_CONTENT  # pylint:disable=import-error
+else:
+    from http.client import ACCEPTED, NO_CONTENT  # pylint:disable=import-error
 
 # pylint:disable=too-many-lines
 # The size of this file is a direct reflection of the size of module

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1082,6 +1082,7 @@ class GenericTestCase(TestCase):
         cls.methods_requests = (
             (entities.ActivationKey(**generic).add_subscriptions, 'put'),
             (entities.ActivationKey(**generic).content_override, 'put'),
+            (entities.DiscoveredHosts(cfg).facts, 'post'),
         )
 
     def test_generic(self):
@@ -1192,28 +1193,6 @@ class AbstractDockerContainerTestCase(TestCase):
                 client_get.call_args[1]['data'],
                 payload if payload else {},
             )
-
-
-class DiscoveredHostsTestCase(TestCase):
-    """Tests for :class:`nailgun.entities.DiscoveredHosts`."""
-
-    def setUp(self):
-        """Set ``self.discovered_hosts``."""
-        self.discovered_hosts = entities.DiscoveredHosts(
-            config.ServerConfig('http://example.com'),
-            id=gen_integer(min_value=1),
-        )
-
-    def test_facts(self):
-        """Call :meth:`nailgun.entities.DiscoveredHosts.facts`."""
-        with mock.patch.object(client, 'post') as client_post:
-            with mock.patch.object(entities, '_handle_response') as handler:
-                payload = gen_integer()
-                response = self.discovered_hosts.facts(payload)
-        self.assertEqual(client_post.call_count, 1)
-        self.assertEqual(client_post.call_args[0][1], payload)
-        self.assertEqual(handler.call_count, 1)
-        self.assertEqual(handler.return_value, response)
 
 
 class ContentViewVersionTestCase(TestCase):


### PR DESCRIPTION
There are two kinds of methods on entities:

* Methods inherited from a mixin. For example, `ActivationKey.create` is
  inherited from the `EntityCreateMixin`.
* Methods defined on that entity, such as `ActivationKey.add_subscriptions`.

The latter set of methods was recently overhauled to make them more uniform. The
methods are now named after the path they call, they are placed on the correct
entities, and their signatures are very similar. However, there are still
differences. Some methods provide default values for their arguments; some
require a second argument; some require only one argument but of a different
kind than others; and so on. This is bad for several reasons:

* It is hard to learn the various methods. A user has to look at the signature
  of each individual method and figure out exactly what arguments it requires.
  This significantly raises the conceptual weight of the methods.
* It is hard to design the various methods. A developer has to spend time
  examining the API docs for the method call to figure out what information the
  API requires, the developer has to reference a variety of other helper methods
  to see which implementation should be copied, and so on.
* Tests for the various methods are not quite the same. This means that there's
  a lot of copy-cat code in the unit test suite.

Design a method signature that addresses these issues. It is an approach that
was not discussed in SatelliteQE/nailgun#41. Here are some examples of method
calls before the change:

    # ActivationKey.add_subscriptions
    activation_key.add_subscriptions({
        'quantity': 1,
        'subscription_id': subs.id,
    })

    # Subscription.upload
    with open(manifests.clone(), 'rb') as manifest:
        sub.upload({'organization_id': org.id}, manifest)

And after the change:

    # ActivationKey.add_subscriptions
    activation_key.add_subscriptions(data={
        'quantity': 1,
        'subscription_id': subs.id,
    })

    # Subscription.upload
    with open(manifests.clone(), 'rb') as handle:
        sub.upload(data={'organization_id': org.id}, files={'content': handle})

The updated approach is more verbose, but it's utterly uniform. All methods have
a signature like so:

    def method_name(self, synchronous=True, **kwargs):

All of the `**kwargs` are passed directly to `nailgun.client` before a call is
made. As a result, clients using one of the helper methods can access the full
power of `nailgun.client`/`requests`!
