### PR TITLE
Fix typing issue

### DIFF
--- a/nailgun/config.py
+++ b/nailgun/config.py
@@ -156,9 +156,9 @@ class BaseServerConfig(object):
         :param path: A string. The configuration file to be manipulated.
             Defaults to what is returned by
             :func:`nailgun.config._get_config_file_path`.
-        :returns: A brand new :class:`nailgun.config.ServerConfig` object whose
-            attributes have been populated as appropriate.
-        :rtype: ServerConfig
+        :returns: A brand new :class:`nailgun.config.BaseServerConfig` object
+            whose attributes have been populated as appropriate.
+        :rtype: BaseServerConfig
 
         """
         if path is None:
@@ -167,7 +167,7 @@ class BaseServerConfig(object):
                 cls._xdg_config_file
             )
         with open(path) as config_file:
-            return ServerConfig(**json.load(config_file)[label])
+            return cls(**json.load(config_file)[label])
 
     @classmethod
     def get_labels(cls, path=None):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -73,6 +73,7 @@ class BaseServerConfigTestCase(TestCase):
             open_ = mock_open(read_data=json.dumps(CONFIGS))
             with patch.object(builtins, 'open', open_):
                 server_config = BaseServerConfig.get(label, FILE_PATH)
+            self.assertEqual(type(server_config), BaseServerConfig)
             open_.assert_called_once_with(FILE_PATH)
             _compare_configs(self, config, server_config)
             if hasattr(server_config, 'auth'):
@@ -183,6 +184,7 @@ class ServerConfigTestCase(TestCase):
             open_ = mock_open(read_data=json.dumps(CONFIGS))
             with patch.object(builtins, 'open', open_):
                 server_config = ServerConfig.get(label, FILE_PATH)
+            self.assertEqual(type(server_config), ServerConfig)
             if hasattr(server_config, 'auth'):
                 self.assertIsInstance(server_config.auth, tuple)
 


### PR DESCRIPTION
`BaseServerConfig.get` returns an object of type `ServerConfig`. This is
ridiculous. A parent class should never return a sub-class. Before the fix:

```python
>>> from nailgun.config import BaseServerConfig, ServerConfig
>>> path = '/home/ichimonji10/.config/nailgun/server_configs.json'
>>> for cls in (BaseServerConfig, ServerConfig):
...     print(type(cls.get('junk', path=path)))
...
<class 'nailgun.config.ServerConfig'>
<class 'nailgun.config.ServerConfig'>
```

After the fix:

```python
>>> from nailgun.config import BaseServerConfig, ServerConfig
>>> path = '/home/ichimonji10/.config/nailgun/server_configs.json'
>>> for cls in (BaseServerConfig, ServerConfig):
...     print(type(cls.get('junk', path=path)))
...
<class 'nailgun.config.BaseServerConfig'>
<class 'nailgun.config.ServerConfig'>
```