### PR TITLE
Change BaseServerConfig and ServerConfig classes

### DIFF
--- a/nailgun/config.py
+++ b/nailgun/config.py
@@ -254,6 +254,8 @@ class ServerConfig(BaseServerConfig):
     _xdg_config_file = 'server_configs.json'
 
     def __init__(self, url, auth=None, version=None, verify=None):
+        if version is None:
+            version = '1!0'
         super(ServerConfig, self).__init__(url, auth, version)
         if verify is not None:
             self.verify = verify

--- a/nailgun/config.py
+++ b/nailgun/config.py
@@ -108,13 +108,16 @@ class BaseServerConfig(object):
             self.version = parse(version)
 
     def __repr__(self):
+        attrs = vars(self).copy()
+        if 'version' in attrs:
+            attrs['version'] = str(attrs.pop('version'))
         return '{0}.{1}({2})'.format(
             self.__module__,
             type(self).__name__,
             ', '.join(
                 '{0}={1}'.format(key, repr(value))
                 for key, value
-                in vars(self).items()
+                in attrs.items()
             )
         )
 

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -167,27 +167,6 @@ def _get_org(server_config, label):
     return organizations[0].read()
 
 
-def _get_version(server_config):
-    """Return ``server_config.version``, or a default version if not present.
-
-    This method is especially useful when an entity must determine what version
-    the server is. :class:`nailgun.config.ServerConfig` does not currently
-    require the "version" attribute, and if none is provided then none is set.
-    This is often problematic - what version should the server be assumed to be
-    running? This method provides an answer to that question.
-
-    Also see #163.
-
-    :param nailgun.config.ServerConfig server_config: Any old server config may
-        be passed in.
-    :returns: A ``packaging.version.Version`` object. The version on
-        ``server_config`` is returned if present, or a default version of '1!0'
-        (epoch 1, version 0) otherwise.
-
-    """
-    return getattr(server_config, 'version', Version('1!0'))
-
-
 class ActivationKey(
         Entity,
         EntityCreateMixin,
@@ -1269,7 +1248,7 @@ class ContentView(
         <https://bugzilla.redhat.com/show_bug.cgi?id=1237257>`_.
 
         """
-        if _get_version(self._server_config) < Version('6.1'):
+        if self._server_config.version < Version('6.1'):
             if attrs is None:
                 attrs = self.read_json()
             org = _get_org(self._server_config, attrs['organization']['label'])
@@ -1698,7 +1677,7 @@ class HostGroup(
             'realm': entity_fields.OneToOneField(Realm),
             'subnet': entity_fields.OneToOneField(Subnet),
         }
-        if _get_version(server_config) >= Version('6.1'):
+        if server_config.version >= Version('6.1'):
             self._fields.update({
                 'content_view': entity_fields.OneToOneField(ContentView),
                 'lifecycle_environment': entity_fields.OneToOneField(
@@ -1731,7 +1710,7 @@ class HostGroup(
             attrs = self.read_json()
         attrs['parent_id'] = attrs.pop('ancestry')  # either an ID or None
         # `version` is a single-use var, but it is used anyway for readability.
-        if _get_version(self._server_config) >= Version('6.1'):
+        if self._server_config.version >= Version('6.1'):
             # We cannot call `self.update_json([])`, as an ID might not be
             # present on self. However, `attrs` is guaranteed to have an ID.
             attrs2 = HostGroup(
@@ -2001,7 +1980,7 @@ class LifecycleEnvironment(
 
         """
         payload = super(LifecycleEnvironment, self).create_payload()
-        if (_get_version(self._server_config) < Version('6.1') and
+        if (self._server_config.version < Version('6.1') and
                 'prior_id' in payload):
             payload['prior'] = payload.pop('prior_id')
         return payload
@@ -2355,7 +2334,7 @@ class Organization(
             'title': entity_fields.StringField(),
             'user': entity_fields.OneToManyField(User),
         }
-        if _get_version(server_config) >= Version('6.1.1'):  # default: True
+        if server_config.version >= Version('6.1.1'):  # default: True
             self._fields.update({
                 'default_content_view': entity_fields.OneToOneField(
                     ContentView
@@ -2568,7 +2547,7 @@ class Product(
         <https://bugzilla.redhat.com/show_bug.cgi?id=1237283>`_.
 
         """
-        if _get_version(self._server_config) < Version('6.1'):
+        if self._server_config.version < Version('6.1'):
             if attrs is None:
                 attrs = self.read_json()
             org = _get_org(self._server_config, attrs['organization']['label'])
@@ -2741,7 +2720,7 @@ class Repository(
                 required=True,
             ),
         }
-        if _get_version(server_config) < Version('6.1'):
+        if server_config.version < Version('6.1'):
             # Adjust for Satellite 6.0
             del self._fields['docker_upstream_name']
             self._fields['content_type'].choices = (tuple(
@@ -3220,7 +3199,7 @@ class Subnet(
             'to': entity_fields.IPAddressField(),
             'vlanid': entity_fields.StringField(),
         }
-        if _get_version(server_config) >= Version('6.1'):
+        if server_config.version >= Version('6.1'):
             self._fields.update({
                 'boot_mode': entity_fields.StringField(
                     choices=('Static', 'DHCP',),


### PR DESCRIPTION
There are two commits in this PR. They're logically separate, but I'm bundling them together for expediency. I can submit two separate PRs if people like. Summary of changes:

* Make `BaseServerConfig.__repr__` encode the `version` attribute in a more sane manner.
* Make `ServerConfig` set a default version is none is passed in.

I expect this will be the last set of changes before I release version 0.21.0 and mark NailGun as beta quality.