### PR TITLE
Add search mixin to DiscoveryRule and HostGroup

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -648,6 +648,7 @@ class DiscoveryRule(
         EntityCreateMixin,
         EntityDeleteMixin,
         EntityReadMixin,
+        EntitySearchMixin,
         EntityUpdateMixin):
     """A representation of a Foreman Discovery Rule entity."""
 
@@ -1728,6 +1729,7 @@ class HostGroup(
         EntityCreateMixin,
         EntityDeleteMixin,
         EntityReadMixin,
+        EntitySearchMixin,
         EntityUpdateMixin):
     """A representation of a Host Group entity."""
 


### PR DESCRIPTION
Inspired by #182. Manual verification shows that this works:

    >>> from nailgun.entities import HostGroup, DiscoveryRule
    >>> host_groups = HostGroup().search()
    >>> discovery_rules = DiscoveryRule().search()
    >>> len(host_groups), len(discovery_rules)
    (11, 1)
    >>> all((isinstance(host_group, HostGroup) for host_group in host_groups))
    True
    >>> isinstance(discovery_rules[0], DiscoveryRule)
    True