### PR TITLE
updated search mixin for various entities

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -307,6 +307,7 @@ class Architecture(
         EntityCreateMixin,
         EntityDeleteMixin,
         EntityReadMixin,
+        EntitySearchMixin,
         EntityUpdateMixin):
     """A representation of a Architecture entity."""
 
@@ -791,6 +792,7 @@ class ConfigTemplate(
         EntityCreateMixin,
         EntityDeleteMixin,
         EntityReadMixin,
+        EntitySearchMixin,
         EntityUpdateMixin):
     """A representation of a Config Template entity."""
 
@@ -1458,6 +1460,7 @@ class Domain(
         EntityCreateMixin,
         EntityDeleteMixin,
         EntityReadMixin,
+        EntitySearchMixin,
         EntityUpdateMixin):
     """A representation of a Domain entity."""
 
@@ -2188,7 +2191,11 @@ class Location(
 
 
 class Media(
-        Entity, EntityCreateMixin, EntityDeleteMixin, EntityReadMixin):
+        Entity,
+        EntityCreateMixin,
+        EntityDeleteMixin,
+        EntityReadMixin,
+        EntitySearchMixin):
     """A representation of a Media entity.
 
     .. NOTE:: The ``path_`` field is named as such due to a naming conflict
@@ -2665,6 +2672,7 @@ class PartitionTable(
         EntityCreateMixin,
         EntityDeleteMixin,
         EntityReadMixin,
+        EntitySearchMixin,
         EntityUpdateMixin):
     """A representation of a Partition Table entity.
 
@@ -3190,7 +3198,7 @@ class Role(
         super(Role, self).__init__(server_config, **kwargs)
 
 
-class SmartProxy(Entity, EntityReadMixin):
+class SmartProxy(Entity, EntityReadMixin, EntitySearchMixin):
     """A representation of a Smart Proxy entity."""
 
     def __init__(self, server_config=None, **kwargs):


### PR DESCRIPTION
I need to this to validate and search some of the entities those are configured by default for configuring a hostgroup.

```
In [3]: arch = entities.Architecture(server_config).search(query={u'search': u'name="x86_64"'})
In [4]: arch[0].id
Out[4]: 1
```

```
In [5]: template1 = entities.ConfigTemplate(server_config).search(query={u'search': u'name="Satellite Kickstart Template"'})
In [6]: template1[0].id
Out[6]: 31
```

```
In [7]: domain = entities.Domain(server_config).search(query={u'search': u'name="idmqe.lab.eng.bos.redhat.com"'})
In [8]: domain[0].name
Out[8]: u'idmqe.lab.eng.bos.redhat.com'
```

```
In [9]: ptable = entities.PartitionTable(server_config).search(query={u'search': u'name="Kickstart default"'})
In [10]: ptable[0].id
Out[10]: 7
```
