### PR TITLE
Work around BZ 1257255

### DIFF
--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -790,11 +790,11 @@ class ReadTestCase(TestCase):
 
         """
         for entity in (
+                # entities.DiscoveryRule,  # see test_discovery_rule
                 # entities.DockerComputeResource,  # see test_attrs_arg_v2
                 # entities.HostGroup,  # see HostGroupTestCase.test_read
                 # entities.Product,  # See Product.test_read
                 # entities.UserGroup,  # see test_attrs_arg_v2
-                entities.DiscoveryRule,
                 entities.Domain,
                 entities.Host,
                 entities.Media,
@@ -931,6 +931,22 @@ class ReadTestCase(TestCase):
                     entities.User(self.cfg).read(ignore=input_ignore)
                 # `call_args` is a two-tuple of (positional, keyword) args.
                 self.assertEqual(actual_ignore, read.call_args[0][2])
+
+    def test_discovery_rule(self):
+        """Call :meth:`nailgun.entities.DiscoveryRule.read`.
+
+        Ensure that the ``max_count`` attribute is fetched.
+
+        """
+        with mock.patch.object(EntityUpdateMixin, 'update_json') as u_json:
+            u_json.return_value = {'max_count': 'max_count'}
+            with mock.patch.object(EntityReadMixin, 'read_json') as read_json:
+                read_json.return_value = {'id': 'id', 'search': 'search'}
+                with mock.patch.object(EntityReadMixin, 'read') as read:
+                    entities.DiscoveryRule(self.cfg).read()
+        for mock_obj in (u_json, read_json, read):
+            self.assertEqual(mock_obj.call_count, 1)
+        self.assertEqual(u_json.call_args, mock.call([]))
 
 
 class SearchRawTestCase(TestCase):


### PR DESCRIPTION
According to the bug:

> An HTTP GET /api/v2/discovery_rules/:id returns a hash of information about a
> discovery rule. The "max_count" key is missing from this hash.

Work around this issue. When `DiscoveryRule.read` is called, submit a no-op PUT
request and fetch the `max_count` attribute from the response. Test the change.
See: https://bugzilla.redhat.com/show_bug.cgi?id=1257255

Test results from Robottelo:

    $ nosetests tests/foreman/api/test_multiple_paths.py -m DiscoveryRule
    ..........S
    ----------------------------------------------------------------------
    Ran 11 tests in 14.982s

    OK (SKIP=1)
    $ nosetests tests/foreman/api/test_discoveryrule.py
    ..........
    ----------------------------------------------------------------------
    Ran 10 tests in 10.777s

    OK