### PR TITLE
Adding new 'registry' entity

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2769,6 +2769,44 @@ class Realm(
         ).read()
 
 
+class Registry(
+        Entity,
+        EntityCreateMixin,
+        EntityDeleteMixin,
+        EntityReadMixin,
+        EntityUpdateMixin):
+    """A representation of a Registry entity."""
+
+    def __init__(self, server_config=None, **kwargs):
+        self._fields = {
+            'description': entity_fields.StringField(),
+            'name': entity_fields.StringField(required=True),
+            'password': entity_fields.StringField(),
+            'url': entity_fields.StringField(required=True),
+            'username': entity_fields.StringField(),
+        }
+        self._meta = {
+            'api_path': 'docker/api/v2/registries',
+            'server_modes': ('sat'),
+        }
+        super(Registry, self).__init__(server_config, **kwargs)
+
+    def create_payload(self):
+        """Wrap submitted data within an extra dict.
+
+        For more information, see `Bugzilla #1151220
+        <https://bugzilla.redhat.com/show_bug.cgi?id=1151220>`_.
+
+        """
+        return {
+            u'registry': super(Registry, self).create_payload()
+        }
+
+    def update_payload(self, fields=None):
+        """Wrap submitted data within an extra dict."""
+        return {u'registry': super(Registry, self).update_payload(fields)}
+
+
 class Report(Entity):
     """A representation of a Report entity."""
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -131,6 +131,7 @@ class InitTestCase(TestCase):
                 entities.PuppetModule,
                 entities.RPMContentViewFilter,
                 entities.Realm,
+                entities.Registry,
                 entities.Report,
                 entities.Repository,
                 entities.Role,
@@ -486,6 +487,7 @@ class CreatePayloadTestCase(TestCase):
                 entities.Location,
                 entities.Media,
                 entities.OperatingSystem,
+                entities.Registry,
                 entities.Subnet,
                 entities.User,
                 entities.UserGroup,
@@ -1039,6 +1041,7 @@ class UpdatePayloadTestCase(TestCase):
             (entities.HostGroup, {'hostgroup': {}}),
             (entities.Location, {'location': {}}),
             (entities.Organization, {'organization': {}}),
+            (entities.Registry, {'registry': {}}),
             (entities.User, {'user': {}}),
         ]
         for entity, payload in entities_payloads:


### PR DESCRIPTION
After recent fix for https://bugzilla.redhat.com/show_bug.cgi?id=1206679 defect, it become possible to add one more entity to API