### PR TITLE
Make 'nailgun.entity_fields.URLField.gen_value' method always generates unique value

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -22,7 +22,7 @@ workings of entity classes.
 
 """
 from datetime import datetime
-from fauxfactory import gen_alpha, gen_alphanumeric, gen_url
+from fauxfactory import gen_alphanumeric
 from nailgun import client, entity_fields
 from nailgun.entity_mixins import (
     Entity,
@@ -1496,9 +1496,9 @@ class Domain(
     def create_missing(self):
         """Customize the process of auto-generating instance attributes.
 
-        By default, :meth:`nailgun.entity_fields.URLField.gen_value` does not
-        return especially unique values. This is problematic, as all domain
-        names must be unique.
+        By default, :meth:`nailgun.entity_fields.StringField.gen_value` can
+        produce strings in both lower and upper cases, but domain name should
+        be always in lower case due logical reason.
 
         """
         if not hasattr(self, 'name'):
@@ -2244,18 +2244,6 @@ class Media(
         }
         self._meta = {'api_path': 'api/v2/media', 'server_modes': ('sat')}
         super(Media, self).__init__(server_config, **kwargs)
-
-    def create_missing(self):
-        """Give the ``path_`` instance attribute a value if it is unset.
-
-        By default, :meth:`nailgun.entity_fields.URLField.gen_value` does not
-        return especially unique values. This is problematic, as all media must
-        have a unique path.
-
-        """
-        if not hasattr(self, 'path_'):
-            self.path_ = gen_url(subdomain=gen_alpha())
-        return super(Media, self).create_missing()
 
     def create_payload(self):
         """Wrap submitted data within an extra dict and rename ``path_``.

--- a/nailgun/entity_fields.py
+++ b/nailgun/entity_fields.py
@@ -19,6 +19,7 @@ unpleasant to work with manually.
 
 """
 from fauxfactory import (
+    gen_alpha,
     gen_boolean,
     gen_choice,
     gen_date,
@@ -265,4 +266,4 @@ class URLField(StringField):
 
     def gen_value(self):
         """Return a value suitable for a :class:`URLField`."""
-        return gen_url()
+        return gen_url(subdomain=gen_alpha())

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -715,23 +715,6 @@ class CreateMissingTestCase(TestCase):
                 with self.assertRaises(entities.APIResponseError):
                     entity.create_missing()
 
-    def test_media_v1(self):
-        """Test ``Media()``."""
-        entity = entities.Media(self.cfg)
-        with mock.patch.object(EntityCreateMixin, 'create_raw'):
-            with mock.patch.object(EntityReadMixin, 'read_raw'):
-                entity.create_missing()
-        self.assertTrue('path_' in entity.get_values())
-
-    def test_media_v2(self):
-        """Test ``Media(path_=…)``."""
-        path = gen_string('alphanumeric')
-        entity = entities.Media(self.cfg, path_=path)
-        with mock.patch.object(EntityCreateMixin, 'create_raw'):
-            with mock.patch.object(EntityReadMixin, 'read_raw'):
-                entity.create_missing()
-        self.assertEqual(entity.path_, path)
-
     def test_repository_v1(self):
         """Test ``Repository(content_type='docker')``."""
         entity = entities.Repository(self.cfg, content_type='docker')


### PR DESCRIPTION
+Removing corresponding workaround
+Removing redundant unit tests