### PR TITLE
Make content view filter rules searchable

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -1120,7 +1120,11 @@ class ContentViewVersion(Entity, EntityReadMixin, EntityDeleteMixin):
 
 
 class ContentViewFilterRule(
-        Entity, EntityCreateMixin, EntityDeleteMixin, EntityReadMixin):
+        Entity,
+        EntityCreateMixin,
+        EntityDeleteMixin,
+        EntityReadMixin,
+        EntitySearchMixin):
     """A representation of a Content View Filter Rule entity."""
 
     def __init__(self, server_config=None, **kwargs):


### PR DESCRIPTION
Sample test results:

    >>> from nailgun import entities
    >>> cv_filter = entities.RPMContentViewFilter(content_view=1).create(True)
    >>> entities.ContentViewFilterRule(content_view_filter=cv_filter).search()
    []