### PR TITLE
Make two more entities searchable

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -486,6 +486,7 @@ class AbstractComputeResource(
         EntityCreateMixin,
         EntityDeleteMixin,
         EntityReadMixin,
+        EntitySearchMixin,
         EntityUpdateMixin):
     """A representation of a Compute Resource entity."""
 
@@ -720,7 +721,7 @@ class DiscoveryRule(
         return {u'discovery_rule': payload}
 
 
-class DockerComputeResource(AbstractComputeResource):
+class DockerComputeResource(AbstractComputeResource):  # pylint:disable=R0901
     """A representation of a Docker Compute Resource entity."""
 
     def __init__(self, server_config=None, **kwargs):
@@ -773,7 +774,7 @@ class DockerComputeResource(AbstractComputeResource):
         return super(DockerComputeResource, self).read(entity, attrs, ignore)
 
 
-class LibvirtComputeResource(AbstractComputeResource):
+class LibvirtComputeResource(AbstractComputeResource):  # pylint:disable=R0901
     """A representation of a Libvirt Compute Resource entity."""
 
     def __init__(self, server_config=None, **kwargs):
@@ -904,7 +905,11 @@ class ConfigTemplate(
 
 
 class AbstractDockerContainer(
-        Entity, EntityCreateMixin, EntityDeleteMixin, EntityReadMixin):
+        Entity,
+        EntityCreateMixin,
+        EntityDeleteMixin,
+        EntityReadMixin,
+        EntitySearchMixin):
     """A representation of a docker container.
 
     This class is abstract because all containers must come from somewhere, but


### PR DESCRIPTION
Add the `EntitySearchMixin` to the following entity classe:

* `AbstractComputeResource`
* `AbstractDockerContainer`

Example of usage:

    >>> compute_resources = entities.AbstractComputeResource().search()
    >>> compute_resources = [
    ...     compute_resource
    ...     for compute_resource in compute_resources
    ...     if compute_resource.provider == 'Docker'
    ... ]
    >>> len(compute_resources)
    25
    >>> for compute_resource in compute_resources:
    ...     compute_resource.id, entities.AbstractDockerContainer(compute_resource=compute_resource).search()
    ...
    (12, [])
    (6, [])
    (41, [])
    (5, [])
    (11, [])
    (19, [])
    (9, [])
    (37, [])
    (20, [nailgun.entities.AbstractDockerContainer(…), nailgun.entities.AbstractDockerContainer(…), nailgun.entities.AbstractDockerContainer(…)])
    (67, [])
    (7, [])
    (13, [])
    (21, [nailgun.entities.AbstractDockerContainer(…), nailgun.entities.AbstractDockerContainer(…), nailgun.entities.AbstractDockerContainer(…)])
    (4, [])
    (25, [])
    (15, [])
    (22, [])
    (10, [])
    (18, [])
    (24, [])
    (39, [])
    (8, [])
    (31, [])
    (33, [])
    (14, [])

Note that it is impossible to search for compute resources based on its provider
type. Given this search:

    AbstractComputeResource().search(query={…})

The following queries will fail:

    {'search': 'provider="Docker"'}
    {'search': 'provider=Docker'}
    {'search': 'provider:Docker'}

Make pylint ignore the "too-many-ancestors" warning for these two classes. Why?
Consider `LibvirtComputeResource`. It has the following inheritance tree:

    LibvirtComputeResource
    └── AbstractComputeResource
        ├── EntityCreateMixin ┐
        ├── EntityDeleteMixin ┤
        ├── EntityReadMixin ──┤
        ├── EntitySearchMixin ┤
        └── EntityUpdateMixin ┤
                              └── Entity
                                  └── object

`LibvirtComputeResource` has eight parents, which is quite a few. However,
the class hierarchy is quite flat. Six of the eight classes are defined in
`entity_mixins.py`.