### PR TITLE
Updated 'subnet' entity with search and update mixin

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -3336,7 +3336,12 @@ class Status(Entity):
 
 
 class Subnet(
-        Entity, EntityCreateMixin, EntityDeleteMixin, EntityReadMixin):
+        Entity,
+        EntityCreateMixin,
+        EntityDeleteMixin,
+        EntityReadMixin,
+        EntitySearchMixin,
+        EntityUpdateMixin):
     """A representation of a Subnet entity."""
 
     def __init__(self, server_config=None, **kwargs):
@@ -3396,6 +3401,10 @@ class Subnet(
             ignore = set()
         ignore.add('discovery')
         return super(Subnet, self).read(entity, attrs, ignore)
+
+    def update_payload(self, fields=None):
+        """Wrap submitted data within an extra dict."""
+        return {u'subnet': super(Subnet, self).update_payload(fields)}
 
 
 class Subscription(

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1040,6 +1040,7 @@ class UpdatePayloadTestCase(TestCase):
             (entities.HostGroup, {'hostgroup': {}}),
             (entities.Location, {'location': {}}),
             (entities.Organization, {'organization': {}}),
+            (entities.Subnet, {'subnet': {}}),
             (entities.Registry, {'registry': {}}),
             (entities.User, {'user': {}}),
         ]


### PR DESCRIPTION
Updated `Subnet` entity with search and update mixin.

`Search results:`
```
In [8]: entities.Subnet(server_config, name="testsubnet", network="192.168.142.0", mask="255.255.255.0").create()
Out[8]: nailgun.entities.Subnet(nailgun.config.ServerConfig(url='https://foreman_server', verify=False, auth=('admin', 'changeme')), dns_primary=None, domain=[], name=u'testsubnet', organization=[], dns_secondary=None, id=2, network=u'192.168.142.0', boot_mode=u'DHCP', from=None, ipam=u'DHCP', mask=u'255.255.255.0', vlanid=None, gateway=None, to=None, location=[], dns=None, dhcp=None, tftp=None)

In [9]: subnet = entities.Subnet(server_config).search(query={u'search': u'network="192.168.142.0"'})

In [10]: subnet
Out[10]: [nailgun.entities.Subnet(nailgun.config.ServerConfig(url='https://foreman_server', verify=False, auth=('admin', 'changeme')), dns_primary=None, dns_secondary=None, gateway=None, network=u'192.168.142.0', name=u'testsubnet', from=None, ipam=u'DHCP', mask=u'255.255.255.0', vlanid=None, id=2, to=None, dns=None, dhcp=None, tftp=None, boot_mode=u'DHCP')]
```