### PR TITLE
Add functionality for puppet module inc updates

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -1095,17 +1095,38 @@ class ContentViewVersion(Entity, EntityReadMixin, EntityDeleteMixin):
 
         The format of the returned path depends on the value of ``which``:
 
+        incremental_update
+            /content_view_versions/incremental_update
         promote
             /content_view_versions/<id>/promote
 
         ``super`` is called otherwise.
 
         """
-        if which == 'promote':
-            return '{0}/promote'.format(
-                super(ContentViewVersion, self).path(which='self')
+        if which in ('incremental_update', 'promote'):
+            prefix = 'base' if which == 'incremental_update' else 'self'
+            return '{0}/{1}'.format(
+                super(ContentViewVersion, self).path(prefix),
+                which
             )
         return super(ContentViewVersion, self).path(which)
+
+    def incremental_update(self, synchronous=True, **kwargs):
+        """Helper for incrementally updating a content view version.
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+
+        """
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.post(self.path('incremental_update'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous)
 
     def promote(self, synchronous=True, **kwargs):
         """Helper for promoting an existing published content view.
@@ -2748,7 +2769,7 @@ class PuppetClass(
         super(PuppetClass, self).__init__(server_config, **kwargs)
 
 
-class PuppetModule(Entity, EntityReadMixin):
+class PuppetModule(Entity, EntityReadMixin, EntitySearchMixin):
     """A representation of a Puppet Module entity."""
 
     def __init__(self, server_config=None, **kwargs):

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -1619,12 +1619,22 @@ class Environment(
         return {u'environment': super(Environment, self).create_payload()}
 
 
-class Errata(Entity):
+class Errata(Entity, EntityReadMixin, EntitySearchMixin):
     """A representation of an Errata entity."""
     # You cannot create an errata. Errata are a read-only entity.
 
     def __init__(self, server_config=None, **kwargs):
-        self._meta = {'api_path': 'api/v2/errata', 'server_modes': ('sat')}
+        self._fields = {
+            'content_view_version': entity_fields.OneToOneField(
+                ContentViewVersion
+            ),
+            'repository': entity_fields.OneToOneField(Repository),
+            'search': entity_fields.StringField(),
+        }
+        self._meta = {
+            'api_path': '/katello/api/v2/errata',
+            'server_modes': ('sat')
+        }
         super(Errata, self).__init__(server_config, **kwargs)
 
 
@@ -3790,7 +3800,11 @@ class SystemPackage(Entity):
 
 
 class System(
-        Entity, EntityCreateMixin, EntityDeleteMixin, EntityReadMixin):
+        Entity,
+        EntityCreateMixin,
+        EntityDeleteMixin,
+        EntityReadMixin,
+        EntitySearchMixin):
     """A representation of a System entity."""
 
     def __init__(self, server_config=None, **kwargs):

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -258,6 +258,7 @@ class PathTestCase(TestCase):
         for entity, which in (
                 (entities.ConfigTemplate, 'build_pxe_default'),
                 (entities.ConfigTemplate, 'revision'),
+                (entities.ContentViewVersion, 'incremental_update'),
                 (entities.DiscoveredHost, 'facts'),
         ):
             with self.subTest((entity, which)):
@@ -1121,6 +1122,10 @@ class GenericTestCase(TestCase):
             (entities.ContentView(**generic).available_puppet_modules, 'get'),
             (entities.ContentView(**generic).copy, 'post'),
             (entities.ContentView(**generic).publish, 'post'),
+            (
+                entities.ContentViewVersion(**generic).incremental_update,
+                'post'
+            ),
             (entities.ContentViewVersion(**generic).promote, 'post'),
             (entities.DiscoveredHost(cfg).facts, 'post'),
             (entities.Product(**generic).sync, 'post'),


### PR DESCRIPTION
Make the following changes:

* Make `ContentViewVersion.path` accept "incremental_update" as an argument.
* Add method `ContentViewVersion.incremental_update`.
* Add the `EntitySearchMixin` to the `PuppetModule` entity class.

These changes make it possible to add puppet modules to a content view version
via the "incremental update" mechanism.