### PR TITLE
Fix typos in documentation

### DIFF
--- a/docs/create_user_nailgun.py
+++ b/docs/create_user_nailgun.py
@@ -23,7 +23,7 @@ def main():
             mail='alice@example.com',
             organization=[org],
             password='hackme',
-        )
+        ).create()
         pprint(user.get_values())  # e.g. {'login': 'Alice', …}
 
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -383,8 +383,8 @@ easy to make a mistake and waste time troubleshooting the resultant error.
 NailGun shields the developer from this issue — not a single path is present!
 
 Fifth, the NailGun script shields developers from idiosyncrasies in JSON request
-formats. Notice how no nested hass is necessary when issuing a GET request for
-organizations, but a nested hash is necessary when issuing a POST request for
+formats. Notice how no nested dict is necessary when issuing a GET request for
+organizations, but a nested dict is necessary when issuing a POST request for
 users. Differences like this abound. NailGun packages data for you.
 
 Sixth, and perhaps most obviously, the NailGun script is *significantly*


### PR DESCRIPTION
One of the sample scripts in the documentation is missing a call to the
`create()` method. Add this missing method call.

One of the paragraphs mentions a "hass". This is a typo of "hash". Change the
word to "dict", which will likely be more familiar term to Python users.