### PR TITLE
Add EntitySearchMixin to ActivationKey entity

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -193,6 +193,7 @@ class ActivationKey(
         EntityCreateMixin,
         EntityDeleteMixin,
         EntityReadMixin,
+        EntitySearchMixin,
         EntityUpdateMixin):
     """A representation of a Activation Key entity."""
 


### PR DESCRIPTION
It's possible to search for an activation key so long as either an organization
or environment ID is specified. This is easy to do:

    >>> orgs = entities.Organization().search(query={'per_page': 25})
    >>> for org in orgs:
    ...     org.id, len(entities.ActivationKey(organization=org).search())
    ...
    (486, 1)
    (743, 0)
    (677, 0)
    (259, 0)
    (494, 0)
    (291, 0)
    (51, 0)
    (261, 0)
    (688, 0)
    (227, 0)
    (280, 0)
    (41, 0)
    (43, 0)
    (672, 0)
    (496, 0)
    (56, 0)
    (245, 0)
    (181, 0)
    (580, 0)
    (489, 0)
    (270, 0)
    (179, 0)
    (321, 0)
    (29, 1)
    (5, 0)
    >>> act_key = entities.ActivationKey(organization=486).search()[0]
    >>> act_key = act_key.read()
    >>> type(act_key)
    <class 'nailgun.entities.ActivationKey'>