### PR TITLE
Fix DockerComputeResource.read()

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -771,7 +771,7 @@ class DockerComputeResource(AbstractComputeResource):  # pylint:disable=R0901
                 **self._server_config.get_client_kwargs()
             )
             response.raise_for_status()
-            attrs['email'] = response.json()['email']
+            attrs['email'] = response.json().get('email')
         return super(DockerComputeResource, self).read(entity, attrs, ignore)
 
 


### PR DESCRIPTION
Small fix for `DockerComputeResource.read()` method.
As per [BZ](https://bugzilla.redhat.com/show_bug.cgi?id=1223540), POST and GET don't contain `email` field, so PUT is used here to do the trick.
The problem is that on upstream PUT doesn't contain `email` field too, and as we're accessing key directly, all the DockerComputeResource tests (20 of them) are failing because of missing key.
`get()` will search for key and return `None` if not found, making all the tests (except those which test `email` field) pass.
Some random test result before and after:
```
 nosetests tests/foreman/api/test_docker.py -m test_create_external_docker_compute_resource
E^C
======================================================================
ERROR: @Test: Create a Docker-based Compute Resource using an external
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/andriy/env/lib/python2.7/site-packages/ddt.py", line 146, in wrapper
    return func(self, *args, **kwargs)
  File "/home/andriy/Downloads/robottelo/tests/foreman/api/test_docker.py", line 1034, in test_create_external_docker_compute_resource
    url=EXTERNAL_DOCKER_URL,
  File "/home/andriy/Downloads/nailgun/nailgun/entities.py", line 749, in create
    id=self.create_json(create_missing)['id'],
  File "/home/andriy/Downloads/nailgun/nailgun/entities.py", line 774, in read
    attrs['email'] = response.json()['email']
KeyError: 'email'
```
```
nosetests tests/foreman/api/test_docker.py -m test_create_external_docker_compute_resource
.......
----------------------------------------------------------------------
Ran 7 tests in 24.499s

OK
```