### PR TITLE
[DONOTMERGE] Use only alpha characters for Host password field.

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2022,7 +2022,10 @@ class Host(  # pylint:disable=too-many-instance-attributes
             'puppet_class': entity_fields.OneToManyField(PuppetClass),
             'puppet_proxy': entity_fields.OneToOneField(SmartProxy),
             'realm': entity_fields.OneToOneField(Realm),
-            'root_pass': entity_fields.StringField(length=(8, 30)),
+            'root_pass': entity_fields.StringField(
+                str_type='alpha',
+                length=(8, 30),
+            ),
             'subnet': entity_fields.OneToOneField(Subnet),
         }
         self._meta = {'api_path': 'api/v2/hosts', 'server_modes': ('sat')}


### PR DESCRIPTION
Our automation has shown that using UTF-8 characters for the password
field for a Host can be problematic. Defaulting to 'alpha' by default.