### PR TITLE
Change the length of AbstractDockerContainer name

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -958,6 +958,7 @@ class AbstractDockerContainer(
             # The "name" field may be any of a-zA-Z0-9_.-,
             # "alphanumeric" is a subset of those legal characters.
             'name': entity_fields.StringField(
+                length=(2, 30),
                 required=True,
                 str_type='alphanumeric',
             ),


### PR DESCRIPTION
Docker container names must follow the following rule
`[a-zA-Z0-9][a-zA-Z0-9_.-]`, to match that, update the length of the
random generated length to have at least two characters.

Closes #228