### PR TITLE
Improve _handle_response

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -115,7 +115,7 @@ def _handle_response(response, server_config, synchronous=False):
         return ForemanTask(server_config, id=response.json()['id']).poll()
     if response.status_code == NO_CONTENT:
         return
-    if response.headers.get('content-type', '').lower() == 'application/json':
+    if 'application/json' in response.headers.get('content-type', '').lower():
         return response.json()
     else:
         return response.content


### PR DESCRIPTION
Check for presence of `application/json` on response headers instead
equality since on the header value the charset can be specified, like
`application/json; charset=utf-8`.