### PR TITLE
Add search functionality to CV entity

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -1377,6 +1377,7 @@ class ContentView(
         EntityCreateMixin,
         EntityDeleteMixin,
         EntityReadMixin,
+        EntitySearchMixin,
         EntityUpdateMixin):
     """A representation of a Content View entity."""
 


### PR DESCRIPTION
Closes #232

```
orgs = entities.Organization().search(query={'per_page': 25})

for org in orgs:
...     org.id, len(entities.ContentView(organization=org).search())
... 
(88, 1)
(16, 2)
(514, 1)
(129, 1)
(301, 1)
(3, 2)
(21, 2)
(22, 2)
(46, 1)
(118, 1)
(53, 1)
(303, 1)
(298, 1)
(12, 2)
(105, 1)
(56, 1)
(48, 1)
(30, 2)
(137, 1)
(306, 1)
(225, 1)
(62, 1)
(325, 1)
(221, 1)
(400, 1)

We have one Content View per each Organization by default ('Default Organization View')

cv = entities.ContentView(organization=30).search()[0]
cv = cv.read()
type(cv)
<class 'nailgun.entities.ContentView'>
cv.name
u'Default Organization View'
cv = entities.ContentView(organization=30).search()[1]
cv = cv.read()
type(cv)
<class 'nailgun.entities.ContentView'>
cv.name
u'\U00021760\U00022ff5\U00028baf\U00023e73\U000249e1\u86f4\ub3dc\U00026c8f\U0002abdc\u3940\U000244d3\U00020ccb\U00023256\u126c\ub5ab\U000217a2\U00021765\U000132f7\ucaff\U0002118c\u8b63\U000130b9\U0001009b\U0002097b\U0002159a\uaac0\U00027889'
```

We do not have tests for EntitySearchMixin default scenarios, only for unique ones (e.g. 'Subscription')