### PR TITLE
Fix #234

### DIFF
--- a/nailgun/entity_mixins.py
+++ b/nailgun/entity_mixins.py
@@ -2,7 +2,7 @@
 """Defines a set of mixins that provide tools for interacting with entities."""
 from collections import Iterable
 from fauxfactory import gen_choice
-from inflector import Inflector
+from inflection import pluralize
 from nailgun import client, config
 from nailgun.entity_fields import IntegerField, OneToManyField, OneToOneField
 import threading
@@ -260,7 +260,7 @@ def _get_entity_ids(field_name, attrs):
 
     """
     field_name_ids = field_name + '_ids'
-    plural_field_name = Inflector().pluralize(field_name)
+    plural_field_name = pluralize(field_name)
     if field_name_ids in attrs:
         return attrs[field_name_ids]
     elif field_name in attrs:

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'fauxfactory',
-        'inflector',
+        'inflection',
         'packaging',
         'pyxdg',
         'requests>=2.7',


### PR DESCRIPTION
Drop `inflector` library in favor of `inflection` library. Do this in an attempt
to fix the failing ReadTheDocs builds. The former triggers a string encoding bug
in setuptools when built by RTD, and the hope is that the latter will not
trigger such a bux.