### PR TITLE
Update list of OS families

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -72,10 +72,12 @@ else:  # pragma: no cover
 _FAKE_YUM_REPO = 'http://inecas.fedorapeople.org/fakerepos/zoo3/'
 _OPERATING_SYSTEMS = (
     'AIX',
+    'Altlinux',
     'Archlinux',
     'Debian',
     'Freebsd',
     'Gentoo',
+    'Junos'
     'Redhat',
     'Solaris',
     'Suse',
@@ -2367,20 +2369,7 @@ class Media(
             'operatingsystem': entity_fields.OneToManyField(OperatingSystem),
             'organization': entity_fields.OneToManyField(Organization),
             'location': entity_fields.OneToManyField(Location),
-            'os_family': entity_fields.StringField(
-                choices=(
-                    'AIX',
-                    'Archlinux',
-                    'Debian',
-                    'Freebsd',
-                    'Gentoo',
-                    'Junos',
-                    'Redhat',
-                    'Solaris',
-                    'Suse',
-                    'Windows',
-                ),
-            ),
+            'os_family': entity_fields.StringField(choices=_OPERATING_SYSTEMS),
         }
         self._meta = {'api_path': 'api/v2/media', 'server_modes': ('sat')}
         super(Media, self).__init__(server_config, **kwargs)


### PR DESCRIPTION
- Update list of possible OS families according to UI:
![image](https://cloud.githubusercontent.com/assets/10895065/11206982/1d8defee-8d1b-11e5-8437-955635d1684f.png)

- Remove duplication of code for Media entity as it has same list of operation systems:
![image](https://cloud.githubusercontent.com/assets/10895065/11206996/44177ab8-8d1b-11e5-81c9-e1a5bd9573c5.png)

Verified that change works properly using `test_update_with_new_os` test from `api/test_partitiontable.py`

Corresponding update for robottelo part will be provided soon (there are no impact by any of that change, so we are free to merge current PR whenever we like)