### PR TITLE
Fix upload_payload method for Media entity

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2418,9 +2418,10 @@ class Media(
 
     def update_payload(self, fields=None):
         """Wrap submitted data within an extra dict."""
-        return {
-            u'medium': super(Media, self).update_payload(fields)
-        }
+        payload = super(Media, self).update_payload(fields)
+        if 'path_' in payload:
+            payload['path'] = payload.pop('path_')
+        return {u'medium': payload}
 
 
 class Model(

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1084,6 +1084,17 @@ class UpdatePayloadTestCase(TestCase):
         self.assertNotIn('search_', payload['discovery_rule'])
         self.assertIn('search', payload['discovery_rule'])
 
+    def test_media_path(self):
+        """Check whether ``Media`` updates its ``path_`` field.
+
+        The field should be renamed from ``path_`` to ``path`` when
+        ``update_payload`` is called.
+
+        """
+        payload = entities.Media(self.cfg, path_='foo').update_payload()
+        self.assertNotIn('path_', payload['medium'])
+        self.assertIn('path', payload['medium'])
+
 
 # 2. Tests for entity-specific methods. ---------------------------------- {{{1
 


### PR DESCRIPTION
Made necessary changes for `upload_payload()` method in Media entity to have similar look as that entity has for `create_payload()` method. +Added required unit test

Tested using robottelo and functionality started to work as intended