### PR TITLE
Add one more field to OS entity

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2479,6 +2479,10 @@ class OperatingSystem(
             'ptable': entity_fields.OneToManyField(PartitionTable),
             'config_template': entity_fields.OneToManyField(ConfigTemplate),
             'release_name': entity_fields.StringField(),
+            'password_hash': entity_fields.StringField(
+                choices=('MD5', 'SHA256', 'SHA512'),
+                default='MD5',
+            ),
         }
         self._meta = {
             'api_path': 'api/v2/operatingsystems',


### PR DESCRIPTION
Verify that functionality really works properly:

```
>>> entities.OperatingSystem().create(create_missing=True)
nailgun.entities.OperatingSystem(nailgun.config.ServerConfig(url=u'https://cisco-c220m3-01.klab.eng.bos.redhat.com', verify=False, auth=(u'admin', u'changeme')), major=u'93', family=None, media=[], ptable=[], description=None, config_template=[], architecture=[], password_hash=u'MD5', release_name=None, id=38, minor=u'', name=u'\u07cd\u9654\U000266f9\U00023ca0\U0002aa5e\u0279\U00022d0b\U0002a3ba\u9734\U0002297c\u7e34\U0002ada4\ub096\ua186\U000250ef\u3a62\u4020\ufbf2\u9954\U00028d50\u7b82\ud2ac\ud525\ua695\u017c\u9955')

>>> entities.OperatingSystem(password_hash='SHA256').create(create_missing=True)
nailgun.entities.OperatingSystem(nailgun.config.ServerConfig(url=u'https://cisco-c220m3-01.klab.eng.bos.redhat.com', verify=False, auth=(u'admin', u'changeme')), major=u'00', family=None, media=[], ptable=[], description=None, config_template=[], architecture=[], password_hash=u'SHA256', release_name=None, id=39, minor=u'', name=u'\U000255e9\U0002276f\u4d05\u88af\U00027a31\u2da0\U000281b6\U00022377\u3c0e\U0002a346\U0002067a\u3b61\U000220f6')
```