### PR TITLE
Fix Media name field for Operating System entity

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2470,7 +2470,7 @@ class OperatingSystem(
                 required=True,
                 str_type='numeric',
             ),
-            'media': entity_fields.OneToManyField(Media),
+            'medium': entity_fields.OneToManyField(Media),
             'minor': entity_fields.StringField(
                 length=(1, 16),
                 str_type='numeric',


### PR DESCRIPTION
According to APIdoc we have `medium` field, not `media` field:
```
operatingsystem[medium_ids]  - IDs of associated media
optional , nil allowed	
```

Of course, we can add some renaming functionality to `create()` and `update()` methods, but proposed solution seems much better

Before fix:
```
>>>media = entities.Media().create(create_missing=True)
>>>entities.OperatingSystem(media=[media]).create(create_missing=True)
WARNING:nailgun.client:Received HTTP 500 response: {
  "error": {"message":"unknown attribute: media_ids"}
}

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/oshtaier/Desktop/nailgun/nailgun/entity_mixins.py", line 842, in create
    return self.read(attrs=self.create_json(create_missing))
  File "/home/oshtaier/Desktop/nailgun/nailgun/entity_mixins.py", line 813, in create_json
    response.raise_for_status()
  File "/usr/lib/python2.7/site-packages/requests/models.py", line 837, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 500 Server Error: Internal Server Error for url: https://cisco-c220m3-01.klab.eng.bos.redhat.com/api/v2/operatingsystems
```

After fix (proper media assigned to OS):
```
>>>media = entities.Media().create(create_missing=True)
>>>entities.OperatingSystem(medium=[media]).create(create_missing=True)
nailgun.entities.OperatingSystem(nailgun.config.ServerConfig(url=u'https://cisco-c220m3-01.klab.eng.bos.redhat.com', verify=False, auth=(u'admin', u'changeme')), major=u'69245', medium=[nailgun.entities.Media(nailgun.config.ServerConfig(url=u'https://cisco-c220m3-01.klab.eng.bos.redhat.com', verify=False, auth=(u'admin', u'changeme')), id=165)], family=None, ptable=[], description=None, config_template=[], architecture=[], password_hash=u'MD5', release_name=None, id=46, minor=u'', name=u'\uae4e\U00023ca7\U0001d62d\U0002b07b\u3cb1\U000260c1\U00021872\u5f31\U000207e0\U000204f4\u965c\U000294df\u4340\U00027286\U0002a992\U00028777\u4c94\U0002aef7\U0002788d\U000219fa\u43d6\U000254ad\u1472\u6568\u7ca9\u3073\U000121fe')
```