### PR TITLE
Override update_payload for operating system entity

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2501,6 +2501,15 @@ class OperatingSystem(
             u'operatingsystem': super(OperatingSystem, self).create_payload()
         }
 
+    def update_payload(self, fields=None):
+        """Wrap submitted data within an extra dict."""
+        return {
+            u'operatingsystem': super(
+                OperatingSystem,
+                self
+            ).update_payload(fields)
+        }
+
 
 class OperatingSystemParameter(
         Entity, EntityCreateMixin, EntityDeleteMixin, EntityReadMixin):

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1034,6 +1034,7 @@ class UpdatePayloadTestCase(TestCase):
             (entities.HostGroup, {'hostgroup': {}}),
             (entities.Location, {'location': {}}),
             (entities.Media, {'medium': {}}),
+            (entities.OperatingSystem, {'operatingsystem': {}}),
             (entities.Organization, {'organization': {}}),
             (entities.Setting, {'setting': {}}),
             (entities.SmartProxy, {'smart_proxy': {}}),


### PR DESCRIPTION
When it is not mandatory to wrap every attribute for update procedure, there is still some (like `family`) that need it, so overriding `update_payload` method like we usually did in similar situations