### PR TITLE
Add 'title' field to OperatingSystem entity

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2450,14 +2450,12 @@ class OperatingSystem(
 
     ``major`` is listed as a string field in the API docs, but only numeric
     values are accepted, and they may be no longer than 5 digits long. Also see
-    bugzilla bug #1122261.
+    `Bugzilla #1122261 <https://bugzilla.redhat.com/show_bug.cgi?id=1122261>`_.
 
-    The following fields are valid despite not being listed in the API docs:
-
-    * architecture
-    * medium
-    * ptable
-
+    ``title`` field is valid despite not being listed in the API docs. This may
+    be changed in future as both ``title`` and ``description`` fields share
+    similar purpose. See `Bugzilla #1290359
+    <https://bugzilla.redhat.com/show_bug.cgi?id=1290359>`_ for more details.
     """
 
     def __init__(self, server_config=None, **kwargs):
@@ -2483,6 +2481,7 @@ class OperatingSystem(
                 choices=('MD5', 'SHA256', 'SHA512'),
                 default='MD5',
             ),
+            'title': entity_fields.StringField(),
         }
         self._meta = {
             'api_path': 'api/v2/operatingsystems',


### PR DESCRIPTION
```python
>>> os1 = entities.OperatingSystem(name=gen_string('alphanumeric')).create()
2015-12-07 18:14:51 - nailgun.client - DEBUG - Making HTTP POST request to https://**************************.redhat.com:443/api/v2/operatingsystems with options {'verify': False, 'auth': ('*****', '********'), 'headers': {'content-type': 'application/json'}} and data {"operatingsystem": {"major": "5", "name": "co3zQU6cUT"}}.
2015-12-07 18:14:52 - nailgun.client - DEBUG - Received HTTP 200 response: {"id":249,"name":"co3zQU6cUT","title":"co3zQU6cUT 5","description":null,"major":"5","minor":"","family":null,"release_name":null,"password_hash":"MD5","created_at":"2015-12-07T16:14:52Z","updated_at":"2015-12-07T16:14:52Z","parameters":[],"media":[],"architectures":[],"ptables":[],"config_templates":[],"os_default_templates":[],"images":[]}
>>> os1.title
u'co3zQU6cUT 5'
```