### PR TITLE
Use old version of Pylint

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,9 +2,11 @@
 mock
 unittest2 ; python_version < '3.4'
 
-# For `make lint`
+# For `make lint`. See: https://github.com/SatelliteQE/nailgun/issues/246
+# and https://github.com/SatelliteQE/nailgun/issues/247
 flake8
-pylint
+pylint<1.5.0
+astroid<1.4.0
 
 # For `make docs-html` and `make docs-clean`
 sphinx


### PR DESCRIPTION
Fix #246:

> Pylint 1.5 and astroid 1.4 have recently been released. Due to this update,
> the `make lint` target is now failing.

As a follow-up, #247 should be addressed:

> Let's make NailGun compatible with the current version of Pylint and/or work
> with the Pylint developers to fix any possible regressions in the tool.