### PR TITLE
Drop unneeded workaround

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,10 +52,6 @@ the challenges developers face:
   experienced developers may find the API hard to work with.
 * The Satellite 6 API is not consistent in its implementation. For example, see
   the "Payload Generation" section of `this blog post`_.
-* The Satellite 6 API contains bugs. For example, `Foreman bug #4638`_ describes
-  how it is impossible to definitively know whether a given activation key
-  exists. (:meth:`nailgun.entities.ActivationKey.read_raw` contains a
-  work-around.)
 
 All of the above issues are compounded by the size of the Satellite 6 API. As of
 this writing, there are 405 paths. This makes it tough to design compact and

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -35,7 +35,6 @@ from nailgun.entity_mixins import (
     _poll_task,
 )
 from packaging.version import Version
-from time import sleep
 import random
 
 from sys import version_info
@@ -224,25 +223,6 @@ class ActivationKey(
             'server_modes': ('sat', 'sam'),
         }
         super(ActivationKey, self).__init__(server_config, **kwargs)
-
-    def read_raw(self):
-        """Work around `Redmine #4638`_.
-
-        Poll the server several times upon receiving a 404, just to be *really*
-        sure that the requested activation key is non-existent. Do this because
-        elasticsearch can be slow about indexing newly created activation keys,
-        especially when the server is under load.
-
-        .. _Redmine #4638: http://projects.theforeman.org/issues/4638
-
-        """
-        super_read_raw = super(ActivationKey, self).read_raw
-        response = super_read_raw()
-        for _ in range(5):
-            if response.status_code == 404:
-                sleep(5)
-                response = super_read_raw()
-        return response
 
     def path(self, which=None):
         """Extend ``nailgun.entity_mixins.Entity.path``.


### PR DESCRIPTION
Katello issue 4638 [1] has been resolved. As a result, the workaround for that
bug in `ActivationKey.create_raw` is no longer needed. It is possible to create
an activation key without this workaround in place:

```python
>>> from nailgun import config, entities
>>> cfg = config.ServerConfig(…)
>>> act_key = entities.ActivationKey(cfg).create(create_missing=True)
>>> act_key.id
204
```

Fix #250.

[1] http://projects.theforeman.org/issues/4638