### PR TITLE
Fix Usergroup creation

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -4123,6 +4123,18 @@ class UserGroup(
         """
         return {u'usergroup': super(UserGroup, self).create_payload()}
 
+    def create(self, create_missing=None):
+        """Do extra work to fetch a complete set of attributes for this entity.
+
+        For more information, see `Bugzilla #1301658
+        <https://bugzilla.redhat.com/show_bug.cgi?id=1301658>`_.
+
+        """
+        return UserGroup(
+            self._server_config,
+            id=self.create_json(create_missing)['id'],
+        ).read()
+
     def read(self, entity=None, attrs=None, ignore=None):
         """Work around `Redmine #9594`_.
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -426,6 +426,7 @@ class CreateTestCase(TestCase):
             entities.Media(self.cfg),
             entities.Organization(self.cfg),
             entities.Realm(self.cfg),
+            entities.UserGroup(self.cfg),
         )
         for entity in entities_:
             with self.subTest(entity):


### PR DESCRIPTION
POST /api/v2/usergroups doesn't return `users`, `roles` and some other fields. Adding workaround to fetch the complete set of attributes



Before:
```python
>>> role = entities.Role().create(True)
>>> user = entities.User(
...     location=[location],
...     organization=[organization],
...     role=[role],
... ).create(True)
>>> usergroup = entities.UserGroup(
...     role=[role],
...     user=[user],
... ).create(True)
Traceback (most recent call last):
  File "<stdin>", line 4, in <module>
  File "nailgun/entity_mixins.py", line 842, in create
    return self.read(attrs=self.create_json(create_missing))
  File "nailgun/entities.py", line 4145, in read
    return super(UserGroup, self).read(entity, attrs, ignore)
  File "nailgun/entity_mixins.py", line 697, in read
    in _get_entity_ids(field_name, attrs)
  File "nailgun/entity_mixins.py", line 277, in _get_entity_ids
    attrs.keys()
nailgun.entity_mixins.MissingValueError: Cannot find a value for the "role" field. Searched for keys named ('role_ids', 'role', 'roles'), but available keys are [u'admin', u'created_at', u'id', u'updated_at', u'name'].
```

After:
```python
>>> role = entities.Role().create(True)
>>> user = entities.User(
...     location=[location],
...     organization=[organization],
...     role=[role],
... ).create(True)
>>> usergroup = entities.UserGroup(
...     role=[role],
...     user=[user],
... ).create(True)
>>> usergroup
nailgun.entities.UserGroup(nailgun.config.ServerConfig(url=u'https://****************************.redhat.com', verify=False, auth=(u'admin', u'********')), admin=False, role=[nailgun.entities.Role(nailgun.config.ServerConfig(url=u'https://****************************.redhat.com', verify=False, auth=(u'admin', u'********')), id=24)], user=[nailgun.entities.User(nailgun.config.ServerConfig(url=u'https://****************************.redhat.com', verify=False, auth=(u'admin', u'********')), id=56)], usergroup=[], id=5, name=u'\U0002335c\ub10d\ucd9b\uc685\uce85\u8c86\U0002135d\U00021c92\U0001d6ee\U00029647\U0002432a\U00029dfa\u5b42\u6b82\U00023233\U00010c47\U000256d8\u127a\u45a3')
```