### PR TITLE
Add update functionality for gpg keys

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -1787,7 +1787,8 @@ class GPGKey(
         EntityCreateMixin,
         EntityDeleteMixin,
         EntityReadMixin,
-        EntitySearchMixin):
+        EntitySearchMixin,
+        EntityUpdateMixin):
     """A representation of a GPG Key entity."""
 
     def __init__(self, server_config=None, **kwargs):

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1030,6 +1030,7 @@ class UpdateTestCase(TestCase):
             entities.ConfigTemplate(self.cfg),
             entities.Domain(self.cfg),
             entities.Environment(self.cfg),
+            entities.GPGKey(self.cfg),
             entities.Host(self.cfg),
             entities.HostCollection(self.cfg),
             entities.HostGroup(self.cfg),


### PR DESCRIPTION
```
>>> gpg_key = entities.GPGKey(content='test').create(create_missing=True)
>>> gpg_key.name = 'test1'
>>> gpg_key = gpg_key.update(['name'])
>>> gpg_key
nailgun.entities.GPGKey(nailgun.config.ServerConfig(url=u'https://qe-sat6iso-rhel7.satqe.lab.eng.rdu2.redhat.com', verify=False, auth=(u'admin', u'changeme')), content=u'test', organization=nailgun.entities.Organization(nailgun.config.ServerConfig(url=u'https://qe-sat6iso-rhel7.satqe.lab.eng.rdu2.redhat.com', verify=False, auth=(u'admin', u'changeme')), id=845), id=107, name=u'test1')
```