### PR TITLE
Fix HostGroup.read for Satellite 6.2

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -1954,7 +1954,8 @@ class HostGroup(
         if attrs is None:
             attrs = self.read_json()
         attrs['parent_id'] = attrs.pop('ancestry')  # either an ID or None
-        if _get_version(self._server_config) >= Version('6.1'):
+        version = _get_version(self._server_config)
+        if version >= Version('6.1') and version < Version('6.2'):
             # We cannot call `self.update_json([])`, as an ID might not be
             # present on self. However, `attrs` is guaranteed to have an ID.
             attrs2 = HostGroup(


### PR DESCRIPTION
On Satellite 6.2 the work around for the HostGroup.read is not needed
anymore. Just run the work around for Satellite 6.1.z.