### PR TITLE
Adding two more fields for partition table entity

### DIFF
--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -683,7 +683,12 @@ class CreateMissingTestCase(TestCase):
             organization=[2],
         )
         arch = entities.Architecture(self.cfg, id=1)
-        ptable = entities.PartitionTable(self.cfg, id=1)
+        ptable = entities.PartitionTable(
+            self.cfg,
+            id=1,
+            location=[2],
+            organization=[2],
+        )
         oper_sys = entities.OperatingSystem(
             self.cfg,
             id=1,


### PR DESCRIPTION
Adding location and organization fields to Partition Table entity
Please refer to https://bugzilla.redhat.com/show_bug.cgi?id=1320459 for more details
```
>>> test = entities.PartitionTable(organization=[1]).create(True)
>>> test
nailgun.entities.PartitionTable(nailgun.config.ServerConfig(url=u'https://server', verify=False, auth=(u'admin', u'changeme')), layout=u'\u7abf\ufc1c\U00029f67\U00020d89\u7cbb\u0178\U00023182\U000210be\ua20d\U00022c5e\U0002766f\ucb75\U00010008\ubb7d\U00023153\U00022bbe\ufeaa\u857e\U000290e5\u5a17\U00022e79\U0002630e\u5099\U0002a0c1', os_family=None, location=[], organization=[nailgun.entities.Organization(nailgun.config.ServerConfig(url=u'https://server', verify=False, auth=(u'admin', u'changeme')), id=1)], id=198, name=u'\U0002008b\U0002821d\u9789\U00029f91\U00010912\U000208a4\U0002b0d4\u8ec6\ua553\u3b79\ub1d4')
>>> test = entities.PartitionTable(location=[1]).create(True)
>>> test
nailgun.entities.PartitionTable(nailgun.config.ServerConfig(url=u'https://server', verify=False, auth=(u'admin', u'changeme')), layout=u'\U00020c2d\U00026e3d\u98cc\u8e31\U0002823e\U00022cba\u6015', os_family=None, location=[nailgun.entities.Location(nailgun.config.ServerConfig(url=u'https://server', verify=False, auth=(u'admin', u'changeme')), id=1)], organization=[nailgun.entities.Organization(nailgun.config.ServerConfig(url=u'https://server', verify=False, auth=(u'admin', u'changeme')), id=1)], id=199, name=u'\u3f06\U00026ea4\U00025cf9\U00027abe\u1760\u7bac\U00020aa2\ubd69\u6a04\u93d7\U00026977\U00021b11\u3658\u48c6\u37fe\U000259f5\u53e3\U00010b26\U0002a27c\U00023226\U000203c8\U0001305d\U00022706\U00025413\U00027116\u66ae')
```