### PR TITLE
Add Create/Read/Search/Update mixins for ConfigGroup entity

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -785,7 +785,12 @@ class LibvirtComputeResource(AbstractComputeResource):  # pylint:disable=R0901
         self._fields['provider_friendly_name'].default = 'Libvirt'
 
 
-class ConfigGroup(Entity):
+class ConfigGroup(
+        Entity,
+        EntityCreateMixin,
+        EntityReadMixin,
+        EntitySearchMixin,
+        EntityUpdateMixin):
     """A representation of a Config Group entity."""
 
     def __init__(self, server_config=None, **kwargs):

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -419,6 +419,7 @@ class CreateTestCase(TestCase):
         """Call ``create`` on a variety of entities."""
         entities_ = (
             entities.AbstractDockerContainer(self.cfg),
+            entities.ConfigGroup(self.cfg),
             entities.DockerComputeResource(self.cfg),
             entities.Domain(self.cfg),
             entities.HostGroup(self.cfg),
@@ -465,6 +466,7 @@ class CreatePayloadTestCase(TestCase):
                 entities.AbstractComputeResource,
                 entities.AbstractDockerContainer,
                 entities.Architecture,
+                entities.ConfigGroup,
                 entities.ConfigTemplate,
                 entities.DiscoveredHost,
                 entities.DiscoveryRule,
@@ -1048,6 +1050,7 @@ class UpdateTestCase(TestCase):
             entities.AbstractComputeResource(self.cfg),
             entities.Architecture(self.cfg),
             entities.ComputeProfile(self.cfg),
+            entities.ConfigGroup(self.cfg),
             entities.ConfigTemplate(self.cfg),
             entities.Domain(self.cfg),
             entities.Environment(self.cfg),


### PR DESCRIPTION
```python
>>> cg = entities.ConfigGroup().create(True)
>>> cg.read()
nailgun.entities.ConfigGroup(nailgun.config.ServerConfig(url=u'https://example.com', verify=False, auth=(u'admin', u'changeme')), id=21, name=u'\U0002a628\U00022f0b\U00021064\u4c73\U00020f45\ucaac\U000247fb\U000260c3\U0002241b\ub864\U0001047f\ua560\u11ee\u8013\uc7e9\u37d1\u6ef1\U00025c53\u1610')
>>> entities.ConfigGroup(name=cg.name).search()[0]
nailgun.entities.ConfigGroup(nailgun.config.ServerConfig(url=u'https://example.com', verify=False, auth=(u'admin', u'changeme')), id=16, name=u'\U00026eb4\U000213b5\u3718')
>>> cg.name = 'test12345'
>>> cg.update(['name'])
nailgun.entities.ConfigGroup(nailgun.config.ServerConfig(url=u'https://example.com', verify=False, auth=(u'admin', u'changeme')), id=21, name=u'test12345')
```