### PR TITLE
Quick fix for UserGroup entity

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -4233,7 +4233,11 @@ class TemplateKind(Entity, EntityReadMixin):
 
 
 class UserGroup(
-        Entity, EntityCreateMixin, EntityDeleteMixin, EntityReadMixin):
+        Entity,
+        EntityCreateMixin,
+        EntityDeleteMixin,
+        EntityReadMixin,
+        EntityUpdateMixin):
     """A representation of a User Group entity."""
 
     def __init__(self, server_config=None, **kwargs):
@@ -4241,7 +4245,7 @@ class UserGroup(
             'admin': entity_fields.BooleanField(),
             'name': entity_fields.StringField(required=True),
             'role': entity_fields.OneToManyField(Role),
-            'user': entity_fields.OneToManyField(User, required=True),
+            'user': entity_fields.OneToManyField(User),
             'usergroup': entity_fields.OneToManyField(UserGroup),
         }
         self._meta = {'api_path': 'api/v2/usergroups', 'server_modes': ('sat')}
@@ -4255,6 +4259,15 @@ class UserGroup(
 
         """
         return {u'usergroup': super(UserGroup, self).create_payload()}
+
+    def update_payload(self, fields=None):
+        """Wrap submitted data within an extra dict.
+
+        For more information, see `Bugzilla #1151220
+        <https://bugzilla.redhat.com/show_bug.cgi?id=1151220>`_.
+
+        """
+        return {u'usergroup': super(UserGroup, self).update_payload(fields)}
 
     def create(self, create_missing=None):
         """Do extra work to fetch a complete set of attributes for this entity.

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1069,6 +1069,7 @@ class UpdateTestCase(TestCase):
             entities.Organization(self.cfg),
             entities.SmartProxy(self.cfg),
             entities.User(self.cfg),
+            entities.UserGroup(self.cfg),
         )
         for entity in entities_:
             with self.subTest(entity):
@@ -1124,6 +1125,7 @@ class UpdatePayloadTestCase(TestCase):
             (entities.Subnet, {'subnet': {}}),
             (entities.Registry, {'registry': {}}),
             (entities.User, {'user': {}}),
+            (entities.UserGroup, {'usergroup': {}}),
         ]
         for entity, payload in entities_payloads:
             with self.subTest((entity, payload)):


### PR DESCRIPTION
1) Adding Update mixin
2) Removing `required` flag for `User` parameter as it is optional per documentation and in fact

```
>>> user_group = entities.UserGroup().create(True)
>>> user_group
nailgun.entities.UserGroup(nailgun.config.ServerConfig(url=u'https://qe-sat6-rhel7.satqe.lab.eng.rdu2.redhat.com', verify=False, auth=(u'admin', u'changeme')), admin=False, role=[], user=[], usergroup=[], id=123, name=u'\u4a5b\ub4fd\U000121ff\U00028f4e\uc0c7\uaa70\U000261f2\u4b0b\U0002567a\U00026b31')
>>> user_group.name = 'test12345'
>>> user_group.update(['name'])
nailgun.entities.UserGroup(nailgun.config.ServerConfig(url=u'https://qe-sat6-rhel7.satqe.lab.eng.rdu2.redhat.com', verify=False, auth=(u'admin', u'changeme')), admin=False, role=[], user=[], usergroup=[], id=123, name=u'test12345')
```