### PR TITLE
Wrap POST requests for filter entity

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -1690,6 +1690,15 @@ class Filter(
         self._meta = {'api_path': 'api/v2/filters', 'server_modes': ('sat')}
         super(Filter, self).__init__(server_config, **kwargs)
 
+    def create_payload(self):
+        """Wrap submitted data within an extra dict.
+
+        For more information, see `Bugzilla #1151220
+        <https://bugzilla.redhat.com/show_bug.cgi?id=1151220>`_.
+
+        """
+        return {u'filter': super(Filter, self).create_payload()}
+
 
 class ForemanTask(Entity, EntityReadMixin, EntitySearchMixin):
     """A representation of a Foreman task."""

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -472,6 +472,7 @@ class CreatePayloadTestCase(TestCase):
                 entities.DiscoveryRule,
                 entities.Domain,
                 entities.Environment,
+                entities.Filter,
                 entities.Host,
                 entities.HostCollection,
                 entities.HostGroup,


### PR DESCRIPTION
Before fix:
```
>>> entities.Filter(permission=[1], role=1).create()
Received HTTP 500 response: {
  "error": {"message":"ERROR:  operator does not exist: character varying = integer\nLINE 1: ...oles\"  WHERE ((\"roles\".\"id\" = 1 OR \"roles\".\"name\" = 1))  ORD...\n                                                             ^\nHINT:  No operator matches the given name and argument type(s). You might need to add explicit type casts.\n"}
}

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "nailgun/entity_mixins.py", line 842, in create
    return self.read(attrs=self.create_json(create_missing))
  File "nailgun/entity_mixins.py", line 813, in create_json
    response.raise_for_status()
  File "/usr/lib/python2.7/site-packages/requests/models.py", line 837, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 500 Server Error: Internal Server Error for url: https://qe-sat6-rhel7.satqe.lab.eng.rdu2.redhat.com/api/v2/filters
```

After the fix:
```
>>> filter = entities.Filter(permission=[1], role=1).create()
>>> filter
nailgun.entities.Filter(nailgun.config.ServerConfig(url=u'https://qe-sat6-rhel7.satqe.lab.eng.rdu2.redhat.com', verify=False, auth=(u'admin', u'changeme')), search=None, permission=[nailgun.entities.Permission(nailgun.config.ServerConfig(url=u'https://qe-sat6-rhel7.satqe.lab.eng.rdu2.redhat.com', verify=False, auth=(u'admin', u'changeme')), id=1)], role=nailgun.entities.Role(nailgun.config.ServerConfig(url=u'https://qe-sat6-rhel7.satqe.lab.eng.rdu2.redhat.com', verify=False, auth=(u'admin', u'changeme')), id=1), location=[], organization=[], id=193)
```