### PR TITLE
Update ContentViewPuppetModule entity

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -1347,6 +1347,11 @@ class ContentViewPuppetModule(
                 content_view=self.content_view,  # pylint:disable=no-member
             )
 
+        if attrs is None:
+            attrs = self.read_json()
+        # The puppet_module_id is returned as uuid
+        attrs['puppet_module_id'] = attrs.pop('uuid')
+
         if ignore is None:
             ignore = set()
         ignore.add('content_view')


### PR DESCRIPTION
Rename uuid to puppet_module_id when reading the entity information. The same way that puppet_module_id is converted to uuid when creating, when reading, it should be converted back from uuid to puppet_module_id.

The uuid field is populated when reading when the ContentViewPuppetModule entity is created by passing the content_view_id and the puppet_module_id:

```
2016-04-11 19:00:40 - nailgun.client - DEBUG - Making HTTP POST request to https://sat62.example.com:443/katello/api/v2/content_views/345/content_view_puppet_modules with options {'auth': ('admin', 'changeme'), 'headers': {'content-type': 'application/json'}, 'verify': False} and data {"content_view_id": 345, "uuid": 3}.
2016-04-11 19:00:41 - nailgun.client - DEBUG - Received HTTP 200 response:   {"id":15,"uuid":3,"name":"samba","author":"puppet"}
```

The uuid is null when reading when the ContentViewPuppetModule entity is created by passing the puppet module name and author and content_view_id:

```
2016-04-11 19:03:00 - nailgun.client - DEBUG - Making HTTP POST request to https://sat62.example.com:443/katello/api/v2/content_views/345/content_view_puppet_modules with options {'auth': ('admin', 'changeme'), 'headers': {'content-type': 'application/json'}, 'verify': False} and data {"author": "puppet", "content_view_id": 345, "name": "cron"}.
2016-04-11 19:03:02 - nailgun.client - DEBUG - Received HTTP 200 response:   {"id":16,"uuid":null,"name":"cron","author":"puppet"}
```