### PR TITLE
Added 'content_facet_attributes' field for Host entity

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2092,6 +2092,7 @@ class Host(  # pylint:disable=too-many-instance-attributes
             'compute_profile': entity_fields.OneToOneField(ComputeProfile),
             'compute_resource': entity_fields.OneToOneField(
                 AbstractComputeResource),
+            'content_facet_attributes': entity_fields.DictField(),
             'domain': entity_fields.OneToOneField(Domain),
             'enabled': entity_fields.BooleanField(),
             'environment': entity_fields.OneToOneField(Environment),
@@ -2299,11 +2300,17 @@ class Host(  # pylint:disable=too-many-instance-attributes
         For more information, see `Bugzilla #1235019
         <https://bugzilla.redhat.com/show_bug.cgi?id=1235019>`_.
 
+        `content_facet_attributes` are returned as `content`, and only in case
+        any of facet attributes were actually set.
         """
         if attrs is None:
             attrs = self.read_json()
         if ignore is None:
             ignore = set()
+        if attrs.get('content'):
+            attrs['content_facet_attributes'] = attrs.pop('content')
+        else:
+            ignore.add('content_facet_attributes')
         ignore.add('root_pass')
         attrs['host_parameters_attributes'] = attrs.pop('parameters')
         attrs['puppet_class'] = attrs.pop('puppetclasses')


### PR DESCRIPTION
`content_facet_attributes` are not even documented yet :smile: , but that's the way we are supposed to associate host with content view or lifecycle environment, just like that:
```python
        host = entities.Host(
            content_facet_attributes={
                'content_view_id': content_view.id,
                'lifecycle_environment_id': lc_env.id,
            },
            organization=org,
        ).create()
```
The thing with this field is it's returned as `content`, and is only returned when it was set to some value, that's why some workarounds were added.

Some proofs it's actually working:
```python
>>> org = entities.Organization().create()
>>> lc_env = entities.LifecycleEnvironment(organization=org).create()
>>> content_view = entities.ContentView(organization=org).create()
>>> content_view.publish()
>>> content_view = content_view.read()
>>> promote(content_view.version[0], lc_env.id)
>>> host = entities.Host(
...      content_facet_attributes={
...          'content_view_id': content_view.id,
...          'lifecycle_environment_id': lc_env.id,
...      },
...      organization=org,
...  ).create()
>>> host.content_facet_attributes
{u'content_view_id': 1733, u'content_view_name': u'\U000290db\ua0d4\uc0d0\u679b\U00021ad3\uc3bc\u5a07\U0002494d\ubfc2\U00029d65\U0002903e\U0002134f\u8737', u'content_view_version_id': 1623, u'uuid': None, u'content_view': {u'id': 1733, u'name': u'\U000290db\ua0d4\uc0d0\u679b\U00021ad3\uc3bc\u5a07\U0002494d\ubfc2\U00029d65\U0002903e\U0002134f\u8737'}, u'lifecycle_environment_library?': False, u'lifecycle_environment_name': u'\ub070\u98da\U00021e0f\U00021fc2\u1b24\U00026cfa', u'lifecycle_environment': {u'id': 1676, u'name': u'\ub070\u98da\U00021e0f\U00021fc2\u1b24\U00026cfa'}, u'content_view_version': u'1.0', u'lifecycle_environment_id': 1676, u'content_view_default?': False, u'id': 39, u'errata_counts': None}
```
And if no `content_facet_attributes` were passed, Host.read() is ignoring that field, so it won't fail because of missing field.
