### PR TITLE
Let pylint use all CPU cores

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 TEST_OPTIONS=-m unittest discover --start-directory tests --top-level-directory .
+CPU_COUNT=$(shell python -c "from multiprocessing import cpu_count; print(cpu_count())")
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of:"
@@ -19,9 +20,9 @@ docs-clean:
 
 lint:
 	flake8 .
-	pylint --reports=n --disable=I --ignore-imports=y \
+	pylint -j $(CPU_COUNT) --reports=n --disable=I --ignore-imports=y \
 		nailgun tests setup.py docs/conf.py
-	pylint --reports=n --disable=I --ignore-imports=y --disable=similarities \
+	pylint -j $(CPU_COUNT) --reports=n --disable=I --ignore-imports=y --disable=similarities \
 		docs/create_organization_nailgun.py \
 		docs/create_organization_nailgun_v2.py \
 		docs/create_organization_plain.py \


### PR DESCRIPTION
The `lint` make targets calls flake8 and pylint. By default, pylint uses
one CPU core. Update the make file and tell pylint to use all available
CPU cores. On the author's anemic quad-core system, `git clean -dfx &&
time make lint` reports the following times (in seconds) without this
patch:

1. 31
2. 31
3. 31
4. 31
5. 31

…and with this patch:

1. 19
2. 19
3. 18
4. 19
5. 19