### PR TITLE
Fixing Activations Key entity according to 6.2

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -206,14 +206,18 @@ class ActivationKey(
             'description': entity_fields.StringField(),
             'environment': entity_fields.OneToOneField(LifecycleEnvironment),
             'host_collection': entity_fields.OneToManyField(HostCollection),
-            'max_content_hosts': entity_fields.IntegerField(),
+            'max_hosts': entity_fields.IntegerField(),
             'name': entity_fields.StringField(required=True),
             'organization': entity_fields.OneToOneField(
                 Organization,
                 required=True,
             ),
-            'unlimited_content_hosts': entity_fields.BooleanField(),
+            'unlimited_hosts': entity_fields.BooleanField(),
         }
+        if _get_version(server_config) < Version('6.2'):
+            self._fields['max_content_hosts'] = self._fields.pop('max_hosts')
+            self._fields['unlimited_content_hosts'] = self._fields.pop(
+                'unlimited_hosts')
         self._meta = {
             'api_path': 'katello/api/v2/activation_keys',
             'server_modes': ('sat', 'sam'),


### PR DESCRIPTION
```
>>> test = entities.ActivationKey().create(create_missing=True)
>>> test
nailgun.entities.ActivationKey(nailgun.config.ServerConfig(url=u'https://server', verify=False, auth=(u'admin', u'changeme')), host_collection=[], max_hosts=None, content_view=None, description=None, unlimited_hosts=True, environment=None, auto_attach=True, organization=nailgun.entities.Organization(nailgun.config.ServerConfig(url=u'https://server', verify=False, auth=(u'admin', u'changeme')), id=1240), id=102, name=u'org_name')
```