### PR TITLE
Link to readthedocs.io, not readthedocs.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ NailGun
 NailGun is a GPL-licensed Python library that facilitates easy usage of the
 Satellite 6 API.
 
-The `full documentation <http://nailgun.readthedocs.org/en/latest/>`_ is
+The `full documentation <http://nailgun.readthedocs.io/en/latest/>`_ is
 available on ReadTheDocs. It can also be generated locally::
 
     pip install -r requirements.txt -r requirements-dev.txt

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -392,4 +392,4 @@ shorter! This makes it easier to focus on high-level business logic instead of
 worrying about implementation details.
 
 .. _Requests: http://docs.python-requests.org/en/latest/
-.. _Robottelo: http://robottelo.readthedocs.org/en/latest/
+.. _Robottelo: http://robottelo.readthedocs.io/en/latest/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -128,6 +128,6 @@ Please adhere to the following guidelines:
 .. _good commit messages: http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html
 .. _Rebasing: http://www.git-scm.com/book/en/v2/Git-Branching-Rebasing
 .. _Requests: http://docs.python-requests.org/en/latest/
-.. _Robottelo: http://robottelo.readthedocs.org/en/latest/
+.. _Robottelo: http://robottelo.readthedocs.io/en/latest/
 .. _Robottelo source code: https://github.com/SatelliteQE/robottelo
 .. _this blog post: http://www.ichimonji10.name/blog/4/


### PR DESCRIPTION
From an announcement sent on 2016-04-27:

> Starting today, Read the Docs will start hosting projects from
> subdomains on the domain readthedocs.io, instead of on
> readthedocs.org. This change addresses some security concerns around
> site cookies while hosting user generated data on the same domain as
> our dashboard.