### PR TITLE
Updated `display_type` attribute of LibvirtComputeResource for GA

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -774,7 +774,7 @@ class LibvirtComputeResource(AbstractComputeResource):  # pylint:disable=R0901
     def __init__(self, server_config=None, **kwargs):
         self._fields = {
             'display_type': entity_fields.StringField(
-                choices=(u'VNC', u'SPICE'),
+                choices=(u'vnc', u'spice'),
                 required=True,
             ),
             'set_console_password': entity_fields.BooleanField(),


### PR DESCRIPTION
`display_type` attribute of LibvirtComputeResource entity is now returned in lower case.
Uppercase is still accepted, but we have some tests which validate consistency between accepted & returned values.
Related robottelo PR: SatelliteQE/robottelo#3436
Test results:
```python
py.test tests/foreman/api/test_multiple_paths.py -k DoubleCheckTestCase
================================ test session starts =================================
platform linux2 -- Python 2.7.10, pytest-2.9.1, py-1.4.31, pluggy-0.3.1
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
collected 16 items 

tests/foreman/api/test_multiple_paths.py ...

=================== 13 tests deselected by '-kDoubleCheckTestCase' ===================
===================== 3 passed, 13 deselected in 339.35 seconds ======================
```