### PR TITLE
Fixing sync plan update_payload to update only specific field

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -4167,7 +4167,7 @@ class SyncPlan(
 
     def update_payload(self, fields=None):
         """Convert ``sync_date`` to a string if datetime object provided."""
-        data = super(SyncPlan, self).update_payload()
+        data = super(SyncPlan, self).update_payload(fields)
         if isinstance(data.get('sync_date'), datetime):
             data['sync_date'] = data['sync_date'].strftime('%Y-%m-%d %H:%M:%S')
         return data


### PR DESCRIPTION
Just an example that fix is working
```
for i in {1..10}; do py.test tests/foreman/api/test_syncplan.py -k test_positive_update_interval; done
=========================================================================== test session starts ============================================================================
platform linux2 -- Python 2.7.5, pytest-2.8.1, py-1.4.30, pluggy-0.3.1
rootdir: /home/oshtaier/Desktop/robottelo, inifile: 
collected 30 items 

tests/foreman/api/test_syncplan.py .

========================================================= 29 tests deselected by '-ktest_positive_update_interval' =========================================================
================================================================= 1 passed, 29 deselected in 12.65 seconds =================================================================
=========================================================================== test session starts ============================================================================
platform linux2 -- Python 2.7.5, pytest-2.8.1, py-1.4.30, pluggy-0.3.1
rootdir: /home/oshtaier/Desktop/robottelo, inifile: 
collected 30 items 

tests/foreman/api/test_syncplan.py .

========================================================= 29 tests deselected by '-ktest_positive_update_interval' =========================================================
================================================================= 1 passed, 29 deselected in 12.94 seconds =================================================================
=========================================================================== test session starts ============================================================================
platform linux2 -- Python 2.7.5, pytest-2.8.1, py-1.4.30, pluggy-0.3.1
rootdir: /home/oshtaier/Desktop/robottelo, inifile: 
collected 30 items 

tests/foreman/api/test_syncplan.py .

========================================================= 29 tests deselected by '-ktest_positive_update_interval' =========================================================
================================================================= 1 passed, 29 deselected in 12.63 seconds =================================================================
=========================================================================== test session starts ============================================================================
platform linux2 -- Python 2.7.5, pytest-2.8.1, py-1.4.30, pluggy-0.3.1
rootdir: /home/oshtaier/Desktop/robottelo, inifile: 
collected 30 items 

tests/foreman/api/test_syncplan.py .

========================================================= 29 tests deselected by '-ktest_positive_update_interval' =========================================================
================================================================= 1 passed, 29 deselected in 12.79 seconds =================================================================
=========================================================================== test session starts ============================================================================
platform linux2 -- Python 2.7.5, pytest-2.8.1, py-1.4.30, pluggy-0.3.1
rootdir: /home/oshtaier/Desktop/robottelo, inifile: 
collected 30 items 

tests/foreman/api/test_syncplan.py .

========================================================= 29 tests deselected by '-ktest_positive_update_interval' =========================================================
================================================================= 1 passed, 29 deselected in 13.94 seconds =================================================================
=========================================================================== test session starts ============================================================================
platform linux2 -- Python 2.7.5, pytest-2.8.1, py-1.4.30, pluggy-0.3.1
rootdir: /home/oshtaier/Desktop/robottelo, inifile: 
collected 30 items 

tests/foreman/api/test_syncplan.py .

========================================================= 29 tests deselected by '-ktest_positive_update_interval' =========================================================
================================================================= 1 passed, 29 deselected in 13.03 seconds =================================================================
=========================================================================== test session starts ============================================================================
platform linux2 -- Python 2.7.5, pytest-2.8.1, py-1.4.30, pluggy-0.3.1
rootdir: /home/oshtaier/Desktop/robottelo, inifile: 
collected 30 items 

tests/foreman/api/test_syncplan.py .

========================================================= 29 tests deselected by '-ktest_positive_update_interval' =========================================================
================================================================= 1 passed, 29 deselected in 12.78 seconds =================================================================
=========================================================================== test session starts ============================================================================
platform linux2 -- Python 2.7.5, pytest-2.8.1, py-1.4.30, pluggy-0.3.1
rootdir: /home/oshtaier/Desktop/robottelo, inifile: 
collected 30 items 

tests/foreman/api/test_syncplan.py .

========================================================= 29 tests deselected by '-ktest_positive_update_interval' =========================================================
================================================================= 1 passed, 29 deselected in 13.04 seconds =================================================================
=========================================================================== test session starts ============================================================================
platform linux2 -- Python 2.7.5, pytest-2.8.1, py-1.4.30, pluggy-0.3.1
rootdir: /home/oshtaier/Desktop/robottelo, inifile: 
collected 30 items 

tests/foreman/api/test_syncplan.py .

========================================================= 29 tests deselected by '-ktest_positive_update_interval' =========================================================
================================================================= 1 passed, 29 deselected in 12.72 seconds =================================================================
=========================================================================== test session starts ============================================================================
platform linux2 -- Python 2.7.5, pytest-2.8.1, py-1.4.30, pluggy-0.3.1
rootdir: /home/oshtaier/Desktop/robottelo, inifile: 
collected 30 items 

tests/foreman/api/test_syncplan.py .

========================================================= 29 tests deselected by '-ktest_positive_update_interval' =========================================================
================================================================= 1 passed, 29 deselected in 16.23 seconds =================================================================
```