### PR TITLE
Fix parameter list for content view puppet modules entity

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -1363,7 +1363,7 @@ class ContentViewPuppetModule(
                 str_type='alpha',
                 length=(6, 12)
             ),
-            'puppet_module': entity_fields.OneToOneField(PuppetModule),
+            'uuid': entity_fields.StringField(),
         }
         super(ContentViewPuppetModule, self).__init__(server_config, **kwargs)
         self._meta = {
@@ -1396,28 +1396,10 @@ class ContentViewPuppetModule(
                 self._server_config,
                 content_view=self.content_view,  # pylint:disable=no-member
             )
-
-        if attrs is None:
-            attrs = self.read_json()
-        # The puppet_module_id is returned as uuid
-        attrs['puppet_module_id'] = attrs.pop('uuid')
-
         if ignore is None:
             ignore = set()
         ignore.add('content_view')
         return super(ContentViewPuppetModule, self).read(entity, attrs, ignore)
-
-    def create_payload(self):
-        """Rename the ``puppet_module_id`` field to ``uuid``.
-
-        For more information, see `Bugzilla #1238731
-        <https://bugzilla.redhat.com/show_bug.cgi?id=1238731>`_.
-
-        """
-        payload = super(ContentViewPuppetModule, self).create_payload()
-        if 'puppet_module_id' in payload:
-            payload['uuid'] = payload.pop('puppet_module_id')
-        return payload
 
 
 class ContentView(

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -523,8 +523,7 @@ class CreatePayloadTestCase(TestCase):
             )
         ]
         entities_.extend([
-            (entities.SyncPlan, {'organization': 1}),
-            (entities.ContentViewPuppetModule, {'content_view': 1}),
+            (entities.SyncPlan, {'organization': 1})
         ])
         for entity, params in entities_:
             with self.subTest():
@@ -543,16 +542,6 @@ class CreatePayloadTestCase(TestCase):
             ).create_payload()['sync_date'],
             type('')  # different for Python 2 and 3
         )
-
-    def test_content_view_puppet_module(self):
-        """Create a :class:`nailgun.entities.ContentViewPuppetModule`."""
-        payload = entities.ContentViewPuppetModule(
-            self.cfg,
-            content_view=1,
-            puppet_module=2,
-        ).create_payload()
-        self.assertNotIn('puppet_module_id', payload)
-        self.assertIn('uuid', payload)
 
     def test_host_collection(self):
         """Create a :class:`nailgun.entities.HostCollection`."""


### PR DESCRIPTION
It seems that overall logic for the flow that we have for that entity has been changed and none from:
```
GET /katello/api/content_views/:content_view_id/content_view_puppet_modules
POST /katello/api/content_views/:content_view_id/content_view_puppet_modules
GET /katello/api/content_views/:content_view_id/content_view_puppet_modules/:id
PUT /katello/api/content_views/:content_view_id/content_view_puppet_modules/:id
DELETE /katello/api/content_views/:content_view_id/content_view_puppet_modules/:id
```
accept `'puppet_module': entity_fields.OneToOneField(PuppetModule)` parameter
and
`payload['uuid'] = payload.pop('puppet_module_id')` is invalid as uuid parameter has nothing in common with puppet module id

It doesn't seem that conditions mentioned in https://bugzilla.redhat.com/show_bug.cgi?id=1238731 have been met, but it doesn't seem that it is so critical to have that change in place either.

For example:
```
Making HTTP POST request to https://server/katello/api/v2/content_views/21/content_view_puppet_modules with options {'verify': False, 'auth': ('admin', 'changeme'), 'headers': {'content-type': 'application/json'}} and data {"content_view_id": 21, "id": 2}.

Received HTTP 200 response:   {"id":7,"uuid":"c7f26ae2-e87e-490f-a3c0-493977e3bd8e","name":"ntp","author":"puppetlabs"}
```
Here we can understand that `"id": 2` is puppet module id, `"id":7` is content view puppet module id and `"uuid":"c7f26ae2-e87e-490f-a3c0-493977e3bd8e"` is puppet module uuid.

Anyway if we have changes to the names in future, we can work on that, but current logic (especially with create_payload) is invalid. We can apply something like this for `update_payload` once we gonna add that mixin to the entity, but at that moment let's stick to proper code
