### PR TITLE
Using a decorator to emit signals "DRY"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ docs-clean:
 	@cd docs; $(MAKE) clean
 
 lint:
-	flake8 .
+	flake8 --ignore=E731 .
 	pylint -j $(CPU_COUNT) --reports=n --disable=I --ignore-imports=y \
 		nailgun tests setup.py docs/conf.py
 	pylint -j $(CPU_COUNT) --reports=n --disable=I --ignore-imports=y --disable=similarities \

--- a/docs/signals.rst
+++ b/docs/signals.rst
@@ -15,6 +15,9 @@ Signals
 Overview
 --------
 
+The nailgun signals are provided by `blinker_herald`_ module and offers the same
+features as `blinker`_.
+
 Signals are found within the `nailgun.signals` module.
 The first positional argument of a signal handler is always `sender` which is a
 reference to the caller object (self).
@@ -79,6 +82,19 @@ A handler (also called listener) is a function like the following::
         sender.domain = "http://example.com"
 
 
+The first argument is always the **sender** which defaults to the **self** or **cls**
+of the caller. Note that handlers can accept only one positional argument,
+all the others arguments must be named or captured by the ``**kwargs``
+also note that **signal_emitter** argument will always be passed to handlers
+to keep a reference to caller object in the cases where **sender** argument
+is explicitly specified in the caller.
+
+.. note::
+  NOTE: Always end your handler signature with
+  ``**kwargs`` to capture all possible arguments
+  otherwise signals will fail if new arguments added to emitter function.
+
+
 You attach the event handler to a signal that will be emitted to all entities in general::
 
     from nailgun import signals
@@ -88,9 +104,11 @@ You attach the event handler to a signal that will be emitted to all entities in
 Everytime the `.create` method is called the all the connected handlers will be called
 by signaling and any kind of manipulation can be performed.
 
-If your handler meant to deal only with a specific type of entity you'll need
-to inspect its instance type. `if isinstance(sender, entities.Organization)` otherwise
-the action will be performed for all types of entities.
+.. note::
+  If your handler meant to deal only with a specific type of entity you'll need
+  to inspect its instance type. :code:`if isinstance(sender, entities.Organization)` otherwise
+  the action will be performed for all types of entities. Or use a specific
+  sender and connect using :code:`.connect_via()` decorator os specifying **sender** while connecting.
 
 Finally, you can also use signals as decorators to quickly create a number of
 signals handlers and attach them::
@@ -103,3 +121,4 @@ signals handlers and attach them::
             # do something in post create only for Organizations
 
 .. _blinker: http://pypi.python.org/pypi/blinker
+.. _blinker_herald: http://pypi.python.org/pypi/blinker_herald

--- a/nailgun/client.py
+++ b/nailgun/client.py
@@ -115,7 +115,7 @@ def _log_response(response):
         response.status_code,
         response.text
     )
-    if response.status_code >= 400:
+    if response.status_code >= 400:  # pragma: no cover
         logger.warning(message)
     else:
         logger.debug(message)

--- a/nailgun/config.py
+++ b/nailgun/config.py
@@ -209,7 +209,7 @@ class BaseServerConfig(object):
         """
         # What will we write out?
         cfg = vars(self)
-        if 'version' in cfg:
+        if 'version' in cfg:  # pragma: no cover
             cfg['version'] = str(cfg['version'])
 
         # Where is the file we're writing to?
@@ -226,7 +226,7 @@ class BaseServerConfig(object):
             try:
                 with open(path) as config_file:
                     config = json.load(config_file)
-            except IOError:
+            except IOError:  # pragma: no cover
                 config = {}
             config[label] = cfg
             with open(path, 'w') as config_file:

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -323,6 +323,7 @@ class Architecture(
         """
         return {u'architecture': super(Architecture, self).create_payload()}
 
+    @signals.emit(sender=signals.SENDER_CLASS, post_result_name='entity')
     def update(self, fields=None):
         """Fetch a complete set of attributes for this entity.
 
@@ -576,6 +577,7 @@ class AbstractComputeResource(
             ).update_payload(fields)
         }
 
+    @signals.emit(sender=signals.SENDER_CLASS)
     def update(self, fields=None):
         """Fetch a complete set of attributes for this entity.
 
@@ -762,6 +764,7 @@ class DockerComputeResource(AbstractComputeResource):  # pylint:disable=R0901
         self._fields['provider'].required = True
         self._fields['provider_friendly_name'].default = 'Docker'
 
+    @signals.emit(sender=signals.SENDER_CLASS, post_result_name='entity')
     def create(self, create_missing=None):
         """Do extra work to fetch a complete set of attributes for this entity.
 
@@ -903,6 +906,7 @@ class ConfigTemplate(
             u'config_template': super(ConfigTemplate, self).create_payload()
         }
 
+    @signals.emit(sender=signals.SENDER_CLASS, post_result_name='entity')
     def update(self, fields=None):
         """Fetch a complete set of attributes for this entity.
 
@@ -1042,6 +1046,7 @@ class AbstractDockerContainer(
             u'container': super(AbstractDockerContainer, self).create_payload()
         }
 
+    @signals.emit(sender=signals.SENDER_CLASS, post_result_name='entity')
     def create(self, create_missing=None):
         """Do extra work to fetch a complete set of attributes for this entity.
 
@@ -1627,6 +1632,7 @@ class Domain(
         """
         return {u'domain': super(Domain, self).create_payload()}
 
+    @signals.emit(sender=signals.SENDER_CLASS, post_result_name='entity')
     def create(self, create_missing=None):
         """Manually fetch a complete set of attributes for this entity.
 
@@ -1651,6 +1657,7 @@ class Domain(
         attrs['domain_parameters_attributes'] = attrs.pop('parameters')
         return super(Domain, self).read(entity, attrs, ignore)
 
+    @signals.emit(sender=signals.SENDER_CLASS, post_result_name='entity')
     def update(self, fields=None):
         """Fetch a complete set of attributes for this entity.
 
@@ -1700,6 +1707,7 @@ class Environment(
         """
         return {u'environment': super(Environment, self).create_payload()}
 
+    @signals.emit(sender=signals.SENDER_CLASS, post_result_name='entity')
     def update(self, fields=None):
         """Fetch a complete set of attributes for this entity.
 
@@ -2031,6 +2039,7 @@ class HostGroup(
         self._meta = {'api_path': 'api/v2/hostgroups', 'server_modes': ('sat')}
         super(HostGroup, self).__init__(server_config, **kwargs)
 
+    @signals.emit(sender=signals.SENDER_CLASS, post_result_name='entity')
     def create(self, create_missing=None):
         """Do extra work to fetch a complete set of attributes for this entity.
 
@@ -2080,6 +2089,7 @@ class HostGroup(
                 attrs[attr] = attrs2[attr]
         return super(HostGroup, self).read(entity, attrs, ignore)
 
+    @signals.emit(sender=signals.SENDER_CLASS, post_result_name='entity')
     def update(self, fields=None):
         """Deal with several bugs.
 
@@ -2391,6 +2401,7 @@ class Host(  # pylint:disable=too-many-instance-attributes
         attrs['puppet_class'] = attrs.pop('puppetclasses')
         return super(Host, self).read(entity, attrs, ignore)
 
+    @signals.emit(sender=signals.SENDER_CLASS, post_result_name='entity')
     def update(self, fields=None):
         """Fetch a complete set of attributes for this entity.
 
@@ -2589,6 +2600,7 @@ class Location(
             u'location': super(Location, self).create_payload()
         }
 
+    @signals.emit(sender=signals.SENDER_CLASS, post_result_name='entity')
     def create(self, create_missing=None):
         """Manually fetch a complete set of attributes for this entity.
 
@@ -2611,6 +2623,7 @@ class Location(
         ignore.add('realm')
         return super(Location, self).read(entity, attrs, ignore)
 
+    @signals.emit(sender=signals.SENDER_CLASS, post_result_name='entity')
     def update(self, fields=None):
         """Fetch a complete set of attributes for this entity.
 
@@ -2671,6 +2684,7 @@ class Media(
             payload['path'] = payload.pop('path_')
         return {u'medium': payload}
 
+    @signals.emit(sender=signals.SENDER_CLASS, post_result_name='entity')
     def create(self, create_missing=None):
         """Manually fetch a complete set of attributes for this entity.
 
@@ -2690,6 +2704,7 @@ class Media(
         attrs['path_'] = attrs.pop('path')
         return super(Media, self).read(entity, attrs, ignore)
 
+    @signals.emit(sender=signals.SENDER_CLASS, post_result_name='entity')
     def update(self, fields=None):
         """Fetch a complete set of attributes for this entity.
 
@@ -2949,6 +2964,7 @@ class Organization(
             )
         return super(Organization, self).path(which)
 
+    @signals.emit(sender=signals.SENDER_CLASS, post_result_name='entity')
     def create(self, create_missing=None):
         """Do extra work to fetch a complete set of attributes for this entity.
 
@@ -2956,13 +2972,10 @@ class Organization(
         <https://bugzilla.redhat.com/show_bug.cgi?id=1230873>`_.
 
         """
-        signals.pre_create.send(self, create_missing=create_missing)
-        entity = Organization(
+        return Organization(
             self._server_config,
             id=self.create_json(create_missing)['id'],
         ).read()
-        signals.post_create.send(self, entity=entity)
-        return entity
 
     def read(self, entity=None, attrs=None, ignore=None):
         """Fetch as many attributes as possible for this entity.
@@ -2977,6 +2990,7 @@ class Organization(
         ignore.add('realm')
         return super(Organization, self).read(entity, attrs, ignore)
 
+    @signals.emit(sender=signals.SENDER_CLASS, post_result_name='entity')
     def update(self, fields=None):
         """Fetch a complete set of attributes for this entity.
 
@@ -2987,11 +3001,8 @@ class Organization(
             #1230865 <https://bugzilla.redhat.com/show_bug.cgi?id=1230865>`_.
 
         """
-        signals.pre_update.send(self, fields=fields)
         self.update_json(fields)
-        entity = self.read()
-        signals.post_update.send(self, entity=entity, fields=fields)
-        return entity
+        return self.read()
 
     def update_payload(self, fields=None):
         """Wrap submitted data within an extra dict."""
@@ -3223,6 +3234,7 @@ class PartitionTable(
         # The following fields were added in Satellite 6.2, removing them if we
         # have previous version of Satellite
         if _get_version(self._server_config) < Version('6.2'):
+            # pragma: no cover
             self._fields.pop('location')
             self._fields.pop('organization')
 
@@ -3299,6 +3311,7 @@ class Realm(
         self._meta = {'api_path': 'api/v2/realms', 'server_modes': ('sat')}
         super(Realm, self).__init__(server_config, **kwargs)
 
+    @signals.emit(sender=signals.SENDER_CLASS, post_result_name='entity')
     def create(self, create_missing=None):
         """Do extra work to fetch a complete set of attributes for this entity.
 
@@ -3306,13 +3319,10 @@ class Realm(
         <https://bugzilla.redhat.com/show_bug.cgi?id=1232855>`_.
 
         """
-        signals.pre_create.send(self, create_missing=create_missing)
-        entity = Realm(
+        return Realm(
             self._server_config,
             id=self.create_json(create_missing)['id'],
         ).read()
-        signals.post_create.send(self, entity=entity)
-        return entity
 
 
 class Registry(
@@ -3882,6 +3892,7 @@ class SmartProxy(
         response = client.put(self.path('refresh'), **kwargs)
         return _handle_response(response, self._server_config, synchronous)
 
+    @signals.emit(sender=signals.SENDER_CLASS, post_result_name='entity')
     def update(self, fields=None):
         """Fetch a complete set of attributes for this entity.
 
@@ -3889,11 +3900,8 @@ class SmartProxy(
         <https://bugzilla.redhat.com/show_bug.cgi?id=1262037>`_.
 
         """
-        signals.pre_update.send(self, fields=fields)
         self.update_json(fields)
-        entity = self.read()
-        signals.post_update.send(self, entity=entity, fields=fields)
-        return entity
+        return self.read()
 
     def update_payload(self, fields=None):
         """Wrap submitted data within an extra dict."""
@@ -4552,6 +4560,7 @@ class UserGroup(
         """
         return {u'usergroup': super(UserGroup, self).update_payload(fields)}
 
+    @signals.emit(sender=signals.SENDER_CLASS, post_result_name='entity')
     def create(self, create_missing=None):
         """Do extra work to fetch a complete set of attributes for this entity.
 
@@ -4559,13 +4568,10 @@ class UserGroup(
         <https://bugzilla.redhat.com/show_bug.cgi?id=1301658>`_.
 
         """
-        signals.pre_create.send(self, create_missing=create_missing)
-        entity = UserGroup(
+        return UserGroup(
             self._server_config,
             id=self.create_json(create_missing)['id'],
         ).read()
-        signals.post_create.send(self, entity=entity)
-        return entity
 
     def read(self, entity=None, attrs=None, ignore=None):
         """Work around `Redmine #9594`_.
@@ -4658,6 +4664,7 @@ class User(
         """Wrap submitted data within an extra dict."""
         return {u'user': super(User, self).update_payload(fields)}
 
+    @signals.emit(sender=signals.SENDER_CLASS, post_result_name='entity')
     def update(self, fields=None):
         """Fetch a complete set of attributes for this entity.
 
@@ -4665,8 +4672,5 @@ class User(
         <https://bugzilla.redhat.com/show_bug.cgi?id=1235012>`_.
 
         """
-        signals.pre_update.send(self, fields=fields)
         self.update_json(fields)
-        entity = self.read()
-        signals.post_update.send(self, entity=entity, fields=fields)
-        return entity
+        return self.read()

--- a/nailgun/signals.py
+++ b/nailgun/signals.py
@@ -1,60 +1,21 @@
 # -*- coding: utf-8 -*-
 """Defines a set of named signals for entities operations"""
 # pylint: disable-all
-__all__ = ['pre_create', 'post_create',
-           'pre_delete', 'post_delete',
-           'pre_update', 'post_update',
-           'pre_search', 'post_search']
 
-SIGNALS_AVAILABLE = False
-try:
-    from blinker import Namespace
-    SIGNALS_AVAILABLE = True
-except ImportError:  # pragma: no cover
-    class Namespace(object):
-        """A fake namespace in case of blinker is not installed"""
+import blinker_herald
 
-        def signal(self, name, doc=None):
-            """A fake signal when blinker is not installed"""
-            return _FakeSignal(name, doc)
+emit = blinker_herald.emit
+SENDER_CLASS = blinker_herald.SENDER_CLASS
+SIGNALS_AVAILABLE = blinker_herald.SIGNALS_AVAILABLE
 
-    class _FakeSignal(object):
-        """If blinker is unavailable, create a fake class with the same
-        interface that allows sending of signals but will fail with an
-        error on anything else.  Instead of doing anything on send, it
-        will just ignore the arguments and do nothing instead.
-        """
+pre_create = blinker_herald.signals_namespace.signal('pre_create')
+post_create = blinker_herald.signals_namespace.signal('post_create')
 
-        def __init__(self, name, doc=None):
-            self.name = name
-            self.__doc__ = doc
+pre_update = blinker_herald.signals_namespace.signal('pre_update')
+post_update = blinker_herald.signals_namespace.signal('post_update')
 
-        def _fail(self, *args, **kwargs):
-            """To raise if blinker is not installed"""
-            raise RuntimeError('signalling support is unavailable '
-                               'because the blinker library is '
-                               'not installed.')
+pre_delete = blinker_herald.signals_namespace.signal('pre_delete')
+post_delete = blinker_herald.signals_namespace.signal('post_delete')
 
-        def send(self, *sender, **kwargs):
-            """A fake send does nothing"""
-            pass
-
-        connect = disconnect = has_receivers_for = _fail
-        receivers_for = temporarily_connected_to = _fail
-        del _fail
-
-# the namespace for code signals.  If you are not nailgun code, do
-# not put signals in here.  Create your own namespace instead.
-_signals = Namespace()
-
-pre_create = _signals.signal('pre_create')
-post_create = _signals.signal('post_create')
-
-pre_update = _signals.signal('pre_update')
-post_update = _signals.signal('post_update')
-
-pre_delete = _signals.signal('pre_delete')
-post_delete = _signals.signal('post_delete')
-
-pre_search = _signals.signal('pre_search')
-post_search = _signals.signal('post_search')
+pre_search = blinker_herald.signals_namespace.signal('pre_search')
+post_search = blinker_herald.signals_namespace.signal('post_search')

--- a/setup.py
+++ b/setup.py
@@ -44,5 +44,6 @@ setup(
         'packaging',
         'pyxdg',
         'requests>=2.7',
+        'blinker_herald'
     ],
 )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -34,6 +34,11 @@ class ContentTypeIsJsonTestCase(TestCase):
             # pylint:disable=protected-access
             self.assertFalse(client._content_type_is_json(kwargs))
 
+    def test_false_with_no_headers(self):
+        """If no headers passed should return None"""
+        # pylint:disable=protected-access
+        self.assertFalse(client._content_type_is_json({}))
+
 
 class SetContentTypeTestCase(TestCase):
     """Tests for function ``_set_content_type``."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,8 @@
 """Unit tests for :mod:`nailgun.config`."""
 from mock import call, mock_open, patch
-from nailgun.config import BaseServerConfig, ServerConfig
+from nailgun.config import (
+    BaseServerConfig, ServerConfig, _get_config_file_path, ConfigFileError
+)
 from packaging.version import parse
 import json
 
@@ -159,6 +161,12 @@ class ServerConfigTestCase(TestCase):
                 _convert_bsc_attrs(config),
                 vars(ServerConfig(**config)),
             )
+
+    def test_raise_config_file_error(self):
+        """Should raise error if path not found"""
+        with self.assertRaises(ConfigFileError):
+            # pylint:disable=protected-access
+            _get_config_file_path('foo', 'bar')
 
     def test_get_client_kwargs(self):
         """Test :meth:`nailgun.config.ServerConfig.get_client_kwargs`.

--- a/tests/test_entity_mixins.py
+++ b/tests/test_entity_mixins.py
@@ -329,7 +329,8 @@ class EntityTestCase(TestCase):
         # Call `path()` on an entity with an ID.
         self.assertEqual(SampleEntity(self.cfg, id=5).path(), path + '/5')
         self.assertEqual(SampleEntity(self.cfg, id=5).path('base'), path)
-        self.assertEqual(SampleEntity(self.cfg, id=5).path('self'), path+'/5')
+        self.assertEqual(
+            SampleEntity(self.cfg, id=5).path('self'), path + '/5')
 
     def test_no_such_field_error(self):
         """Try to raise a :class:`nailgun.entity_mixins.NoSuchFieldError`."""

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -68,87 +68,90 @@ class SignalsTestCase(TestCase):
     and if the arguments were passed and catch by connected listeners
     """
 
-    def test_patching(self, client_get, organization_read):
+    def test_signals_available(self, *args, **kwargs):
+        self.assertTrue(signals.SIGNALS_AVAILABLE)
+
+    def test_patching(self, *args, **kwargs):
         '''Make sure patching works'''
         self.assertIsInstance(client.get('http://example.com'), FakeResponse)
         self.assertEqual(entities.Organization(cfg).read(), org)
 
-    def test_pre_create_signal(self, client_get, Organization_read):
+    def test_pre_create_signal(self, *args, **kwargs):
         self.assertIsNone(getattr(org, 'pre_create_emitted', None))
 
         @signals.pre_create.connect
-        def pre_create(sender, create_missing):
+        def pre_create(sender, create_missing, **kwargs):
             sender.pre_create_emitted = True
 
         org.create()
         self.assertTrue(org.pre_create_emitted)
 
-    def test_post_create_signal(self, client_get, Organization_read):
+    def test_post_create_signal(self, *args, **kwargs):
         self.assertIsNone(getattr(org, 'post_create_emitted', None))
 
         @signals.post_create.connect
-        def post_create(sender, entity):
+        def post_create(sender, entity, **kwargs):
             entity.post_create_emitted = True
 
         org.create()
         self.assertTrue(org.post_create_emitted)
 
-    def test_pre_update_signal(self, client_get, Organization_read):
+    def test_pre_update_signal(self, *args, **kwargs):
         self.assertIsNone(getattr(org, 'pre_update_emitted', None))
 
         @signals.pre_update.connect
-        def pre_update(sender, fields):
+        def pre_update(sender, fields, **kwargs):
             sender.pre_update_emitted = True
 
         org.update()
         self.assertTrue(org.pre_update_emitted)
 
-    def test_post_update_signal(self, client_get, Organization_read):
+    def test_post_update_signal(self, *args, **kwargs):
         self.assertIsNone(getattr(org, 'post_update_emitted', None))
 
         @signals.post_update.connect
-        def post_update(sender, entity, fields):
+        def post_update(sender, entity, fields, **kwargs):
             entity.post_update_emitted = True
 
         org.update()
         self.assertTrue(org.post_update_emitted)
 
-    def test_pre_delete_signal(self, client_get, Organization_read):
+    def test_pre_delete_signal(self, *args, **kwargs):
         self.assertIsNone(getattr(org, 'pre_delete_emitted', None))
 
         @signals.pre_delete.connect
-        def pre_delete(sender, synchronous):
+        def pre_delete(sender, synchronous, **kwargs):
             sender.pre_delete_emitted = True
 
         org.delete()
         self.assertTrue(org.pre_delete_emitted)
 
-    def test_post_delete_signal(self, client_get, Organization_read):
+    def test_post_delete_signal(self, *args, **kwargs):
         self.assertIsNone(getattr(org, 'post_delete_emitted', None))
 
         @signals.post_delete.connect
-        def post_delete(sender, synchronous, result):
+        def post_delete(sender, synchronous, result, **kwargs):
             sender.post_delete_emitted = True
 
         deletion_result = org.delete()
         self.assertTrue(org.post_delete_emitted)
         self.assertEqual(deletion_result, ORG_DATA)
 
-    def test_pre_search_signal(self, client_get, Organization_read):
+    def test_pre_search_signal(self, *args, **kwargs):
         self.assertIsNone(getattr(org, 'pre_search_emitted', None))
 
         @signals.pre_search.connect
-        def pre_search(sender, fields, query, filters):
+        def pre_search(sender, fields, query, filters, **kwargs):
             sender.pre_search_emitted = True
 
         org.search()
         self.assertTrue(org.pre_search_emitted)
 
-    def test_post_search_signal(self, client_get, Organization_read):
+    def test_post_search_signal(self, *args, **kwargs):
         self.assertIsNone(getattr(org, 'post_search_emitted', None))
 
         @signals.post_search.connect
-        def post_search(sender, entities, fields, query, filters):
+        def post_search(sender, entities, fields, query, filters, **kwargs):
             sender.post_search_emitted = True
 
         org.search()


### PR DESCRIPTION
I was annoyed by the amount of **.send()** calls we added and thinking on follow the DRY concept I turned all the **.send()** calls in to a decorator.

Now whenever we want to emit a signal we just need to decorate it.

> ~~That decorator can be turned in to an opensource python library itself as a blinker plugin, as I did not found any plugin or blinker feature that does that out of the box~~  https://github.com/SatelliteQE/blinker_herald

Instead of

```python
def create(self, ...):
     signals.pre_create.send(....)
     ...
     signals.post_create.send(...)
     return ...
```

Now we just need to to do

```python
@signals.emit()
def create(self, ....):
    ...
```

No need to change anything in method or function and the **pre** and **post** signals will be emitted.

> Checked the overhead and no significant impact added, actually it is taking less time now, maybe because decorator is pre-compiled in signals.py module and there is only one **send** call there.