### PR TITLE
Read content_facet_attributes directly

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2357,16 +2357,14 @@ class Host(  # pylint:disable=too-many-instance-attributes
         For more information, see `Bugzilla #1235019
         <https://bugzilla.redhat.com/show_bug.cgi?id=1235019>`_.
 
-        `content_facet_attributes` are returned as `content`, and only in case
-        any of facet attributes were actually set.
+        `content_facet_attributes` are returned only in case any of facet
+        attributes were actually set.
         """
         if attrs is None:
             attrs = self.read_json()
         if ignore is None:
             ignore = set()
-        if attrs.get('content'):
-            attrs['content_facet_attributes'] = attrs.pop('content')
-        else:
+        if 'content_facet_attributes' not in attrs:
             ignore.add('content_facet_attributes')
         ignore.add('root_pass')
         attrs['host_parameters_attributes'] = attrs.pop('parameters')

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -919,9 +919,8 @@ class ReadTestCase(TestCase):
             ),
             (
                 entities.Host(self.cfg),
-                {'content': 1, 'parameters': None, 'puppetclasses': None},
+                {'parameters': None, 'puppetclasses': None},
                 {
-                    'content_facet_attributes': 1,
                     'host_parameters_attributes': None,
                     'puppet_class': None,
                 },
@@ -1560,14 +1559,13 @@ class HostTestCase(TestCase):
 
     def test_no_facet_attributes(self):
         """Assert that ``content_facet_attributes`` attribute is ignored when
-        ``content`` attribute is not returned for host
+        ``content_facet_attributes`` attribute is not returned for host
         """
         with mock.patch.object(EntityReadMixin, 'read') as read:
             entities.Host(self.cfg).read(attrs={
                 'parameters': None,
                 'puppetclasses': None,
             })
-            self.assertNotIn('content', read.call_args[0][1])
             self.assertNotIn('content_facet_attributes', read.call_args[0][1])
             self.assertIn('content_facet_attributes', read.call_args[0][2])
 


### PR DESCRIPTION
Satellite is now returning the `content_facet_attributes` as
`content_facet_attributes` key and not more content.

An updated request and response to the host path can be seen below:

```
2016-05-30 09:38:26 - nailgun.client - DEBUG - Making HTTP POST request to https://10.16.4.117:443/api/v2/hosts with options {'verify': False, 'headers': {'content-type': 'application/json'}, 'auth': ('admin', 'changeme')} and data {"host": {"name": "mgcwlg", "root_pass": "\u1fba\u370c\ud853\udd58\ub1a9\ud868\udf42\ud862\ude39\ud866\uddf6\ud3b1\ud86b\uddf5\u8286\ud81a\udc97\u390e\ua444\ufab4\ud864\udd2e\ud85d\udce1\ud868\udfd6\ud85d\ude56\ud852\udca1\ud86c\udeaa\ud867\udc9c\ud867\udf2b\ud71d\ud844\ude4d\u051c\ud851\udee6\u9394\ud854\udd76", "content_facet_attributes": {"lifecycle_environment_id": 7, "content_view_id": 7}, "ptable_id": 109, "domain_id": 4, "organization_id": 7, "mac": "3f:cb:24:45:f2:e2", "location_id": 8, "operatingsystem_id": 5, "environment_id": 10, "architecture_id": 5, "medium_id": 11}}.
2016-05-30 09:38:27 - nailgun.client - DEBUG - Received HTTP 201 response: {"ip":null,"environment_id":9,"environment_name":"KT_SIFehvoJ_WvFZYsj_eSFMcrrkoN_7","last_report":null,"mac":"3f:cb:24:45:f2:e2","realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":4,"domain_name":"mwqb1sde8b","architecture_id":5,"architecture_name":"NowKJTeuWv","operatingsystem_id":5,"operatingsystem_name":"fsahiVlEDvne 858","subnet_id":null,"subnet_name":null,"sp_subnet_id":null,"ptable_id":109,"ptable_name":"XfouujtTsXzb","medium_id":11,"medium_name":"MrUAqF","build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":3,"owner_type":"User","enabled":true,"puppet_ca_proxy_id":null,"managed":true,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","puppet_proxy_id":null,"certname":"mgcwlg.mwqb1sde8b","image_id":null,"image_name":null,"created_at":"2016-05-30 12:38:27 UTC","updated_at":"2016-05-30 12:38:27 UTC","last_compile":null,"global_status":0,"global_status_label":"Warning","organization_id":7,"organization_name":"SIFehvoJ","location_id":8,"location_name":"wzxFmav","puppet_status":0,"model_name":null,"build_status":0,"build_status_label":"Installed","errata_status":0,"errata_status_label":"Could not calculate errata status, ensure host is registered and katello-agent is installed","name":"mgcwlg.mwqb1sde8b","id":4,"hostgroup_name":null,"hostgroup_title":null,"content_facet_attributes":{"id":3,"uuid":null,"content_view_id":7,"content_view_name":"eSFMcrrkoN","lifecycle_environment_id":7,"lifecycle_environment_name":"WvFZYsj","content_view":{"id":7,"name":"eSFMcrrkoN"},"lifecycle_environment":{"id":7,"name":"WvFZYsj"},"errata_counts":null,"content_view_version":"1.0","content_view_version_id":7,"content_view_default?":false,"lifecycle_environment_library?":false,"katello_agent_installed":false},"parameters":[],"interfaces":[{"id":8,"name":"mgcwlg.mwqb1sde8b","ip":null,"mac":"3f:cb:24:45:f2:e2","identifier":null,"primary":true,"provision":true,"type":"interface"}],"puppetclasses":[],"config_groups":[],"all_parameters":[],"all_puppetclasses":[],"facts":{},"host_collections":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot":true,"puppetrun_hosts":true,"view_discovered_hosts":true,"submit_discovered_hosts":true,"auto_provision_discovered_hosts":true,"provision_discovered_hosts":true,"edit_discovered_hosts":true,"destroy_discovered_hosts":true}}
```

I have tested this PR by running the API end to end robottelo test suite. The test failed when provisioning a client (after checking the host information) because I am using the IP address which is not related with the changes introduced by this PR.  