### PR TITLE
Small fix: using enumerate instead of iterating with range and len

### DIFF
--- a/tests/test_entity_mixins.py
+++ b/tests/test_entity_mixins.py
@@ -192,9 +192,9 @@ class MakeEntitiesFromIdsTestCase(TestCase):
                 self.cfg
             )
             self.assertEqual(len(entities), len(entity_ids))
-            for i in range(len(entity_ids)):
+            for i, entity_id in enumerate(entity_ids):
                 self.assertIsInstance(entities[i], SampleEntity)
-                self.assertEqual(entities[i].id, entity_ids[i])
+                self.assertEqual(entities[i].id, entity_id)
 
     def test_pass_in_both(self):
         """Let ``entity_objs_and_ids`` be an iterable of integers and IDs."""


### PR DESCRIPTION
Using enumerate will make the code more cleaner and will avoid us to call two functions for retrieving the value.
 
It is possible to iterate a sequence by using range and len, as seen below:

```python
for index in range(len(obj)):
    value = obj[index]
    print(value)
```

This can be rewritten in a more Pythonic way by using the concept of iterable that Python has. If the object provides this capability, this can be rewritten more cleanly as:

```python
for value in obj:
    print(value)
```

But if both the index of the value and value itself are needed, a more Pythonic way of writing an iteration, instead of using range and len, is to use the enumerate builtin, which returns an iterator of pairs, where the first item is the index and the second one is the value:

```python
for index, value in enumerate(obj):
    print(index, value)
```

```bash
py.test
=== 190 passed, 6 skipped in 1.45 seconds ===
```
**PyLint powered review**