### PR TITLE
Add two more helpers to activation key entity

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -249,6 +249,7 @@ class ActivationKey(
         if which in (
                 'add_subscriptions',
                 'content_override',
+                'host_collections',
                 'releases',
                 'remove_subscriptions',
                 'subscriptions'):
@@ -257,6 +258,23 @@ class ActivationKey(
                 which
             )
         return super(ActivationKey, self).path(which)
+
+    def add_host_collection(self, synchronous=True, **kwargs):
+        """Helper for associating host collection with activation key.
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+
+        """
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.post(self.path('host_collections'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous)
 
     def add_subscriptions(self, synchronous=True, **kwargs):
         """Helper for adding subscriptions to activation key.
@@ -290,6 +308,23 @@ class ActivationKey(
         kwargs = kwargs.copy()  # shadow the passed-in kwargs
         kwargs.update(self._server_config.get_client_kwargs())
         response = client.put(self.path('content_override'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous)
+
+    def remove_host_collection(self, synchronous=True, **kwargs):
+        """Helper for disassociating host collection from the activation key.
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+
+        """
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.put(self.path('host_collections'), **kwargs)
         return _handle_response(response, self._server_config, synchronous)
 
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -258,6 +258,7 @@ class PathTestCase(TestCase):
                 (entities.AbstractDockerContainer, 'power'),
                 (entities.ActivationKey, 'add_subscriptions'),
                 (entities.ActivationKey, 'content_override'),
+                (entities.ActivationKey, 'host_collections'),
                 (entities.ActivationKey, 'releases'),
                 (entities.ActivationKey, 'remove_subscriptions'),
                 (entities.ActivationKey, 'subscriptions'),
@@ -1266,8 +1267,10 @@ class GenericTestCase(TestCase):
         cls.methods_requests = (
             (entities.AbstractDockerContainer(**generic).logs, 'get'),
             (entities.AbstractDockerContainer(**generic).power, 'put'),
+            (entities.ActivationKey(**generic).add_host_collection, 'post'),
             (entities.ActivationKey(**generic).add_subscriptions, 'put'),
             (entities.ActivationKey(**generic).content_override, 'put'),
+            (entities.ActivationKey(**generic).remove_host_collection, 'put'),
             (entities.ConfigTemplate(**generic).build_pxe_default, 'get'),
             (entities.ContentView(**generic).available_puppet_modules, 'get'),
             (entities.ContentView(**generic).copy, 'post'),


### PR DESCRIPTION
```
>>> org = entities.Organization().create(True)
>>> act_key = entities.ActivationKey(organization=org).create(True)
>>> act_key.host_collection
[]
>>> host_collection = entities.HostCollection(organization=org).create(True)
>>> act_key.add_host_collection(data={'host_collection_ids': [host_collection.id]})
>>> act_key.read().host_collection
[nailgun.entities.HostCollection(nailgun.config.ServerConfig(url=u'https://qe-sat6-rhel7.satqe.lab.eng.rdu2.redhat.com', verify=False, auth=(u'admin', u'changeme')), id=71)]
>>> host_collection.id
71
>>> act_key.remove_host_collection(data={'host_collection_ids': [host_collection.id]})
>>> act_key.read().host_collection
[]
```