### PR TITLE
Add DockerRegistryContainer entity

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -1041,10 +1041,7 @@ class AbstractDockerContainer(
             'attach_stderr': entity_fields.BooleanField(),
             'attach_stdin': entity_fields.BooleanField(),
             'attach_stdout': entity_fields.BooleanField(),
-            'command': entity_fields.StringField(
-                required=True,
-                str_type='latin1',
-            ),
+            'command': entity_fields.StringField(required=True, default='top'),
             'compute_resource': entity_fields.OneToOneField(
                 AbstractComputeResource,
                 required=True,
@@ -1169,6 +1166,24 @@ class DockerHubContainer(AbstractDockerContainer):
             'tag': entity_fields.StringField(required=True, default='latest'),
         }
         super(DockerHubContainer, self).__init__(server_config, **kwargs)
+
+
+class DockerRegistryContainer(AbstractDockerContainer):
+    """A docker container that comes from custom external registry.
+
+    .. WARNING:: The ``repository_name`` field references an image repository
+        on the custom registry, not a locally created
+        :class:`nailgun.entities.Repository`.
+
+    """
+
+    def __init__(self, server_config=None, **kwargs):
+        self._fields = {
+            'registry': entity_fields.OneToOneField(Registry, required=True),
+            'repository_name': entity_fields.StringField(required=True),
+            'tag': entity_fields.StringField(required=True, default='latest'),
+        }
+        super(DockerRegistryContainer, self).__init__(server_config, **kwargs)
 
 
 class ContentUpload(Entity):

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -101,6 +101,7 @@ class InitTestCase(TestCase):
                 entities.DiscoveryRule,
                 entities.DockerComputeResource,
                 entities.DockerHubContainer,
+                entities.DockerRegistryContainer,
                 entities.Domain,
                 entities.Environment,
                 entities.Errata,
@@ -1342,27 +1343,38 @@ class AbstractDockerContainerTestCase(TestCase):
     def test_get_fields(self):
         """Call ``nailgun.entity_mixins.Entity.get_fields``.
 
-        Assert that ``nailgun.entities.DockerHubContainer.get_fields`` returns
+        Assert that ``nailgun.entities.DockerHubContainer.get_fields`` and
+        ``nailgun.entities.DockerRegistryContainer.get_fields`` return
         a dictionary of attributes that match what is returned by
         ``nailgun.entities.AbstractDockerContainer.get_fields`` but also
-        returns extra attibutes unique to
-        :class:`nailgun.entities.DockerHubContainer`.
+        returns extra attributes unique to them.
 
         """
         abstract_docker = entities.AbstractDockerContainer(
             self.cfg
         ).get_fields()
         docker_hub = entities.DockerHubContainer(self.cfg).get_fields()
+        docker_registry = entities.DockerRegistryContainer(
+            self.cfg).get_fields()
         # Attributes should not match
         self.assertNotEqual(abstract_docker, docker_hub)
+        self.assertNotEqual(abstract_docker, docker_registry)
         # All attributes from a `entities.AbstractDockerContainer`
-        # should be found in a `entities.DockerHubContainer`.
+        # should be found in `entities.DockerHubContainer` and
+        # `entities.DockerRegistyContainer`.
         for key in abstract_docker:
             self.assertIn(key, docker_hub)
+            self.assertIn(key, docker_registry)
         # These fields should be present in a `entities.DockerHubContainer`
         # class but not in a `entities.AbstractDockerContainer` class.
         for attr in ['repository_name', 'tag']:
             self.assertIn(attr, docker_hub)
+            self.assertNotIn(attr, abstract_docker)
+        # These fields should be present in a
+        # `entities.DockerRegistryContainer` class but not in a
+        # `entities.AbstractDockerContainer` class.
+        for attr in ['registry', 'repository_name', 'tag']:
+            self.assertIn(attr, docker_registry)
             self.assertNotIn(attr, abstract_docker)
 
 


### PR DESCRIPTION
```python
>>> entities.DockerRegistryContainer(
...     compute_resource=215,
...     organization=[1784],
...     registry=38,
...     repository_name='rhel',
... ).create()
nailgun.entities.DockerRegistryContainer(nailgun.config.ServerConfig(url=u'https://example.com', verify=False, auth=(u'admin', u'changeme')), tty=None, attach_stdin=None, command=None, tag=None, registry=nailgun.entities.Registry(nailgun.config.ServerConfig(url=u'https://example.com', verify=False, auth=(u'admin', u'changeme')), id=38), id=36, name=u'hopeful_babbage', cpu_set=None, repository_name=u'rhel', attach_stderr=None, compute_resource=nailgun.entities.AbstractComputeResource(nailgun.config.ServerConfig(url=u'https://example.com', verify=False, auth=(u'admin', u'changeme')), id=215), entrypoint=None, location=[], memory=None, organization=[], attach_stdout=None, cpu_shares=None)
```