### PR TITLE
Add EntitySearchMixin to HostCollection closes #307

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -1994,6 +1994,7 @@ class HostCollection(
         EntityCreateMixin,
         EntityDeleteMixin,
         EntityReadMixin,
+        EntitySearchMixin,
         EntityUpdateMixin):
     """A representation of a Host Collection entity."""
 


### PR DESCRIPTION
```console
$ manage shell

In [1]: hcs = entities.HostCollection(organization=5).search(query={'search':'name=GtLsWQY'})

2016-08-19 18:20:44 - nailgun.client - DEBUG - Making HTTP GET request to https://FQDN:443/katello/api/v2/host_collections with options {'verify': False, 'data': '{"organization_id": 5, "search": "name=GtLsWQY"}', 'auth': ('admin', 'xxxxxxx'), 'headers': {'content-type': 'application/json'}} and no data.
2016-08-19 18:20:46 - nailgun.client - DEBUG - Received HTTP 200 response: {"total":13,"subtotal":1,"page":1,"per_page":20,"error":null,"search":"name=GtLsWQY","sort":{"by":null,"order":null},"results":[{"name":"GtLsWQY","organization_id":5,"max_hosts":null,"description":null,"total_hosts":0,"unlimited_hosts":true,"created_at":"2016-08-19 21:17:31 UTC","updated_at":"2016-08-19 21:17:34 UTC","id":14,"permissions":{"deletable":true,"editable":true}}]}

In [2]: type(hcs[0])
Out[2]: nailgun.entities.HostCollection

In [3]: hcs[0].name
Out[3]: u'GtLsWQY'
```