### PR TITLE
Added Smart Class Parameters entity and helpers needed for SCP.

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -1784,6 +1784,40 @@ class Environment(
             ).update_payload(fields)
         }
 
+    def path(self, which=None):
+        """Extend ``nailgun.entity_mixins.Entity.path``.
+        The format of the returned path depends on the value of ``which``:
+
+        smart_class_parameters
+            /api/environments/:environment_id/smart_class_parameters
+
+        Otherwise, call ``super``.
+
+        """
+        if which in ('smart_class_parameters',):
+            return '{0}/{1}'.format(
+                super(Environment, self).path(which='self'),
+                which
+            )
+        return super(Environment, self).path(which)
+
+    def list_scparams(self, synchronous=True, **kwargs):
+        """List all smart class parameters
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+
+        """
+        kwargs = kwargs.copy()
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.get(self.path('smart_class_parameters'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous)
+
 
 class Errata(Entity, EntityReadMixin, EntitySearchMixin):
     """A representation of an Errata entity."""
@@ -2166,6 +2200,59 @@ class HostGroup(
         """Wrap submitted data within an extra dict."""
         return {u'hostgroup': super(HostGroup, self).update_payload(fields)}
 
+    def path(self, which=None):
+        """Extend ``nailgun.entity_mixins.Entity.path``.
+        The format of the returned path depends on the value of ``which``:
+
+        puppetclass_ids
+            /api/hostgroups/:hostgroup_id/puppetclass_ids
+        smart_class_parameters
+            /api/hostgroups/:hostgroup_id/smart_class_parameters
+
+        Otherwise, call ``super``.
+
+        """
+        if which in ('puppetclass_ids', 'smart_class_parameters'):
+            return '{0}/{1}'.format(
+                super(HostGroup, self).path(which='self'),
+                which
+            )
+        return super(HostGroup, self).path(which)
+
+    def add_puppetclass(self, synchronous=True, **kwargs):
+        """Add a Puppet class to host
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+
+        """
+        kwargs = kwargs.copy()
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.post(self.path('puppetclass_ids'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous)
+
+    def list_scparams(self, synchronous=True, **kwargs):
+        """List all smart class parameters
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+
+        """
+        kwargs = kwargs.copy()
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.get(self.path('smart_class_parameters'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous)
+
 
 class HostPackage(Entity):
     """A representation of a Host Package entity."""
@@ -2473,6 +2560,40 @@ class Host(  # pylint:disable=too-many-instance-attributes
     def update_payload(self, fields=None):
         """Wrap submitted data within an extra dict."""
         return {u'host': super(Host, self).update_payload(fields)}
+
+    def path(self, which=None):
+        """Extend ``nailgun.entity_mixins.Entity.path``.
+        The format of the returned path depends on the value of ``which``:
+
+        smart_class_parameters
+            /api/hosts/:host_id/smart_class_parameters
+
+        Otherwise, call ``super``.
+
+        """
+        if which in ('smart_class_parameters',):
+            return '{0}/{1}'.format(
+                super(Host, self).path(which='self'),
+                which
+            )
+        return super(Host, self).path(which)
+
+    def list_scparams(self, synchronous=True, **kwargs):
+        """List all smart class parameters
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+
+        """
+        kwargs = kwargs.copy()
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.get(self.path('smart_class_parameters'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous)
 
 
 class Image(Entity):
@@ -3105,26 +3226,79 @@ class OSDefaultTemplate(Entity):
         super(OSDefaultTemplate, self).__init__(server_config, **kwargs)
 
 
-class OverrideValue(Entity):
+class OverrideValue(
+        Entity,
+        EntityCreateMixin,
+        EntityDeleteMixin,
+        EntityReadMixin,
+        EntityUpdateMixin):
     """A representation of a Override Value entity."""
 
     def __init__(self, server_config=None, **kwargs):
         self._fields = {
-            'match': entity_fields.StringField(),
+            'match': entity_fields.StringField(required=True),
+            'value': entity_fields.StringField(required=True),
+            'smart_class_parameter': entity_fields.OneToOneField(
+                SmartClassParameters),
             'smart_variable': entity_fields.OneToOneField(SmartVariable),
-            'value': entity_fields.StringField(),
-        }
-        self._meta = {
-            'api_path': (
-                # Create an override value for a specific smart_variable
-                '/api/v2/smart_variables/:smart_variable_id/override_values',
-                # Create an override value for a specific smart class parameter
-                '/api/v2/smart_class_parameters/:smart_class_parameter_id/'
-                'override_values',
-            ),
-            'server_modes': ('sat'),
+            'use_puppet_default': entity_fields.BooleanField(),
         }
         super(OverrideValue, self).__init__(server_config, **kwargs)
+        # Create an override value for a specific smart class parameter
+        if hasattr(self, 'smart_class_parameter'):
+            # pylint:disable=no-member
+            partial_path = self.smart_class_parameter.path('self')
+        # Create an override value for a specific smart_variable
+        elif hasattr(self, 'smart_variable'):
+            # pylint:disable=no-member
+            partial_path = self.smart_variable.path('self')
+        else:
+            raise TypeError(
+                'A value must be provided for one of the following fields: '
+                '"smart_class_parameter", "smart_variable"'
+            )
+        self._meta = {
+            'api_path': '{0}/override_values'.format(partial_path),
+            'server_modes': ('sat'),
+        }
+
+    def read(self, entity=None, attrs=None, ignore=None):
+        """Provide a default value for ``entity``.
+
+        By default, ``nailgun.entity_mixins.EntityReadMixin.read provides a
+        default value for ``entity`` like so::
+
+            entity = type(self)()
+
+        However, :class:`OverrideValue` requires that an
+        ``smart_class_parameter`` or ``smart_varaiable`` be provided, so this
+        technique will not work. Do this instead::
+
+            entity = type(self)(
+                smart_class_parameter=self.smart_class_parameter)
+            entity = type(self)(smart_variable=self.smart_variable)
+
+        """
+        # read() should not change the state of the object it's called on, but
+        # super() alters the attributes of any entity passed in. Creating a new
+        # object and passing it to super() lets this one avoid changing state.
+        if entity is None:
+            if hasattr(self, 'smart_class_parameter'):
+                entity = type(self)(
+                    self._server_config,
+                    # pylint:disable=no-member
+                    smart_class_parameter=self.smart_class_parameter,
+                )
+            elif hasattr(self, 'smart_variable'):
+                entity = type(self)(
+                    self._server_config,
+                    # pylint:disable=no-member
+                    smart_variable=self.smart_variable,
+                )
+        if ignore is None:
+            ignore = set()
+        ignore.update(['smart_class_parameter', 'smart_variable'])
+        return super(OverrideValue, self).read(entity, attrs, ignore)
 
 
 class Permission(Entity, EntityReadMixin, EntitySearchMixin):
@@ -3295,7 +3469,11 @@ class PartitionTable(
 
 
 class PuppetClass(
-        Entity, EntityCreateMixin, EntityDeleteMixin, EntityReadMixin):
+        Entity,
+        EntityCreateMixin,
+        EntityDeleteMixin,
+        EntityReadMixin,
+        EntitySearchMixin):
     """A representation of a Puppet Class entity."""
 
     def __init__(self, server_config=None, **kwargs):
@@ -3311,6 +3489,54 @@ class PuppetClass(
             'server_modes': ('sat'),
         }
         super(PuppetClass, self).__init__(server_config, **kwargs)
+
+    def search_normalize(self, results):
+        """Flattens results.
+        :meth:`nailgun.entity_mixins.EntitySearchMixin.search_normalize`
+        expects structure like
+        list(dict_1(name: class_1), dict_2(name: class_2)),
+        while Puppet Class entity returns dictionary with lists of subclasses
+        split by main puppet class.
+        """
+        flattened_results = []
+        for key in results.keys():
+            for item in results[key]:
+                flattened_results.append(item)
+        return super(PuppetClass, self).search_normalize(flattened_results)
+
+    def path(self, which=None):
+        """Extend ``nailgun.entity_mixins.Entity.path``.
+        The format of the returned path depends on the value of ``which``:
+
+        smart_class_parameters
+            /api/puppetclasses/:puppetclass_id/smart_class_parameters
+
+        Otherwise, call ``super``.
+
+        """
+        if which in ('smart_class_parameters',):
+            return '{0}/{1}'.format(
+                super(PuppetClass, self).path(which='self'),
+                which
+            )
+        return super(PuppetClass, self).path(which)
+
+    def list_scparams(self, synchronous=True, **kwargs):
+        """List of smart class parameters for a specific Puppet class
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+
+        """
+        kwargs = kwargs.copy()
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.get(self.path('smart_class_parameters'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous)
 
 
 class PuppetModule(Entity, EntityReadMixin, EntitySearchMixin):
@@ -3922,11 +4148,12 @@ class SmartProxy(
 
     def path(self, which=None):
         """Extend ``nailgun.entity_mixins.Entity.path``.
-
         The format of the returned path depends on the value of ``which``:
 
         refresh
-            /katello/api/v2/smart_proxies/:id/refresh
+            /api/smart_proxies/:id/refresh
+
+        Otherwise, call ``super``.
 
         """
         if which in ('refresh',):
@@ -3953,6 +4180,34 @@ class SmartProxy(
         response = client.put(self.path('refresh'), **kwargs)
         return _handle_response(response, self._server_config, synchronous)
 
+    def import_puppetclasses(self, synchronous=True, **kwargs):
+        """Import puppet classes from puppet Capsule.
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+
+        """
+        kwargs = kwargs.copy()
+        kwargs.update(self._server_config.get_client_kwargs())
+        # Check if environment_id was sent and substitute it to the path
+        # but do not pass it to requests
+        if 'environment' in kwargs:
+            if isinstance(kwargs['environment'], Environment):
+                environment_id = kwargs.pop('environment').id
+            else:
+                environment_id = kwargs.pop('environment')
+            path = '{0}/environments/{1}/import_puppetclasses'.format(
+                self.path(), environment_id)
+        else:
+            path = '{0}/import_puppetclasses'.format(self.path())
+        return _handle_response(
+            client.post(path, **kwargs), self._server_config, synchronous)
+
     @signals.emit(sender=signals.SENDER_CLASS, post_result_name='entity')
     def update(self, fields=None):
         """Fetch a complete set of attributes for this entity.
@@ -3969,6 +4224,43 @@ class SmartProxy(
         return {
             u'smart_proxy': super(SmartProxy, self).update_payload(fields)
         }
+
+
+class SmartClassParameters(
+        Entity,
+        EntityReadMixin,
+        EntitySearchMixin,
+        EntityUpdateMixin):
+    """A representation of a Smart Class Parameters."""
+
+    def __init__(self, server_config=None, **kwargs):
+        self._fields = {
+            'puppetclass': entity_fields.OneToOneField(PuppetClass),
+            'override': entity_fields.BooleanField(),
+            'description': entity_fields.StringField(),
+            'default_value': entity_fields.StringField(),
+            'hidden_value': entity_fields.BooleanField(),
+            'hidden_value?': entity_fields.BooleanField(),
+            'use_puppet_default': entity_fields.BooleanField(),
+            'validator_type': entity_fields.StringField(
+                choices=('regexp', 'list')
+            ),
+            'validator_rule': entity_fields.StringField(),
+            'parameter_type': entity_fields.StringField(
+                choices=('string', 'boolean', 'integer', 'real',
+                         'array', 'hash', 'yaml', 'json')
+            ),
+            'required': entity_fields.BooleanField(),
+            'merge_overrides': entity_fields.BooleanField(),
+            'merge_default': entity_fields.BooleanField(),
+            'avoid_duplicates': entity_fields.BooleanField(),
+            'override_values': entity_fields.DictField()
+        }
+        self._meta = {
+            'api_path': 'api/v2/smart_class_parameters',
+            'server_modes': ('sat'),
+        }
+        super(SmartClassParameters, self).__init__(server_config, **kwargs)
 
 
 class SmartVariable(Entity):

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -124,7 +124,6 @@ class InitTestCase(TestCase):
                 entities.OSDefaultTemplate,
                 entities.OperatingSystem,
                 entities.Organization,
-                entities.OverrideValue,
                 entities.PackageGroupContentViewFilter,
                 entities.PartitionTable,
                 entities.Permission,
@@ -140,6 +139,7 @@ class InitTestCase(TestCase):
                 entities.Role,
                 entities.RoleLDAPGroups,
                 entities.Setting,
+                entities.SmartClassParameters,
                 entities.SmartProxy,
                 entities.SmartVariable,
                 entities.Status,
@@ -167,6 +167,8 @@ class InitTestCase(TestCase):
             (entities.HostPackage, {'host': 1}),
             (entities.HostSubscription, {'host': 1}),
             (entities.OperatingSystemParameter, {'operatingsystem': 1}),
+            (entities.OverrideValue, {'smart_class_parameter': 1}),
+            (entities.OverrideValue, {'smart_variable': 1}),
             (entities.RepositorySet, {'product': 1}),
             (entities.SyncPlan, {'organization': 1}),
         ])
@@ -197,6 +199,7 @@ class InitTestCase(TestCase):
                 entities.ContentViewPuppetModule,
                 entities.HostPackage,
                 entities.HostSubscription,
+                entities.OverrideValue,
                 entities.OperatingSystemParameter,
                 entities.RepositorySet,
                 entities.SyncPlan,
@@ -227,8 +230,12 @@ class PathTestCase(TestCase):
                 (entities.ContentViewVersion, '/content_view_versions'),
                 (entities.DiscoveredHost, '/discovered_hosts'),
                 (entities.DiscoveryRule, '/discovery_rules'),
+                (entities.Environment, '/environments'),
                 (entities.Organization, '/organizations'),
+                (entities.Host, '/hosts'),
+                (entities.HostGroup, '/hostgroups'),
                 (entities.Product, '/products'),
+                (entities.PuppetClass, '/puppetclasses'),
                 (entities.RHCIDeployment, '/deployments'),
                 (entities.Repository, '/repositories'),
                 (entities.Setting, '/settings'),
@@ -270,6 +277,10 @@ class PathTestCase(TestCase):
                 (entities.ContentView, 'copy'),
                 (entities.ContentView, 'publish'),
                 (entities.ContentViewVersion, 'promote'),
+                (entities.Environment, 'smart_class_parameters'),
+                (entities.Host, 'smart_class_parameters'),
+                (entities.HostGroup, 'puppetclass_ids'),
+                (entities.HostGroup, 'smart_class_parameters'),
                 (entities.Organization, 'download_debug_certificate'),
                 (entities.Organization, 'subscriptions'),
                 (entities.Organization, 'subscriptions/delete_manifest'),
@@ -278,6 +289,7 @@ class PathTestCase(TestCase):
                 (entities.Organization, 'subscriptions/upload'),
                 (entities.Organization, 'sync_plans'),
                 (entities.Product, 'sync'),
+                (entities.PuppetClass, 'smart_class_parameters'),
                 (entities.Repository, 'sync'),
                 (entities.Repository, 'upload_content'),
                 (entities.RHCIDeployment, 'deploy'),
@@ -833,6 +845,8 @@ class ReadTestCase(TestCase):
                 ),
                 entities.ContentViewPuppetModule(self.cfg, content_view=2),
                 entities.OperatingSystemParameter(self.cfg, operatingsystem=2),
+                entities.OverrideValue(self.cfg, smart_class_parameter=2),
+                entities.OverrideValue(self.cfg, smart_variable=2),
                 entities.RepositorySet(self.cfg, product=2),
                 entities.SyncPlan(self.cfg, organization=2),
         ):
@@ -1284,17 +1298,23 @@ class GenericTestCase(TestCase):
             ),
             (entities.ContentViewVersion(**generic).promote, 'post'),
             (entities.DiscoveredHost(cfg).facts, 'post'),
+            (entities.Environment(**generic).list_scparams, 'get'),
             (entities.ForemanTask(cfg).summary, 'get'),
             (
                 entities.Organization(**generic).download_debug_certificate,
                 'get'
             ),
+            (entities.Host(**generic).list_scparams, 'get'),
+            (entities.HostGroup(**generic).add_puppetclass, 'post'),
+            (entities.HostGroup(**generic).list_scparams, 'get'),
             (entities.Product(**generic).sync, 'post'),
+            (entities.PuppetClass(**generic).list_scparams, 'get'),
             (entities.RHCIDeployment(**generic).deploy, 'put'),
             (entities.Repository(**generic).sync, 'post'),
             (entities.RepositorySet(**repo_set).available_repositories, 'get'),
             (entities.RepositorySet(**repo_set).disable, 'put'),
             (entities.RepositorySet(**repo_set).enable, 'put'),
+            (entities.SmartProxy(**generic).import_puppetclasses, 'post'),
             (entities.SmartProxy(**generic).refresh, 'put'),
             (entities.SyncPlan(**sync_plan).add_products, 'put'),
             (entities.SyncPlan(**sync_plan).remove_products, 'put'),
@@ -1587,6 +1607,34 @@ class HostTestCase(TestCase):
             self.assertIn('content_facet_attributes', read.call_args[0][2])
 
 
+class PuppetClassTestCase(TestCase):
+    """Tests for :class:`nailgun.entities.PuppetClass`."""
+
+    def setUp(self):
+        """Set ``self.puppet_class``."""
+        self.puppet_class = entities.PuppetClass(
+            config.ServerConfig('http://example.com'),
+            id=gen_integer(min_value=1),
+        )
+
+    def test_search_normalize(self):
+        """Call :meth:`nailgun.entities.PuppetClass.search_normalize`.
+        Assert that returned value is a list and contains all subdictionaries.
+        """
+        with mock.patch.object(EntitySearchMixin, 'search_normalize') as s_n:
+            self.puppet_class.search_normalize({
+                'class1': [
+                    {'name': 'subclass1'},
+                    {'name': 'subclass2'}],
+                'class2': [
+                    {'name': 'subclass1'},
+                    {'name': 'subclass2'}]
+            })
+        self.assertEqual(s_n.call_count, 1)
+        self.assertIsInstance(s_n.call_args[0][0], list)
+        self.assertEqual(len(s_n.call_args[0][0]), 4)
+
+
 class RepositoryTestCase(TestCase):
     """Tests for :class:`nailgun.entities.Repository`."""
 
@@ -1664,6 +1712,37 @@ class RepositorySetTestCase(TestCase):
         for result in s_n.call_args[0][0]:
             # pylint:disable=no-member
             self.assertEqual(result['product_id'], self.product.id)
+
+
+class SmartProxyTestCase(TestCase):
+    """Tests for :class:`nailgun.entities.SmartProxy`."""
+
+    def setUp(self):
+        """Set ``self.smart_proxy``."""
+        self.cfg = config.ServerConfig('http://example.com')
+        self.smart_proxy = entities.SmartProxy(self.cfg)
+        self.env = entities.Environment(self.cfg, id='2')
+
+    def test_import_puppetclasses(self):
+        """Call :meth:`nailgun.entities.SmartProxy.import_puppetclasses`.
+        Assert that
+        * ``environment`` parameter is not sent to requests,
+        * proper path is built
+        """
+        params = [
+            {},
+            {'environment': 2},
+            {'environment': self.env}
+        ]
+        for param in params:
+            with self.subTest(param):
+                with mock.patch.object(client, 'post') as post:
+                    self.smart_proxy.import_puppetclasses(**param)
+                self.assertEqual(post.call_count, 1)
+                self.assertNotIn('environment', post.call_args[1])
+                self.assertIn('/import_puppetclasses', post.call_args[0][0])
+                if 'environment' in param:
+                    self.assertIn('/environments', post.call_args[0][0])
 
 
 class SubscriptionTestCase(TestCase):


### PR DESCRIPTION
This is my first PR for nailgun so I would be appreciate for any comments and suggestions. Especially about what unit-tests should be added.

```python
entities.SmartClassParameters().search(query={'search': 'puppetclass="ntp"', 'per_page': 100})
2016-09-02 11:15:47 - nailgun.client - DEBUG - Making HTTP GET request to https://example.com/api/v2/smart_class_parameters
2016-09-02 11:15:48 - nailgun.client - DEBUG - Received HTTP 200 response:
[nailgun.entities.SmartClassParameters(nailgun.config.ServerConfig(url='https://example.com', verify=False, auth=('admin', 'changeme')), description=None, puppetclass=nailgun.entities.PuppetClass(nailgun.config.ServerConfig(url='example.com', verify=False, auth=('admin', 'changeme')), id=12), hidden_value=u'*****', validator_type=None, id=120, merge_overrides=False, default_value=u'${$ntp::params::authprov}', validator_rule=None, use_puppet_default=None, avoid_duplicates=False, required=False, merge_default=False, parameter_type=u'string', override=False, hidden_value?=False)]
```

```python
proxy = entities.SmartProxy(name=cls.host_name).search()[0]
proxy.import_puppetclasses(data={'environment_id': cls.env.id})
2016-09-02 11:18:52 - nailgun.client - DEBUG - Making HTTP POST request to https://example.com/api/v2/smart_proxies/1/environments/1/import_puppetclasses with options {'verify': False, 'auth': ('admin', 'changeme'), 'headers': {'content-type': 'application/json'}} and data {}.
2016-09-02 11:18:56 - nailgun.client - DEBUG - Received HTTP 200 response: {
  "message": "Successfully updated environment and puppetclasses from the on-disk puppet installation",
  "results": {"name":"production","actions":["new"],"new_puppetclasses":["ntp::config","ntp","ntp::install","ntp::params","ntp::service"]}
}
```

```python
puppet = entities.PuppetClass().search(query={'search': 'name="ntp"'})[0]
puppet.list_scparams()
2016-09-02 11:23:04 - nailgun.client - DEBUG - Making HTTP GET request to https://example.com/api/v2/puppetclasses/12/smart_class_parameters with options {'verify': False, 'auth': ('admin', 'changeme'), 'headers': {'content-type': 'application/json'}} and no data.
2016-09-02 11:23:05 - nailgun.client - DEBUG - Received HTTP 200 response: {
  "results": [{"description":null,"override":false,"parameter_type":"string","default_value":"${$ntp::params::authprov}","hidden_value?":false,"hidden_value":"*****","use_puppet_default":null,"required":false,"validator_type":null,"validator_rule":null,"merge_overrides":false,"merge_default":false,"avoid_duplicates":false,"override_value_order":"fqdn\nhostgroup\nos\ndomain","override_values_count":0,"created_at":"2016-09-02 08:18:56 UTC","updated_at":"2016-09-02 08:18:56 UTC","puppetclass_name":"ntp","parameter":"authprov","id":120,"puppetclass_id":12},]
}
```
```python
entities.OverrideValue(
     smart_class_parameter=sc_param,  match='domain=example.com', value=value,
).create()

2016-09-02 11:27:29 - nailgun.client - DEBUG - Making HTTP POST request to https://example.com/api/v2/smart_class_parameters/118/override_values with options {'verify': False, 'auth': ('admin', 'changeme'), 'headers': {'content-type': 'application/json'}} and data {"smart_class_parameter_id": 118, "value": "kZylGAGNPC", "match": "domain=example.com"}.
2016-09-02 11:27:30 - nailgun.client - DEBUG - Received HTTP 201 response: {"created_at":"2016-09-02 08:27:30 UTC","updated_at":"2016-09-02 08:27:30 UTC","id":2,"match":"domain=example.com","value":"kZylGAGNPC","use_puppet_default":false}
nailgun.entities.OverrideValue(nailgun.config.ServerConfig(url='example.com', verify=False, auth=('admin', 'changeme')), use_puppet_default=False, value=u'kZylGAGNPC', id=2, match=u'domain=example.com', smart_class_parameter=nailgun.entities.SmartClassParameters(nailgun.config.ServerConfig(url='https://example.com', verify=False, auth=('admin', 'changeme')), description=None, puppetclass=nailgun.entities.PuppetClass(nailgun.config.ServerConfig(url='https://example.com', verify=False, auth=('admin', 'changeme')), id=12), hidden_value=u'*****', validator_type=None, id=118, merge_overrides=False, default_value=u'${$ntp::params::udlc_stratum}', validator_rule=None, use_puppet_default=None, avoid_duplicates=False, required=False, merge_default=False, parameter_type=u'string', override=False, hidden_value?=False))