### PR TITLE
[needs cherrypick to 6.2.z] removing workaround for BZ#1325989 after it has been resolved

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2071,18 +2071,6 @@ class HostCollection(
             payload['system_uuids'] = payload.pop('system_ids')
         return payload
 
-    def read(self, entity=None, attrs=None, ignore=None):
-        """Ignore 'host' field as it is not returned by the server.
-
-        For more information, see `Bugzilla #1325989
-        <https://bugzilla.redhat.com/show_bug.cgi?id=1325989>`_.
-
-        """
-        if ignore is None:
-            ignore = set()
-        ignore.add('host')
-        return super(HostCollection, self).read(entity, attrs, ignore)
-
     def update_payload(self, fields=None):
         """Rename ``system_ids`` to ``system_uuids``."""
         payload = super(HostCollection, self).update_payload(fields)

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -969,7 +969,6 @@ class ReadTestCase(TestCase):
 
         """
         for entity, ignored_attrs in (
-                (entities.HostCollection, {'host'}),
                 (entities.Subnet, {'discovery'}),
                 (entities.User, {'password'}),
         ):


### PR DESCRIPTION
```
2016-09-09 18:10:38 - nailgun.client - DEBUG - Making HTTP POST request to https://qe-sat6-rhel6.com/katello/api/v2/host_collections with options {'verify': False, 'auth': ('admin', 'changeme'), 'headers': {'content-type': 'application/json'}} and data {"organization_id": 21, "host_ids": [14, 15], "name": "zLSOvpHqMeR"}.
2016-09-09 18:10:39 - nailgun.client - DEBUG - Received HTTP 200 response:   {"host_ids":[14,15],"name":"zLSOvpHqMeR","organization_id":21,"max_hosts":null,"description":null,"total_hosts":2,"unlimited_hosts":true,"created_at":"2016-09-09 16:10:38 UTC","updated_at":"2016-09-09 16:10:38 UTC","id":7,"permissions":{"deletable":true,"editable":true}}

```


We probably want to backport this to `6.2.z` too