### PR TITLE
Add Smart Variables helpers

### DIFF
--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -969,6 +969,7 @@ class ReadTestCase(TestCase):
 
         """
         for entity, ignored_attrs in (
+                (entities.SmartVariable, {'variable_type'}),
                 (entities.Subnet, {'discovery'}),
                 (entities.User, {'password'}),
         ):
@@ -1304,10 +1305,13 @@ class GenericTestCase(TestCase):
                 'get'
             ),
             (entities.Host(**generic).list_scparams, 'get'),
+            (entities.Host(**generic).list_smart_variables, 'get'),
             (entities.HostGroup(**generic).add_puppetclass, 'post'),
             (entities.HostGroup(**generic).list_scparams, 'get'),
+            (entities.HostGroup(**generic).list_smart_variables, 'get'),
             (entities.Product(**generic).sync, 'post'),
             (entities.PuppetClass(**generic).list_scparams, 'get'),
+            (entities.PuppetClass(**generic).list_smart_variables, 'get'),
             (entities.RHCIDeployment(**generic).deploy, 'put'),
             (entities.Repository(**generic).sync, 'post'),
             (entities.RepositorySet(**repo_set).available_repositories, 'get'),


### PR DESCRIPTION
```python
hostgroup = entities.HostGroup().create()
hostgroup.add_puppetclass(data={'puppetclass_id': puppet.id})
hostgroup.list_smart_variables()

016-09-14 10:32:04 - nailgun.client - DEBUG - Making HTTP GET request to https://example.com/api/v2/hostgroups/14/smart_variables with options {'verify': False, 'auth': ('admin', 'changeme'), 'headers': {'content-type': 'application/json'}} and no data.
2016-09-14 10:32:05 - nailgun.client - DEBUG - Received HTTP 200 response: {
  "total": 190,
  "subtotal": 190,
  "page": 1,
  "per_page": 20,
  "search": null,
  "sort": {
    "by": null,
    "order": null
  },
  "results": [{"description":null,"parameter_type":null,"default_value":"example","hidden_value?":false,"hidden_value":"*****","validator_type":"list","validator_rule":"test, example, 30","override_value_order":"fqdn\nhostgroup\nos\ndomain","override_values_count":1,"merge_overrides":false,"merge_default":false,"avoid_duplicates":false,"puppetclass_id":2,"puppetclass_name":"ntp","created_at":"2016-09-13 16:08:30 UTC","updated_at":"2016-09-13 16:08:31 UTC","variable":"숖","id":180},
]
}
```