### PR TITLE
Add puppet class helpers

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2260,9 +2260,11 @@ class HostGroup(
         Otherwise, call ``super``.
 
         """
-        if which in ('puppetclass_ids',
-                     'smart_class_parameters',
-                     'smart_variables'):
+        if which in (
+                'puppetclass_ids',
+                'smart_class_parameters',
+                'smart_variables',
+        ):
             return '{0}/{1}'.format(
                 super(HostGroup, self).path(which='self'),
                 which
@@ -2270,7 +2272,7 @@ class HostGroup(
         return super(HostGroup, self).path(which)
 
     def add_puppetclass(self, synchronous=True, **kwargs):
-        """Add a Puppet class to host
+        """Add a Puppet class to host group
 
         Here is an example of how to use this method::
             hostgroup.add_puppetclass(data={'puppetclass_id': puppet.id})
@@ -2288,6 +2290,33 @@ class HostGroup(
         kwargs.update(self._server_config.get_client_kwargs())
         response = client.post(self.path('puppetclass_ids'), **kwargs)
         return _handle_response(response, self._server_config, synchronous)
+
+    def delete_puppetclass(self, synchronous=True, **kwargs):
+        """Remove a Puppet class from host group
+
+        Here is an example of how to use this method::
+            hostgroup.delete_puppetclass(data={'puppetclass_id': puppet.id})
+
+        Constructs path:
+            /api/hostgroups/:hostgroup_id/puppetclass_ids/:id
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+
+        """
+        kwargs = kwargs.copy()
+        kwargs.update(self._server_config.get_client_kwargs())
+        path = "{0}/{1}".format(
+            self.path('puppetclass_ids'),
+            kwargs['data'].pop('puppetclass_id')
+        )
+        return _handle_response(
+            client.delete(path, **kwargs), self._server_config, synchronous)
 
     def list_scparams(self, synchronous=True, **kwargs):
         """List all smart class parameters
@@ -2692,6 +2721,8 @@ class Host(  # pylint:disable=too-many-instance-attributes
             /api/hosts/:host_id/errata
         errata/apply
             /api/hosts/:host_id/errata/apply
+        puppetclass_ids
+            /api/hosts/:host_id/puppetclass_ids
         smart_class_parameters
             /api/hosts/:host_id/smart_class_parameters
         smart_variables
@@ -2703,6 +2734,7 @@ class Host(  # pylint:disable=too-many-instance-attributes
         if which in (
                 'errata',
                 'errata/apply',
+                'puppetclass_ids',
                 'smart_class_parameters',
                 'smart_variables',
         ):
@@ -2716,6 +2748,53 @@ class Host(  # pylint:disable=too-many-instance-attributes
                 which
             )
         return super(Host, self).path(which)
+
+    def add_puppetclass(self, synchronous=True, **kwargs):
+        """Add a Puppet class to host
+
+        Here is an example of how to use this method::
+            host.add_puppetclass(data={'puppetclass_id': puppet.id})
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+
+        """
+        kwargs = kwargs.copy()
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.post(self.path('puppetclass_ids'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous)
+
+    def delete_puppetclass(self, synchronous=True, **kwargs):
+        """Remove a Puppet class from host
+
+        Here is an example of how to use this method::
+            host.delete_puppetclass(data={'puppetclass_id': puppet.id})
+
+        Constructs path:
+           /api/hosts/:hostgroup_id/puppetclass_ids/:id
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+
+        """
+        kwargs = kwargs.copy()
+        kwargs.update(self._server_config.get_client_kwargs())
+        path = "{0}/{1}".format(
+            self.path('puppetclass_ids'),
+            kwargs['data'].pop('puppetclass_id')
+        )
+        return _handle_response(
+            client.delete(path, **kwargs), self._server_config, synchronous)
 
     def list_scparams(self, synchronous=True, **kwargs):
         """List all smart class parameters
@@ -3639,6 +3718,7 @@ class PuppetClass(
                 str_type='alpha',
                 length=(6, 12),
             ),
+            'hostgroup': entity_fields.OneToManyField(HostGroup),
         }
         self._meta = {
             'api_path': 'api/v2/puppetclasses',
@@ -4460,6 +4540,7 @@ class SmartVariable(
         EntityCreateMixin,
         EntityDeleteMixin,
         EntityReadMixin,
+        EntitySearchMixin,
         EntityUpdateMixin):
     """A representation of a Smart Variable entity."""
 


### PR DESCRIPTION
```python
hostgroup.delete_puppetclass(data={'puppetclass_id': puppet.id})
DEBUG - Making HTTP DELETE request to https://example.com/api/v2/puppetclasses/429 with options {'verify': False, 'auth': ('admin', 'changeme'), 'headers': {'content-type': 'application/json'}} and no data.
DEBUG - Received HTTP 200 response: {"id":429,"name":"firewall","created_at":"2016-09-28T15:47:40.960Z","updated_at":"2016-09-28T15:47:40.960Z"}
```