### PR TITLE
added helpers for hostgroup clone, fixes #318

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2250,6 +2250,8 @@ class HostGroup(
         """Extend ``nailgun.entity_mixins.Entity.path``.
         The format of the returned path depends on the value of ``which``:
 
+        clone
+            /api/hostgroups/:hostgroup_id/clone
         puppetclass_ids
             /api/hostgroups/:hostgroup_id/puppetclass_ids
         smart_class_parameters
@@ -2261,9 +2263,10 @@ class HostGroup(
 
         """
         if which in (
+                'clone',
                 'puppetclass_ids',
                 'smart_class_parameters',
-                'smart_variables',
+                'smart_variables'
         ):
             return '{0}/{1}'.format(
                 super(HostGroup, self).path(which='self'),
@@ -2350,6 +2353,22 @@ class HostGroup(
         kwargs = kwargs.copy()
         kwargs.update(self._server_config.get_client_kwargs())
         response = client.get(self.path('smart_variables'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous)
+
+    def clone(self, synchronous=True, **kwargs):
+        """Helper to clone an existing host group
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+        """
+        kwargs = kwargs.copy()
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.post(self.path('clone'), **kwargs)
         return _handle_response(response, self._server_config, synchronous)
 
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -284,6 +284,7 @@ class PathTestCase(TestCase):
                 (entities.Host, 'puppetclass_ids'),
                 (entities.Host, 'smart_class_parameters'),
                 (entities.Host, 'smart_variables'),
+                (entities.HostGroup, 'clone'),
                 (entities.HostGroup, 'puppetclass_ids'),
                 (entities.HostGroup, 'smart_class_parameters'),
                 (entities.HostGroup, 'smart_variables'),
@@ -1323,6 +1324,7 @@ class GenericTestCase(TestCase):
             (entities.Host(**generic).list_scparams, 'get'),
             (entities.Host(**generic).list_smart_variables, 'get'),
             (entities.HostGroup(**generic).add_puppetclass, 'post'),
+            (entities.HostGroup(**generic).clone, 'post'),
             (entities.HostGroup(**generic).list_scparams, 'get'),
             (entities.HostGroup(**generic).list_smart_variables, 'get'),
             (entities.Product(**generic).sync, 'post'),
@@ -1548,6 +1550,7 @@ class HostGroupTestCase(TestCase):
             * Method calls `entities._handle_response` once.
             * The result of `_handle_response(…)` is the return value.
 
+
         """
         entity = self.entity
         entity.id = 1
@@ -1568,6 +1571,29 @@ class HostGroupTestCase(TestCase):
         self.assertEqual(client_request.call_args[1], kwargs)
         self.assertEqual(handlr.call_count, 1)
         self.assertEqual(handlr.return_value, response)
+
+    def test_clone_hostgroup(self):
+        """"Test for :meth:`nailgun.entities.HostGroup.clone`
+        Assert that the method is called one with correct argumets
+        """
+        entity = self.entity
+        entity.id = 1
+        self.assertEqual(
+            inspect.getargspec(entity.clone),
+            (['self', 'synchronous'], None, 'kwargs', (True,))
+        )
+        kwargs = {
+            'kwarg': gen_integer(),
+            'data': {'name': gen_string('utf8', 5)}
+        }
+        with mock.patch.object(entities, '_handle_response') as handler:
+            with mock.patch.object(client, 'post') as post:
+                response = entity.clone(**kwargs)
+        self.assertEqual(post.call_count, 1)
+        self.assertEqual(len(post.call_args[0]), 1)
+        self.assertEqual(post.call_args[1], kwargs)
+        self.assertEqual(handler.call_count, 1)
+        self.assertEqual(handler.return_value, response)
 
 
 class HostTestCase(TestCase):


### PR DESCRIPTION
```
>>> hg = entities.HostGroup().create()
>>> newHg = entities.HostGroup(id=hg.id).clone(data={u'name':'cloned'})
>>> newHg['name']
u'cloned'
```