### PR TITLE
Add smart class parameter name field ('parameter')

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -4537,6 +4537,7 @@ class SmartClassParameters(
                 choices=('regexp', 'list')
             ),
             'validator_rule': entity_fields.StringField(),
+            'parameter': entity_fields.StringField(),
             'parameter_type': entity_fields.StringField(
                 choices=('string', 'boolean', 'integer', 'real',
                          'array', 'hash', 'yaml', 'json')


### PR DESCRIPTION
```python
> scp_list = entities.SmartClassParameters().search(query={'search': 'puppetclass="ntp"'})
> print scp_list[0].parameter
u'authprov'
```