### PR TITLE
CherPick to 6.2.z - adding 'download_policy' to `Repository` entities

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -3449,6 +3449,11 @@ class Repository(
             'docker_upstream_name': entity_fields.StringField(
                 default='busybox'
             ),
+            'download_policy': entity_fields.StringField(
+                choices=('background', 'immediate', 'on_demand'),
+                default='immediate',
+                required=True,
+            ),
             'gpg_key': entity_fields.OneToOneField(GPGKey),
             'label': entity_fields.StringField(),
             'name': entity_fields.StringField(


### PR DESCRIPTION
Adding newer `download_policy` field to the `Repository` entity. As per
official API documentation:

      download policy for yum repos (either 'immediate', 'on_demand', or
'background')

      Validations:

	Must be one of: immediate, on_demand, background.