### PR TITLE
Added json method to Entity

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -327,6 +327,51 @@ examples of how to search, see
 search queries are generated, see
 :meth:`nailgun.entity_mixins.EntitySearchMixin.search_payload`.
 
+
+Helper Functions
+----------------
+
+Nailgun has also some helper functions for common operations.
+
+``to_json_serializable``
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+This function parses nested nailgun entities, date, datetime, numbers, dict
+and list so the result can be parsed by json module:
+
+    >>> from nailgun import entities
+    >>> from nailgun.config import ServerConfig
+    >>> from datetime import date, datetime
+    >>> cfg=ServerConfig('https://foo.bar')
+    >>> dct = {'dict': {'objs':
+    [
+        1, 'str', 2.5, date(2016, 12 , 13),
+        datetime(2016, 12, 14, 1, 2, 3)
+    ]}}
+    >>> entities.to_json(dct)
+    {'dict':
+        {'objs': [1, 'str', 2.5, '2016-12-13', '2016-12-14 01:02:03']}
+    }
+    >>> env = entities.Environment(cfg, id=1, name='env')
+    >>> entities.to_json(env)
+    {'id': 1, 'name': 'env'}
+    >>> location =  entities.Location(cfg, name='loc')
+    >>> hostgroup = entities.HostGroup(
+            cfg, name='hgroup', id=2, location=[location])
+    >>> entities.to_json_serializable(hostgroup)
+    {'location': [{'name': 'loc'}], 'name': 'hgroup', 'id': 2}
+    >>> mixed = [regular_object, env, hostgroup]
+    >>> entities.to_json_serializable(mixed)
+    [
+        {'dict': {'objs': [1, 'str', 2.5, '2016-12-13', '2016-12-13']}},
+        {'id': 1, 'name': 'env'},
+        {'location': [{'name': 'loc'}], 'name': 'hgroup', 'id': 2}
+    ]
+    >>> import json
+    >>> json.dumps(entities.to_json_serializable(mixed))
+    '[{"dict": {"objs": [1, "str", 2.5, "2016-12-13", "2016-12-13"]}}, {"id": 1, "name": "env"}, {"location": [{"name": "loc"}], "name": "hgroup", "id": 2}]'
+
+
 Using Lower Layers
 ------------------
 

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -36,6 +36,7 @@ from nailgun.entity_mixins import (
     EntityUpdateMixin,
     MissingValueError,
     _poll_task,
+    to_json_serializable as to_json
 )
 
 if version_info.major == 2:  # pragma: no cover
@@ -191,6 +192,18 @@ def _get_version(server_config):
 
     """
     return getattr(server_config, 'version', Version('1!0'))
+
+
+def to_json_serializable(obj):
+    """Just an alias to entity_mixins.to_json_seriazable so this module can
+    be used as a facade
+
+    :param obj: entity or any json serializable object
+
+    :return: serializable object
+
+    """
+    return to_json(obj)
 
 
 class ActivationKey(

--- a/nailgun/entity_mixins.py
+++ b/nailgun/entity_mixins.py
@@ -493,7 +493,6 @@ class Entity(object):
         returned dict.
 
         :return: A dict mapping field names to user-provided values.
-
         """
         attrs = vars(self).copy()
         attrs.pop('_server_config')
@@ -537,7 +536,6 @@ class Entity(object):
         fields.
 
         :return: dct
-
         """
         fields, values = self.get_fields(), self.get_values()
         json_dct = {}

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1,5 +1,6 @@
 # -*- encoding: utf-8 -*-
 """Tests for :mod:`nailgun.entities`."""
+import json
 from datetime import datetime
 from fauxfactory import gen_integer, gen_string
 from nailgun import client, config, entities
@@ -1957,6 +1958,48 @@ class GetOrgTestCase(TestCase):
                     # pylint:disable=protected-access
                     entities._get_org(*self.args)
             self.assertEqual(search.call_count, 1)
+
+    def test_to_json(self):
+        """json serialization"""
+        kwargs = {
+            'id': 1,
+            'description': 'some description',
+            'label': 'some label',
+            'name': 'Nailgun Org',
+            'title': 'some title',
+        }
+        org = entities.Organization(config.ServerConfig('foo'), **kwargs)
+        self.assertEqual(kwargs, json.loads(org.to_json()))
+
+
+class PackageTestCase(TestCase):
+    """Class with entity Package tests"""
+    def test_to_json(self):
+        """Check json serialisation on nested entities"""
+        package_kwargs = {
+            'nvrea': u'sclo-git25-1.0-2.el7.x86_64',
+            'checksum': (
+                u'751e639a0b8add0adc0c5cf0bf77693b3197b17533037ce2e7b9daa6188'
+                u'98b99'
+            ),
+            'summary': u'Package that installs sclo-git25',
+            'filename': u'sclo-git25-1.0-2.el7.x86_64.rpm',
+            'epoch': u'0', 'version': u'1.0',
+            'nvra': u'sclo-git25-1.0-2.el7.x86_64',
+            'release': u'2.el7',
+            'sourcerpm': u'sclo-git25-1.0-2.el7.src.rpm',
+            'arch': u'x86_64',
+            'id': 64529,
+            'name': u'sclo-git25'
+        }
+        cfg = config.ServerConfig(
+            url='https://sat-r220-02.lab.eng.rdu2.redhat.com/', verify=False,
+            auth=('admin', 'changeme'))
+        repo_kwargs = {'id': 3, 'content_type': 'file'}
+        repo = entities.Repository(cfg, **repo_kwargs)
+        package = entities.Package(cfg, repository=repo, **package_kwargs)
+        package_kwargs['repository'] = repo_kwargs
+        self.assertDictEqual(package_kwargs, json.loads(package.to_json()))
 
 
 class HandleResponseTestCase(TestCase):


### PR DESCRIPTION
close #323

Once the methods uses _payload, some Entities maybe need
 override this to match names expected on API

I followed @elyezer tip and made a this POC that worked for simple properties: https://github.com/renzon/nailgun/commit/d092468853d49239fa909ceba1da8af0e3271ba0.

The problem is when the default naming mapping is not correct with the expected for API. But in this case Subclasses can override _to_json_dict for the exceptions.

@ehelms and @rochacbruno could give it a try to check exceptions as they use it and creating issues here for them. What you guys think?
