### PR TITLE
[6.2.z] Fixed download_policy required flag only if content_type='yum' (#309)

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -3452,7 +3452,6 @@ class Repository(
             'download_policy': entity_fields.StringField(
                 choices=('background', 'immediate', 'on_demand'),
                 default='immediate',
-                required=True,
             ),
             'gpg_key': entity_fields.OneToOneField(GPGKey),
             'label': entity_fields.StringField(),
@@ -3475,6 +3474,8 @@ class Repository(
                 set(self._fields['content_type'].choices) - set(['docker'])
             ))
             del self._fields['checksum_type']
+        if self._fields['content_type'].choices == 'yum':
+            self._fields['download_policy'].required = True
         self._meta = {
             'api_path': 'katello/api/v2/repositories',
             'server_modes': ('sat'),


### PR DESCRIPTION
cherry-picking: https://github.com/SatelliteQE/nailgun/pull/309

![cherry_img](https://media.giphy.com/media/3logyGUisMJKE/giphy.gif)

before
```bash
2016-10-25 10:42:38 - nailgun.client - DEBUG - Making HTTP POST request to https://sat6.com/katello/api/v2/repositories with options {'verify': False, 'auth': ('admin', 'changeme'), 'headers': {'content-type': 'application/json'}} and data {"product_id": 2, "url": "http://davidd.fedorapeople.org/repos/random_puppet/", "download_policy": "immediate", "content_type": "puppet", "name": "BPoKqNJKzmC"}.

2016-10-25 10:42:39 - nailgun.client - WARNING - Received HTTP 422 response: {"displayMessage":"Validation failed: Download policy cannot be set for non-yum repositories.","errors":{"download_policy":["cannot be set for non-yum repositories."]}}
E
======================================================================
ERROR: test suite for <class 'tests.foreman.api.test_contentview.ContentViewPublishPromoteTestCase'>
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/nose/suite.py", line 209, in run
    self.setUp()
  File "/usr/lib/python2.7/site-packages/nose/suite.py", line 292, in setUp
    self.setupContext(ancestor)
  File "/usr/lib/python2.7/site-packages/nose/suite.py", line 315, in setupContext
    try_run(context, names)
  File "/usr/lib/python2.7/site-packages/nose/util.py", line 471, in try_run
    return func()
  File "/home/w1pko/work/robottelo/tests/foreman/api/test_contentview.py", line 353, in setUpClass
    url=FAKE_0_PUPPET_REPO,
  File "/usr/lib/python2.7/site-packages/blinker_herald/base.py", line 137, in wrapper
    result = fn(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/nailgun/entity_mixins.py", line 846, in create
    return self.read(attrs=self.create_json(create_missing))
  File "/usr/lib/python2.7/site-packages/nailgun/entity_mixins.py", line 816, in create_json
    response.raise_for_status()
  File "/usr/lib/python2.7/site-packages/requests/models.py", line 862, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
HTTPError: 422 Client Error: Unprocessable Entity for url: https://qe-sat62-rhel7.satqe.lab.eng.rdu2.redhat.com/katello/api/v2/repositories

----------------------------------------------------------------------
Ran 0 tests in 22.901s

FAILED (errors=1)
```

after:
```bash
2016-10-25 11:02:15 - nailgun.client - DEBUG - Making HTTP POST request to https://qe-sat62-rhel7.sat6.com/katello/api/v2/repositories with options {'verify': False, 'auth': ('admin', 'changeme'), 'headers': {'content-type': 'application/json'}} and data {"product_id": 4, "content_type": "puppet", "url": "http://davidd.fedorapeople.org/repos/random_puppet/", "name": "xsbuwLWRfNxg"}.
2016-10-25 11:02:18 - nailgun.client - DEBUG - Received HTTP 200 response:   {"content_type":"puppet","docker_upstream_name":null,"mirror_on_sync":true,"unprotected":true,"full_path":"http://qe-sat62-rhel7.satqe.lab.eng.rdu2.redhat.com/pulp/puppet/dMsWWISo-uSuZuDHZX-xsbuwLWRfNxg/","checksum_type":null,"container_repository_name":null,"download_policy":null,"url":"http://davidd.fedorapeople.org/repos/random_puppet/","relative_path":"dMsWWISo/Library/custom/uSuZuDHZX/xsbuwLWRfNxg","major":null,"minor":null,"gpg_key_id":null,"content_id":"1477386137721","content_view_version_id":7,"library_instance_id":null,"product_type":"custom","promoted":false,"ostree_branches":[],"organization":{"name":"dMsWWISo","label":"dMsWWISo","id":6},"created_at":"2016-10-25 09:02:16 UTC","updated_at":"2016-10-25 09:02:18 UTC","id":7,"name":"xsbuwLWRfNxg","label":"xsbuwLWRfNxg","product":{"id":4,"cp_id":"1477386112735","name":"uSuZuDHZX","sync_plan":["name","description","sync_date","interval","next_sync"]},"last_sync":null,"content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_tag":0,"rpm":0,"package":0,"package_group":0,"erratum":0,"puppet_module":0},"last_sync_words":null,"gpg_key":null,"environment":{"id":11},"permissions":{"deletable":true}}

```