### PR TITLE
Added a new field root_pass to hostgroup entity

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2198,6 +2198,7 @@ class HostGroup(
             'environment': entity_fields.OneToOneField(Environment),
             'location': entity_fields.OneToManyField(Location),
             'medium': entity_fields.OneToOneField(Media),
+            'root_pass': entity_fields.StringField(),
             'name': entity_fields.StringField(
                 required=True,
                 str_type='alpha',
@@ -2252,6 +2253,10 @@ class HostGroup(
           <https://bugzilla.redhat.com/show_bug.cgi?id=1235379>`_
 
         """
+        if ignore is None:
+            ignore = set()
+        ignore.add('root_pass')
+
         if attrs is None:
             attrs = self.read_json()
         attrs['parent_id'] = attrs.pop('ancestry')  # either an ID or None


### PR DESCRIPTION
```console
In [5]: hg = HostGroup(server_config, name='testpass14', root_pass='test@1234').create()

In [6]: hg
Out[6]: nailgun.entities.HostGroup(nailgun.config.ServerConfig(url='SERVER', verify=False, auth=('admin', 'changeme')), domain=None, medium=None, parent=None, ptable=None, content_source=None, lifecycle_environment=None, operatingsystem=None, name=u'testpass14', subnet=None, puppet_proxy=None, realm=None, content_view=None, id=46, environment=None, location=[], organization=[], puppet_ca_proxy=None, architecture=None)
```