### PR TITLE
Add UpdateMixin for CV Filter Rules entity

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -1329,7 +1329,8 @@ class ContentViewFilterRule(
         EntityCreateMixin,
         EntityDeleteMixin,
         EntityReadMixin,
-        EntitySearchMixin):
+        EntitySearchMixin,
+        EntityUpdateMixin):
     """A representation of a Content View Filter Rule entity."""
 
     def __init__(self, server_config=None, **kwargs):


### PR DESCRIPTION
It doesn't seem that we add entities with required parameters to unit tests when adding new mixins to them.

```
>>> cvf_rule = entities.ContentViewFilterRule(id=1, content_view_filter=5).read()
>>> cvf_rule
nailgun.entities.ContentViewFilterRule(nailgun.config.ServerConfig(url=u'server', verify=False, auth=(u'admin', u'changeme')), id=1, types=[u'bugfix'], content_view_filter=nailgun.entities.AbstractContentViewFilter(nailgun.config.ServerConfig(url=u'server', verify=False, auth=(u'admin', u'changeme')), id=5))
>>> cvf_rule.types = ['enhancement']
>>> cvf_rule = cvf_rule.update(['types'])
>>> cvf_rule
nailgun.entities.ContentViewFilterRule(nailgun.config.ServerConfig(url=u'server', verify=False, auth=(u'admin', u'changeme')), id=1, types=[u'enhancement'], content_view_filter=nailgun.entities.AbstractContentViewFilter(nailgun.config.ServerConfig(url=u'server', verify=False, auth=(u'admin', u'changeme')), id=5))
```