### PR TITLE
Add host count field to CV entity

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -1537,6 +1537,7 @@ class ContentView(
         self._fields = {
             'component': entity_fields.OneToManyField(ContentViewVersion),
             'composite': entity_fields.BooleanField(),
+            'content_host_count': entity_fields.IntegerField(),
             'description': entity_fields.StringField(),
             'label': entity_fields.StringField(),
             'last_published': entity_fields.StringField(),


### PR DESCRIPTION
```
>>> cv = entities.ContentView(name='test', organization=22).create()
>>> cv
nailgun.entities.ContentView(nailgun.config.ServerConfig(url=u'server', verify=False, auth=(u'admin', u'changeme')), puppet_module=[], last_published=None, repository=[], composite=False, component=[], id=41, next_version=1, name=u'test', description=None, label=u'test', version=[], content_host_count=0, organization=nailgun.entities.Organization(nailgun.config.ServerConfig(url=u'server', verify=False, auth=(u'admin', u'changeme')), id=22))
```