### PR TITLE
Fix read() of hostgroup without content_source, lce or cv for sat6.1

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2275,7 +2275,7 @@ class HostGroup(
             for attr in ('content_source_id',
                          'content_view_id',
                          'lifecycle_environment_id'):
-                attrs[attr] = attrs2[attr]
+                attrs[attr] = attrs2.get(attr)
         return super(HostGroup, self).read(entity, attrs, ignore)
 
     @signals.emit(sender=signals.SENDER_CLASS, post_result_name='entity')


### PR DESCRIPTION
Resolves #279 
Issue is pretty old, i'd even think of removing such workaround, but just in case somebody is using sat6.1 with latest nailgun - fix is very trivial.