### PR TITLE
Update Host.puppet_class field name.

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2518,7 +2518,7 @@ class Host(  # pylint:disable=too-many-instance-attributes
             'provision_method': entity_fields.StringField(),
             'ptable': entity_fields.OneToOneField(PartitionTable),
             'puppet_ca_proxy': entity_fields.OneToOneField(SmartProxy),
-            'puppet_class': entity_fields.OneToManyField(PuppetClass),
+            'puppetclass': entity_fields.OneToManyField(PuppetClass),
             'puppet_proxy': entity_fields.OneToOneField(SmartProxy),
             'realm': entity_fields.OneToOneField(Realm),
             'root_pass': entity_fields.StringField(length=(8, 30)),
@@ -2760,7 +2760,6 @@ class Host(  # pylint:disable=too-many-instance-attributes
             ignore.add('content_facet_attributes')
         ignore.add('root_pass')
         attrs['host_parameters_attributes'] = attrs.pop('parameters')
-        attrs['puppet_class'] = attrs.pop('puppetclasses')
         return super(Host, self).read(entity, attrs, ignore)
 
     @signals.emit(sender=signals.SENDER_CLASS, post_result_name='entity')

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -961,11 +961,8 @@ class ReadTestCase(TestCase):
             ),
             (
                 entities.Host(self.cfg),
-                {'parameters': None, 'puppetclasses': None},
-                {
-                    'host_parameters_attributes': None,
-                    'puppet_class': None,
-                },
+                {'parameters': None},
+                {'host_parameters_attributes': None},
             ),
             (
                 entities.System(self.cfg_610),


### PR DESCRIPTION
Looks like that field `host[puppet_class_id]` was changed to `host[puppetclass_ids]`, so currently passing `puppet_class` does nothing when creating/updating host.

```python
puppet_classes = entities.PuppetClass().search(query={
    'search': u'name ~ "generic_1" and environment = "KT_kWtydc_Library_nbVyItrg_60"'})
2016-12-23 00:31:09 - nailgun.client - DEBUG - Making HTTP GET request to https://sat6.com/api/v2/puppetclasses with options {'verify': False, 'data': '{"search": "name ~ \\"generic_1\\" and environment = \\"KT_kWtydc_Library_nbVyItrg_60\\""}', 'auth': ('admin', 'changeme'), 'headers': {'content-type': 'application/json'}} and no data.
2016-12-23 00:31:10 - nailgun.client - DEBUG - Received HTTP 200 response: {
   "results": {"generic_1":[{"id":24,"name":"generic_1","created_at":"2016-12-22T20:53:47.941Z","updated_at":"2016-12-22T20:53:47.941Z"}]}
}

host = entities.Host(
    environment=env.read(),
    puppetclass=puppet_classes,
).create()
2016-12-23 00:31:33 - nailgun.client - DEBUG - Making HTTP POST request to https://sat6.com/api/v2/hosts with options {'verify': False, 'auth': ('admin', 'changeme'), 'headers': {'content-type': 'application/json'}} 
and data .... "puppetclass_ids": [24]}}.
2016-12-23 00:31:34 - nailgun.client - DEBUG - Received HTTP 201 response: {...,
"puppetclasses":[{"id":24,"name":"generic_1","module_name":"generic_1"}],"config_groups":[],"parameters":[],"all_parameters":[],
"all_puppetclasses":[{"id":24,"name":"generic_1","module_name":"generic_1"}],...}

host.puppetclass
<type 'list'>: [nailgun.entities.PuppetClass(nailgun.config.ServerConfig(url='https://example.com', verify=False, auth=('admin', 'changeme')), id=24)]
```