### PR TITLE
[6.2.z] Cherry-pick - Update Host.puppet_class field name. (#346)

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2359,7 +2359,7 @@ class Host(  # pylint:disable=too-many-instance-attributes
             'provision_method': entity_fields.StringField(),
             'ptable': entity_fields.OneToOneField(PartitionTable),
             'puppet_ca_proxy': entity_fields.OneToOneField(SmartProxy),
-            'puppet_class': entity_fields.OneToManyField(PuppetClass),
+            'puppetclass': entity_fields.OneToManyField(PuppetClass),
             'puppet_proxy': entity_fields.OneToOneField(SmartProxy),
             'realm': entity_fields.OneToOneField(Realm),
             'root_pass': entity_fields.StringField(length=(8, 30)),
@@ -2550,7 +2550,6 @@ class Host(  # pylint:disable=too-many-instance-attributes
             ignore.add('content_facet_attributes')
         ignore.add('root_pass')
         attrs['host_parameters_attributes'] = attrs.pop('parameters')
-        attrs['puppet_class'] = attrs.pop('puppetclasses')
         return super(Host, self).read(entity, attrs, ignore)
 
     @signals.emit(sender=signals.SENDER_CLASS, post_result_name='entity')

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -950,11 +950,8 @@ class ReadTestCase(TestCase):
             ),
             (
                 entities.Host(self.cfg),
-                {'parameters': None, 'puppetclasses': None},
-                {
-                    'host_parameters_attributes': None,
-                    'puppet_class': None,
-                },
+                {'parameters': None},
+                {'host_parameters_attributes': None},
             ),
             (
                 entities.System(self.cfg_610),


### PR DESCRIPTION
Cherry-picked from #346

Verified on 6.2.7
```python
host = entities.Host(
    organization=self.org,
    location=self.loc,
    environment=self.env,
    puppetclass=self.puppet_classes,
).create()

2017-01-17 09:28:20 - nailgun.client - DEBUG - Making HTTP POST request to https://sat6.com/api/v2/hosts with ... and data {"host": {..., "puppetclass_ids": [15]}}.
2017-01-17 09:28:21 - nailgun.client - DEBUG - Received HTTP 201 response: {...,"puppetclasses":[{"id":15,"name":"generic_1","module_name":"generic_1"}], ...}}
```