### PR TITLE
[6.2.z] Update Image and Host entities

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2605,7 +2605,12 @@ class Host(  # pylint:disable=too-many-instance-attributes
         return _handle_response(response, self._server_config, synchronous)
 
 
-class Image(Entity):
+class Image(
+        Entity,
+        EntityCreateMixin,
+        EntityDeleteMixin,
+        EntityReadMixin,
+        EntityUpdateMixin):
     """A representation of a Image entity."""
 
     def __init__(self, server_config=None, **kwargs):

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -868,6 +868,7 @@ class ReadTestCase(TestCase):
                     content_view_filter=2,
                 ),
                 entities.ContentViewPuppetModule(self.cfg, content_view=2),
+                entities.Image(self.cfg, compute_resource=1),
                 entities.OperatingSystemParameter(self.cfg, operatingsystem=2),
                 entities.OverrideValue(self.cfg, smart_class_parameter=2),
                 entities.OverrideValue(self.cfg, smart_variable=2),
@@ -1078,6 +1079,37 @@ class ReadTestCase(TestCase):
                 self.assertTrue(hasattr(product, 'sync_plan'))
                 # pylint:disable=no-member
                 self.assertEqual(product.sync_plan.id, sync_plan.id)
+
+    def test_host_with_image(self):
+        """Call :meth:`nailgun.entities.Host.read` for a host with image
+        assigned.
+
+        Ensure that the image entity was correctly fetched.
+        """
+        image = entities.Image(self.cfg, id=1, compute_resource=1)
+        host = entities.Host(self.cfg, id=1)
+        with mock.patch.object(EntityReadMixin, 'read_json') as read_json:
+            with mock.patch.object(EntityReadMixin, 'read') as read:
+                # Image was set
+                read_json.return_value = {
+                    'image_id': 1,
+                    'compute_resource_id': 1,
+                    'parameters': {},
+                }
+                read.return_value = host
+                host = host.read()
+                self.assertTrue(hasattr(host, 'image'))
+                # pylint:disable=no-member
+                self.assertEqual(host.image.id, image.id)
+                # Image wasn't set
+                read_json.return_value = {
+                    'parameters': {},
+                }
+                read.return_value = host
+                host = host.read()
+                self.assertTrue(hasattr(host, 'image'))
+                # pylint:disable=no-member
+                self.assertIsNone(host.image)
 
 
 class SearchRawTestCase(TestCase):

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -123,7 +123,6 @@ class InitTestCase(TestCase):
                 entities.HostCollectionErrata,
                 entities.HostCollectionPackage,
                 entities.HostGroup,
-                entities.Image,
                 entities.Interface,
                 entities.LibvirtComputeResource,
                 entities.LifecycleEnvironment,
@@ -175,6 +174,7 @@ class InitTestCase(TestCase):
             (entities.ContentViewPuppetModule, {'content_view': 1}),
             (entities.HostPackage, {'host': 1}),
             (entities.HostSubscription, {'host': 1}),
+            (entities.Image, {'compute_resource': 1}),
             (entities.OperatingSystemParameter, {'operatingsystem': 1}),
             (entities.OverrideValue, {'smart_class_parameter': 1}),
             (entities.OverrideValue, {'smart_variable': 1}),
@@ -208,6 +208,7 @@ class InitTestCase(TestCase):
                 entities.ContentViewPuppetModule,
                 entities.HostPackage,
                 entities.HostSubscription,
+                entities.Image,
                 entities.OverrideValue,
                 entities.OperatingSystemParameter,
                 entities.RepositorySet,
@@ -552,6 +553,7 @@ class CreatePayloadTestCase(TestCase):
             )
         ]
         entities_.extend([
+            (entities.Image, {'compute_resource': 1}),
             (entities.SyncPlan, {'organization': 1})
         ])
         for entity, params in entities_:
@@ -580,6 +582,14 @@ class CreatePayloadTestCase(TestCase):
         ).create_payload()
         self.assertNotIn('system_ids', payload)
         self.assertIn('system_uuids', payload)
+
+    def test_image(self):
+        """Create a :class:`nailgun.entities.Image`."""
+        payload = entities.Image(
+            self.cfg,
+            compute_resource=1,
+        ).create_payload()
+        self.assertEqual({'image': {'compute_resource_id': 1}}, payload)
 
     def test_media(self):
         """Create a :class:`nailgun.entities.Media`."""
@@ -1240,6 +1250,19 @@ class UpdatePayloadTestCase(TestCase):
         ).update_payload()
         self.assertNotIn('search_', payload['discovery_rule'])
         self.assertIn('search', payload['discovery_rule'])
+
+    def test_image(self):
+        """Check whether ``Image`` updates its ``path_`` field.
+
+        The field should be renamed from ``path_`` to ``path`` when
+        ``update_payload`` is called.
+
+        """
+        payload = entities.Image(
+            self.cfg,
+            compute_resource=1,
+        ).update_payload()
+        self.assertEqual({'image': {'compute_resource_id': 1}}, payload)
 
     def test_media_path(self):
         """Check whether ``Media`` updates its ``path_`` field.


### PR DESCRIPTION
Cherry-picked from #347 
Update: looks like it was not enough only to add mixins to `Image`, its behavior was not correct.
Update 2: Also it requires changes in `Host` class.