### PR TITLE
Increase timeout for manifest delete/refresh

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -4965,7 +4965,12 @@ class Subscription(
             self._org_path('delete_manifest', kwargs['data']),
             **kwargs
         )
-        return _handle_response(response, self._server_config, synchronous)
+        return _handle_response(
+            response,
+            self._server_config,
+            synchronous,
+            timeout=900,
+        )
 
     def manifest_history(self, synchronous=True, **kwargs):
         """Obtain manifest history for subscriptions.
@@ -5005,7 +5010,12 @@ class Subscription(
             self._org_path('refresh_manifest', kwargs['data']),
             **kwargs
         )
-        return _handle_response(response, self._server_config, synchronous)
+        return _handle_response(
+            response,
+            self._server_config,
+            synchronous,
+            timeout=900,
+        )
 
     def upload(self, synchronous=True, **kwargs):
         """Upload a subscription manifest.


### PR DESCRIPTION
Default value for timeout is 5 minutes. Subscription upload takes more
time and as an exclusion has timeout of 15 minutes.
Automation results uncovered manifest delete/refresh commands take
pretty much comparable with upload amount of time (latest run shows
they took ~7 mins), which causes failures.
Updating timeout for manifest delete/refresh to match upload, hopefully
this will help us to get rid of constant subscription test failures.

Test results:
```python
py.test tests/foreman/api/test_subscription.py -k 'delete or refresh'
============================= test session starts ==============================
platform linux2 -- Python 2.7.10, pytest-3.0.3, py-1.4.31, pluggy-0.4.0
rootdir: /home/andrii/workspace/robottelo, inifile: 
plugins: xdist-1.13.1, repeat-0.2
collected 4 items 

tests/foreman/api/test_subscription.py ..

============================== 2 tests deselected ==============================
=================== 2 passed, 2 deselected in 78.82 seconds ====================
```