### PR TITLE
[Cherry-pick][6.2.z] Increase timeout for manifest delete/refresh (#359)

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -4568,7 +4568,12 @@ class Subscription(
             self._org_path('delete_manifest', kwargs['data']),
             **kwargs
         )
-        return _handle_response(response, self._server_config, synchronous)
+        return _handle_response(
+            response,
+            self._server_config,
+            synchronous,
+            timeout=900,
+        )
 
     def manifest_history(self, synchronous=True, **kwargs):
         """Obtain manifest history for subscriptions.
@@ -4608,7 +4613,12 @@ class Subscription(
             self._org_path('refresh_manifest', kwargs['data']),
             **kwargs
         )
-        return _handle_response(response, self._server_config, synchronous)
+        return _handle_response(
+            response,
+            self._server_config,
+            synchronous,
+            timeout=900,
+        )
 
     def upload(self, synchronous=True, **kwargs):
         """Upload a subscription manifest.


### PR DESCRIPTION
Default value for timeout is 5 minutes. Subscription upload takes more
time and as an exclusion has timeout of 15 minutes.
Automation results uncovered manifest delete/refresh commands take
pretty much comparable with upload amount of time (latest run shows
they took ~7 mins), which causes failures.
Updating timeout for manifest delete/refresh to match upload, hopefully
this will help us to get rid of constant subscription test failures.