### PR TITLE
Removed overriden read method for Smart Variable

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -4735,18 +4735,6 @@ class SmartVariable(
         }
         super(SmartVariable, self).__init__(server_config, **kwargs)
 
-    def read(self, entity=None, attrs=None, ignore=None):
-        """Fetch as many attributes as possible for this entity.
-
-        Do not read the ``variable_type`` attribute. For more information, see
-        `Bugzilla #1375881
-        <https://bugzilla.redhat.com/show_bug.cgi?id=1375881>`_.
-        """
-        if ignore is None:
-            ignore = set()
-        ignore.add('variable_type')
-        return super(SmartVariable, self).read(entity, attrs, ignore)
-
     def create_payload(self):
         """Wrap submitted data within an extra dict."""
         return {u'smart_variable': super(SmartVariable, self).create_payload()}

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -994,7 +994,6 @@ class ReadTestCase(TestCase):
         for entity, ignored_attrs in (
                 (entities.Errata,
                  {'content_view_version', 'environment', 'repository'}),
-                (entities.SmartVariable, {'variable_type'}),
                 (entities.Subnet, {'discovery'}),
                 (entities.User, {'password'}),
         ):


### PR DESCRIPTION
Bug [1] that required changes in `read` method for `SmartVariable` is fixed.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1375881