### PR TITLE
Add ProvisioningTemplate.

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -1022,7 +1022,7 @@ class ConfigTemplate(
         """
         kwargs = kwargs.copy()  # shadow the passed-in kwargs
         kwargs.update(self._server_config.get_client_kwargs())
-        response = client.get(self.path('build_pxe_default'), **kwargs)
+        response = client.post(self.path('build_pxe_default'), **kwargs)
         return _handle_response(response, self._server_config, synchronous)
 
     def clone(self, synchronous=True, **kwargs):
@@ -1145,7 +1145,7 @@ class ProvisioningTemplate(
         """
         kwargs = kwargs.copy()  # shadow the passed-in kwargs
         kwargs.update(self._server_config.get_client_kwargs())
-        response = client.get(self.path('build_pxe_default'), **kwargs)
+        response = client.post(self.path('build_pxe_default'), **kwargs)
         return _handle_response(response, self._server_config, synchronous)
 
     def clone(self, synchronous=True, **kwargs):

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -21,7 +21,6 @@ makes use of a work-around notes so in its docstring.
 workings of entity classes.
 
 """
-import random
 from datetime import datetime
 from sys import version_info
 
@@ -964,13 +963,7 @@ class ConfigTemplate(
         super(ConfigTemplate, self).create_missing()
         if (getattr(self, 'snippet', None) is False and
                 not hasattr(self, 'template_kind')):
-            # A server is pre-populated with "num_created_by_default" template
-            # kinds. We use one of those instead of creating a new one.
-            self.template_kind = TemplateKind(self._server_config)
-            self.template_kind.id = random.randint(  # pylint:disable=C0103
-                # pylint:disable=protected-access
-                1, self.template_kind._meta['num_created_by_default']
-            )
+            self.template_kind = TemplateKind(self._server_config, id=1)
 
     def create_payload(self):
         """Wrap submitted data within an extra dict.
@@ -984,17 +977,6 @@ class ConfigTemplate(
             payload['template_combinations_attributes'] = payload.pop(
                 'template_combinations')
         return {u'config_template': payload}
-
-    @signals.emit(sender=signals.SENDER_CLASS, post_result_name='entity')
-    def update(self, fields=None):
-        """Fetch a complete set of attributes for this entity.
-
-        For more information, see `Bugzilla #1234973
-        <https://bugzilla.redhat.com/show_bug.cgi?id=1234973>`_.
-
-        """
-        self.update_json(fields)
-        return self.read()
 
     def update_payload(self, fields=None):
         """Wrap submitted data within an extra dict."""
@@ -1104,13 +1086,7 @@ class ProvisioningTemplate(
         super(ProvisioningTemplate, self).create_missing()
         if (getattr(self, 'snippet', None) is False and
                 not hasattr(self, 'template_kind')):
-            # A server is pre-populated with "num_created_by_default" template
-            # kinds. We use one of those instead of creating a new one.
-            self.template_kind = TemplateKind(self._server_config)
-            self.template_kind.id = random.randint(  # pylint:disable=C0103
-                # pylint:disable=protected-access
-                1, self.template_kind._meta['num_created_by_default']
-            )
+            self.template_kind = TemplateKind(self._server_config, id=1)
 
     def create_payload(self):
         """Wrap submitted data within an extra dict.
@@ -1124,17 +1100,6 @@ class ProvisioningTemplate(
             payload['template_combinations_attributes'] = payload.pop(
                 'template_combinations')
         return {u'provisioning_template': payload}
-
-    @signals.emit(sender=signals.SENDER_CLASS, post_result_name='entity')
-    def update(self, fields=None):
-        """Fetch a complete set of attributes for this entity.
-
-        For more information, see `Bugzilla #1234973
-        <https://bugzilla.redhat.com/show_bug.cgi?id=1234973>`_.
-
-        """
-        self.update_json(fields)
-        return self.read()
 
     def update_payload(self, fields=None):
         """Wrap submitted data within an extra dict."""
@@ -5500,7 +5465,7 @@ class TemplateCombination(Entity, EntityDeleteMixin, EntityReadMixin):
         super(TemplateCombination, self).__init__(server_config, **kwargs)
 
 
-class TemplateKind(Entity, EntityReadMixin):
+class TemplateKind(Entity, EntityReadMixin, EntitySearchMixin):
     """A representation of a Template Kind entity.
 
     Unusually, the ``/api/v2/template_kinds/:id`` path is totally unsupported.

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -1060,6 +1060,146 @@ class ConfigTemplate(
         return _handle_response(response, self._server_config, synchronous)
 
 
+class ProvisioningTemplate(
+        Entity,
+        EntityCreateMixin,
+        EntityDeleteMixin,
+        EntityReadMixin,
+        EntitySearchMixin,
+        EntityUpdateMixin):
+    """A representation of a Provisioning Template entity."""
+
+    def __init__(self, server_config=None, **kwargs):
+        self._fields = {
+            'audit_comment': entity_fields.StringField(),
+            'locked': entity_fields.BooleanField(),
+            'name': entity_fields.StringField(
+                required=True,
+                str_type='alpha',
+                length=(6, 12),
+            ),
+            'operatingsystem': entity_fields.OneToManyField(OperatingSystem),
+            'organization': entity_fields.OneToManyField(Organization),
+            'location': entity_fields.OneToManyField(Location),
+            'snippet': entity_fields.BooleanField(required=True),
+            'template': entity_fields.StringField(required=True),
+            'template_combinations': entity_fields.ListField(),
+            'template_kind': entity_fields.OneToOneField(TemplateKind),
+        }
+        self._meta = {
+            'api_path': 'api/v2/provisioning_templates',
+            'server_modes': ('sat'),
+        }
+        super(ProvisioningTemplate, self).__init__(server_config, **kwargs)
+
+    def create_missing(self):
+        """Customize the process of auto-generating instance attributes.
+
+        Populate ``template_kind`` if:
+
+        * this template is not a snippet, and
+        * the ``template_kind`` instance attribute is unset.
+
+        """
+        super(ProvisioningTemplate, self).create_missing()
+        if (getattr(self, 'snippet', None) is False and
+                not hasattr(self, 'template_kind')):
+            # A server is pre-populated with "num_created_by_default" template
+            # kinds. We use one of those instead of creating a new one.
+            self.template_kind = TemplateKind(self._server_config)
+            self.template_kind.id = random.randint(  # pylint:disable=C0103
+                # pylint:disable=protected-access
+                1, self.template_kind._meta['num_created_by_default']
+            )
+
+    def create_payload(self):
+        """Wrap submitted data within an extra dict.
+
+        For more information, see `Bugzilla #1151220
+        <https://bugzilla.redhat.com/show_bug.cgi?id=1151220>`_.
+
+        """
+        payload = super(ProvisioningTemplate, self).create_payload()
+        if 'template_combinations' in payload:
+            payload['template_combinations_attributes'] = payload.pop(
+                'template_combinations')
+        return {u'provisioning_template': payload}
+
+    @signals.emit(sender=signals.SENDER_CLASS, post_result_name='entity')
+    def update(self, fields=None):
+        """Fetch a complete set of attributes for this entity.
+
+        For more information, see `Bugzilla #1234973
+        <https://bugzilla.redhat.com/show_bug.cgi?id=1234973>`_.
+
+        """
+        self.update_json(fields)
+        return self.read()
+
+    def update_payload(self, fields=None):
+        """Wrap submitted data within an extra dict."""
+        payload = super(ProvisioningTemplate, self).update_payload()
+        if 'template_combinations' in payload:
+            payload['template_combinations_attributes'] = payload.pop(
+                'template_combinations')
+        return {u'provisioning_template': payload}
+
+    def path(self, which=None):
+        """Extend ``nailgun.entity_mixins.Entity.path``.
+
+        The format of the returned path depends on the value of ``which``:
+
+        build_pxe_default
+            /provisioning_templates/build_pxe_default
+        clone
+            /provisioning_templates/clone
+        revision
+            /provisioning_templates/revision
+
+        ``super`` is called otherwise.
+
+        """
+        if which in ('build_pxe_default', 'clone', 'revision'):
+            prefix = 'self' if which == 'clone' else 'base'
+            return '{0}/{1}'.format(
+                super(ProvisioningTemplate, self).path(prefix),
+                which
+            )
+        return super(ProvisioningTemplate, self).path(which)
+
+    def build_pxe_default(self, synchronous=True, **kwargs):
+        """Helper to build pxe default template.
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+        """
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.get(self.path('build_pxe_default'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous)
+
+    def clone(self, synchronous=True, **kwargs):
+        """Helper to clone an existing provision template
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+        """
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.post(self.path('clone'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous)
+
+
 class AbstractDockerContainer(
         Entity,
         EntityCreateMixin,
@@ -3054,7 +3194,8 @@ class Location(
         self._fields = {
             'compute_resource': entity_fields.OneToManyField(
                 AbstractComputeResource),
-            'config_template': entity_fields.OneToManyField(ConfigTemplate),
+            'config_template': entity_fields.OneToManyField(
+                ProvisioningTemplate),
             'description': entity_fields.StringField(),
             'domain': entity_fields.OneToManyField(Domain),
             'environment': entity_fields.OneToManyField(Environment),
@@ -3066,6 +3207,8 @@ class Location(
                 length=(6, 12),
             ),
             'organization': entity_fields.OneToManyField(Organization),
+            'provisioning_template': entity_fields.OneToManyField(
+                ProvisioningTemplate),
             'realm': entity_fields.OneToManyField(Realm),
             'smart_proxy': entity_fields.OneToManyField(SmartProxy),
             'subnet': entity_fields.OneToManyField(Subnet),
@@ -3268,7 +3411,10 @@ class OperatingSystem(
                 length=(6, 12),
             ),
             'ptable': entity_fields.OneToManyField(PartitionTable),
-            'config_template': entity_fields.OneToManyField(ConfigTemplate),
+            'config_template': entity_fields.OneToManyField(
+                ProvisioningTemplate),
+            'provisioning_template': entity_fields.OneToManyField(
+                ProvisioningTemplate),
             'release_name': entity_fields.StringField(),
             'password_hash': entity_fields.StringField(
                 choices=('MD5', 'SHA256', 'SHA512'),
@@ -3382,7 +3528,8 @@ class Organization(
             'compute_resource': entity_fields.OneToManyField(
                 AbstractComputeResource
             ),
-            'config_template': entity_fields.OneToManyField(ConfigTemplate),
+            'config_template': entity_fields.OneToManyField(
+                ProvisioningTemplate),
             'description': entity_fields.StringField(),
             'domain': entity_fields.OneToManyField(Domain),
             'environment': entity_fields.OneToManyField(Environment),
@@ -3394,6 +3541,8 @@ class Organization(
                 str_type='alpha',
                 length=(6, 12),
             ),
+            'provisioning_template': entity_fields.OneToManyField(
+                ProvisioningTemplate),
             'realm': entity_fields.OneToManyField(Realm),
             'smart_proxy': entity_fields.OneToManyField(SmartProxy),
             'subnet': entity_fields.OneToManyField(Subnet),
@@ -3519,10 +3668,13 @@ class OSDefaultTemplate(Entity):
 
     def __init__(self, server_config=None, **kwargs):
         self._fields = {
-            'config_template': entity_fields.OneToOneField(ConfigTemplate),
+            'config_template': entity_fields.OneToOneField(
+                ProvisioningTemplate),
             'operatingsystem': entity_fields.OneToOneField(
                 OperatingSystem
             ),
+            'provisioning_template': entity_fields.OneToOneField(
+                ProvisioningTemplate),
             'template_kind': entity_fields.OneToOneField(TemplateKind),
         }
         self._meta = {
@@ -5333,11 +5485,13 @@ class TemplateCombination(Entity, EntityDeleteMixin, EntityReadMixin):
     def __init__(self, server_config=None, **kwargs):
         self._fields = {
             'config_template': entity_fields.OneToOneField(
-                ConfigTemplate,
-                required=True,
-            ),
+                ProvisioningTemplate),
             'environment': entity_fields.OneToOneField(Environment),
             'hostgroup': entity_fields.OneToOneField(HostGroup),
+            'provisioning_template': entity_fields.OneToOneField(
+                ProvisioningTemplate,
+                required=True,
+            ),
         }
         self._meta = {
             'api_path': 'api/v2/template_combinations',

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1198,8 +1198,6 @@ class UpdateTestCase(TestCase):
             entities.Architecture(self.cfg),
             entities.ComputeProfile(self.cfg),
             entities.ConfigGroup(self.cfg),
-            entities.ConfigTemplate(self.cfg),
-            entities.ProvisioningTemplate(self.cfg),
             entities.DiscoveryRule(self.cfg),
             entities.Domain(self.cfg),
             entities.Environment(self.cfg),

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1372,11 +1372,11 @@ class GenericTestCase(TestCase):
             (entities.ActivationKey(**generic).add_subscriptions, 'put'),
             (entities.ActivationKey(**generic).content_override, 'put'),
             (entities.ActivationKey(**generic).remove_host_collection, 'put'),
-            (entities.ConfigTemplate(**generic).build_pxe_default, 'get'),
+            (entities.ConfigTemplate(**generic).build_pxe_default, 'post'),
             (entities.ConfigTemplate(**generic).clone, 'post'),
             (
                 entities.ProvisioningTemplate(**generic).build_pxe_default,
-                'get'
+                'post'
             ),
             (entities.ProvisioningTemplate(**generic).clone, 'post'),
             (entities.ContentView(**generic).available_puppet_modules, 'get'),

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -103,6 +103,7 @@ class InitTestCase(TestCase):
                 entities.ComputeProfile,
                 entities.ConfigGroup,
                 entities.ConfigTemplate,
+                entities.ProvisioningTemplate,
                 entities.ContentUpload,
                 entities.ContentView,
                 entities.ContentViewVersion,
@@ -236,6 +237,7 @@ class PathTestCase(TestCase):
                 (entities.AbstractDockerContainer, '/containers'),
                 (entities.ActivationKey, '/activation_keys'),
                 (entities.ConfigTemplate, '/config_templates'),
+                (entities.ProvisioningTemplate, '/provisioning_templates'),
                 (entities.ContentView, '/content_views'),
                 (entities.ContentViewVersion, '/content_view_versions'),
                 (entities.DiscoveredHost, '/discovered_hosts'),
@@ -282,6 +284,7 @@ class PathTestCase(TestCase):
                 (entities.ActivationKey, 'remove_subscriptions'),
                 (entities.ActivationKey, 'subscriptions'),
                 (entities.ConfigTemplate, 'clone'),
+                (entities.ProvisioningTemplate, 'clone'),
                 (entities.ContentView, 'available_puppet_module_names'),
                 (entities.ContentView, 'content_view_puppet_modules'),
                 (entities.ContentView, 'content_view_versions'),
@@ -325,6 +328,8 @@ class PathTestCase(TestCase):
         for entity, which in (
                 (entities.ConfigTemplate, 'build_pxe_default'),
                 (entities.ConfigTemplate, 'revision'),
+                (entities.ProvisioningTemplate, 'build_pxe_default'),
+                (entities.ProvisioningTemplate, 'revision'),
                 (entities.ContentViewVersion, 'incremental_update'),
                 (entities.DiscoveredHost, 'facts'),
                 (entities.Errata, 'compare'),
@@ -544,6 +549,7 @@ class CreatePayloadTestCase(TestCase):
                 entities.Architecture,
                 entities.ConfigGroup,
                 entities.ConfigTemplate,
+                entities.ProvisioningTemplate,
                 entities.DiscoveredHost,
                 entities.DiscoveryRule,
                 entities.Domain,
@@ -683,6 +689,46 @@ class CreateMissingTestCase(TestCase):
         """Test ``ConfigTemplate(snippet=False, template_kind=…)``."""
         tk_id = gen_integer()
         entity = entities.ConfigTemplate(
+            self.cfg,
+            snippet=False,
+            template_kind=tk_id,
+        )
+        with mock.patch.object(EntityCreateMixin, 'create_raw'):
+            with mock.patch.object(EntityReadMixin, 'read_raw'):
+                entity.create_missing()
+        self.assertEqual(
+            _get_required_field_names(entity).union(['template_kind']),
+            set(entity.get_values().keys()),
+        )
+        # pylint:disable=no-member
+        self.assertEqual(entity.template_kind.id, tk_id)
+
+    def test_provisioning_template_v1(self):
+        """Test ``ProvisioningTemplate(snippet=True)``."""
+        entity = entities.ProvisioningTemplate(self.cfg, snippet=True)
+        with mock.patch.object(EntityCreateMixin, 'create_raw'):
+            with mock.patch.object(EntityReadMixin, 'read_raw'):
+                entity.create_missing()
+        self.assertEqual(
+            _get_required_field_names(entity),
+            set(entity.get_values().keys()),
+        )
+
+    def test_provisioning_template_v2(self):
+        """Test ``ProvisioningTemplate(snippet=False)``."""
+        entity = entities.ProvisioningTemplate(self.cfg, snippet=False)
+        with mock.patch.object(EntityCreateMixin, 'create_raw'):
+            with mock.patch.object(EntityReadMixin, 'read_raw'):
+                entity.create_missing()
+        self.assertEqual(
+            _get_required_field_names(entity).union(['template_kind']),
+            set(entity.get_values().keys()),
+        )
+
+    def test_provisioning_template_v3(self):
+        """Test ``ProvisioningTemplate(snippet=False, template_kind=…)``."""
+        tk_id = gen_integer()
+        entity = entities.ProvisioningTemplate(
             self.cfg,
             snippet=False,
             template_kind=tk_id,
@@ -1153,6 +1199,7 @@ class UpdateTestCase(TestCase):
             entities.ComputeProfile(self.cfg),
             entities.ConfigGroup(self.cfg),
             entities.ConfigTemplate(self.cfg),
+            entities.ProvisioningTemplate(self.cfg),
             entities.DiscoveryRule(self.cfg),
             entities.Domain(self.cfg),
             entities.Environment(self.cfg),
@@ -1209,6 +1256,7 @@ class UpdatePayloadTestCase(TestCase):
         entities_payloads = [
             (entities.AbstractComputeResource, {'compute_resource': {}}),
             (entities.ConfigTemplate, {'config_template': {}}),
+            (entities.ProvisioningTemplate, {'provisioning_template': {}}),
             (entities.DiscoveredHost, {'discovered_host': {}}),
             (entities.DiscoveryRule, {'discovery_rule': {}}),
             (entities.Domain, {'domain': {}}),
@@ -1328,6 +1376,11 @@ class GenericTestCase(TestCase):
             (entities.ActivationKey(**generic).remove_host_collection, 'put'),
             (entities.ConfigTemplate(**generic).build_pxe_default, 'get'),
             (entities.ConfigTemplate(**generic).clone, 'post'),
+            (
+                entities.ProvisioningTemplate(**generic).build_pxe_default,
+                'get'
+            ),
+            (entities.ProvisioningTemplate(**generic).clone, 'post'),
             (entities.ContentView(**generic).available_puppet_modules, 'get'),
             (entities.ContentView(**generic).copy, 'post'),
             (entities.ContentView(**generic).publish, 'post'),
@@ -1523,6 +1576,53 @@ class ConfigTemplateTestCase(TestCase):
         # pylint: disable=no-member
         cfg_template.template_combinations.append(combination3)
         attrs = expected_dct[u'config_template']
+        attrs['template_combinations_attributes'].append(
+            {'environment_id': 3, 'hostgroup_id': 2}
+        )
+        self.assertEqual(expected_dct, cfg_template.update_payload())
+
+
+class ProvisioningTemplateTestCase(TestCase):
+    """Tests for :class:`nailgun.entities.ProvisioningTemplate`."""
+
+    def test_creation_and_update(self):
+        """Check template combinations as json or entity is set on correct
+        attribute template_combinations_attributes ( check #333)
+        """
+        cfg = config.ServerConfig(url='foo')
+        env = entities.Environment(cfg, id=2, name='env')
+        hostgroup = entities.HostGroup(cfg, id=2, name='hgroup')
+        combination = entities.TemplateCombination(
+            cfg,
+            hostgroup=hostgroup,
+            environment=env)
+        template_combinations = [
+            {'hostgroup_id': 1, 'environment_id': 1},
+            combination]
+        cfg_template = entities.ProvisioningTemplate(
+            cfg, name='cfg',
+            snippet=False,
+            template='cat',
+            template_kind=8,
+            template_combinations=template_combinations)
+        expected_dct = {
+            u'provisioning_template': {
+                'name': 'cfg', 'snippet': False, 'template': 'cat',
+                'template_kind_id': 8, 'template_combinations_attributes': [
+                    {'environment_id': 1, 'hostgroup_id': 1},
+                    {'environment_id': 2, 'hostgroup_id': 2}]
+            }
+        }
+        self.assertEqual(expected_dct, cfg_template.create_payload())
+        # Testing update
+        env3 = entities.Environment(cfg, id=3, name='env3')
+        combination3 = entities.TemplateCombination(
+            cfg,
+            hostgroup=hostgroup,
+            environment=env3)
+        # pylint: disable=no-member
+        cfg_template.template_combinations.append(combination3)
+        attrs = expected_dct[u'provisioning_template']
         attrs['template_combinations_attributes'].append(
             {'environment_id': 3, 'hostgroup_id': 2}
         )
@@ -2420,7 +2520,7 @@ class JsonSerializableTestCase(TestCase):
 
         cfg_kwargs = {'id': 5, 'snippet': False, 'template': 'cat'}
         cfg_template = make_entity(
-            entities.ConfigTemplate,
+            entities.ProvisioningTemplate,
             template_combinations=combinations,
             **cfg_kwargs)
 


### PR DESCRIPTION
`Config Template` entity now is deprecated and it is just an alias for `Provisioning Template`, so rename should be enough.
Probably same change should be made for 6.2 as well.