### PR TITLE
[Cherry-pick][6.2.z] Add EntitySearchMixin to HostCollection

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2043,6 +2043,7 @@ class HostCollection(
         EntityCreateMixin,
         EntityDeleteMixin,
         EntityReadMixin,
+        EntitySearchMixin,
         EntityUpdateMixin):
     """A representation of a Host Collection entity."""
 


### PR DESCRIPTION
```console
/home/dlezz/bin/redhat/6.2.z/python/2.7/bin/python2.7 /home/dlezz/bin/pycharm-2016.3/helpers/pydev/pydevconsole.py 44384 40530
PyDev console: starting.
import sys; print('Python %s on %s' % (sys.version, sys.platform))
sys.path.extend(['/home/dlezz/projects/nailgun'])
Python 2.7.12 (default, Oct 11 2016, 17:04:14) 
[GCC 4.8.4] on linux2
from nailgun import entities
from nailgun.config import ServerConfig
server_config = ServerConfig(
    auth=('admin', 'changeme'),
    url='server-host-masked',
    verify=False
)
org = entities.Organization(server_config, name='htttttt').create()
hc = entities.HostCollection(server_config, organization=org, name='ht_host').create()
hc_list = entities.HostCollection(server_config, organization=org).search()
len(hc_list)
1
type(hc_list[0])
<class 'nailgun.entities.HostCollection'>
hc_list[0].id == hc.id
True
```