### PR TITLE
Provide default name length & type for ComputeResource entities

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -581,7 +581,8 @@ class AbstractComputeResource(
             'location': entity_fields.OneToManyField(Location),
             'name': entity_fields.StringField(
                 required=True,
-                str_type=('alphanumeric', 'cjk'),  # cannot contain whitespace
+                str_type='alphanumeric',  # cannot contain whitespace
+                length=(6, 12),
             ),
             'organization': entity_fields.OneToManyField(Organization),
             'provider': entity_fields.StringField(


### PR DESCRIPTION
Default name length for `AbstractComputeResource` (and subentities like LibvirtComputeResource) was not set, which can lead to entities with one character in name being created, which in rare cases (like latest automation run 😄 ) can attempt to create 2 entities with the same name (the longer name is, the less is the chance of the same name generation).
Also removing `cjk` from the tuple of acceptable string types as it creates issues with readability and basically increases efforts for debugging.
This PR should have been implemented as a part of #290