### PR TITLE
[6.2.z] [Cherry-pick] Provide default name length & type for ComputeResource entities (#369)

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -581,7 +581,8 @@ class AbstractComputeResource(
             'location': entity_fields.OneToManyField(Location),
             'name': entity_fields.StringField(
                 required=True,
-                str_type=('alphanumeric', 'cjk'),  # cannot contain whitespace
+                str_type='alphanumeric',  # cannot contain whitespace
+                length=(6, 12),
             ),
             'organization': entity_fields.OneToManyField(Organization),
             'provider': entity_fields.StringField(


### PR DESCRIPTION
Part of #368