### PR TITLE
Implemented Interface entity with all its fields and basic operations

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2496,6 +2496,7 @@ class Host(  # pylint:disable=too-many-instance-attributes
             'hostgroup': entity_fields.OneToOneField(HostGroup),
             'host_parameters_attributes': entity_fields.ListField(),
             'image': entity_fields.OneToOneField(Image),
+            'interface': entity_fields.OneToManyField(Interface),
             'ip': entity_fields.StringField(),
             'location': entity_fields.OneToOneField(Location, required=True),
             'mac': entity_fields.MACAddressField(),
@@ -2761,7 +2762,19 @@ class Host(  # pylint:disable=too-many-instance-attributes
             ignore.add('content_facet_attributes')
         ignore.add('root_pass')
         attrs['host_parameters_attributes'] = attrs.pop('parameters')
-        return super(Host, self).read(entity, attrs, ignore)
+        # host id is required for interface initialization
+        ignore.add('interface')
+        result = super(Host, self).read(entity, attrs, ignore)
+        if 'interfaces' in attrs and attrs['interfaces']:
+            result.interface = [
+                Interface(
+                    self._server_config,
+                    host=result.id,
+                    id=interface['id'],
+                )
+                for interface in attrs['interfaces']
+            ]
+        return result
 
     @signals.emit(sender=signals.SENDER_CLASS, post_result_name='entity')
     def update(self, fields=None):
@@ -2938,31 +2951,117 @@ class Image(
         super(Image, self).__init__(server_config, **kwargs)
 
 
-class Interface(Entity):
-    """A representation of a Interface entity."""
+class Interface(
+        Entity,
+        EntityCreateMixin,
+        EntityDeleteMixin,
+        EntityReadMixin,
+        EntitySearchMixin,
+        EntityUpdateMixin):
+    """A representation of a Interface entity.
+
+    ``host`` must be passed in when this entity is instantiated.
+
+    :raises: ``TypeError`` if ``host`` is not passed in.
+    """
 
     def __init__(self, server_config=None, **kwargs):
+        _check_for_value('host', kwargs)
         self._fields = {
+            'attached_devices': entity_fields.DictField(),  # for 'bond' or ...
+            # ... 'bridge' type
+            'attached_to': entity_fields.StringField(),  # for 'virtual' type
+            'bond_options': entity_fields.StringField(),  # for 'bond' type
             'domain': entity_fields.OneToOneField(Domain),
             'host': entity_fields.OneToOneField(Host, required=True),
-            'type': entity_fields.StringField(required=True),
+            'identifier': entity_fields.StringField(),
             'ip': entity_fields.IPAddressField(required=True),
             'mac': entity_fields.MACAddressField(required=True),
+            'managed': entity_fields.BooleanField(),
+            'mode': entity_fields.StringField(  # for 'bond' type
+                choices=('802.3ad', 'active-backup', 'balance-alb',
+                         'balance-rr', 'balance-tlb', 'balance-xor',
+                         'broadcast')
+            ),
             'name': entity_fields.StringField(
                 required=True,
                 str_type='alpha',
                 length=(6, 12),
             ),
-            'password': entity_fields.StringField(),
-            'provider': entity_fields.StringField(),
+            'password': entity_fields.StringField(),  # for 'bmc' type
+            'primary': entity_fields.BooleanField(),
+            'provider': entity_fields.StringField(),  # for 'bmc' type
+            'provision': entity_fields.BooleanField(),
             'subnet': entity_fields.OneToOneField(Subnet),
-            'username': entity_fields.StringField(),
-        }
-        self._meta = {
-            'api_path': 'api/v2/hosts/:host_id/interfaces',
-            'server_modes': ('sat'),
+            'tag': entity_fields.StringField(),  # for 'virtual' type
+            'type': entity_fields.StringField(
+                choices=('interface', 'bmc', 'bond', 'bridge'),
+                default='interface',
+                required=True),
+
+            'virtual': entity_fields.BooleanField(),
+            'username': entity_fields.StringField(),  # for 'bmc' type
         }
         super(Interface, self).__init__(server_config, **kwargs)
+        self._meta = {
+            # pylint:disable=no-member
+            'api_path': '{}/interfaces'.format(self.host.path()),
+            'server_modes': ('sat'),
+        }
+
+    def read(self, entity=None, attrs=None, ignore=None):
+        """Provide a default value for ``entity``.
+
+        By default, ``nailgun.entity_mixins.EntityReadMixin.read`` provides a
+        default value for ``entity`` like so::
+
+            entity = type(self)()
+
+        However, :class:`Interface` requires that a ``host`` must be provided,
+        so this technique will not work. Do this instead::
+
+            entity = type(self)(host=self.host)
+
+        In addition, some of interface fields are specific to its ``type`` and
+        are never returned for different ``type`` so ignoring all the redundant
+        fields.
+
+        """
+        # read() should not change the state of the object it's called on, but
+        # super() alters the attributes of any entity passed in. Creating a new
+        # object and passing it to super() lets this one avoid changing state.
+        if entity is None:
+            entity = type(self)(
+                self._server_config,
+                host=self.host,  # pylint:disable=no-member
+            )
+        if attrs is None:
+            attrs = self.read_json()
+        if ignore is None:
+            ignore = set()
+        ignore.add('host')
+        # type-specific fields
+        if attrs['type'] != 'bmc':
+            ignore.add('password')
+            ignore.add('provider')
+            ignore.add('username')
+        if attrs['type'] != 'bond':
+            ignore.add('mode')
+            ignore.add('bond_options')
+        if attrs['type'] != 'virtual':
+            ignore.add('attached_to')
+            ignore.add('tag')
+        if attrs['type'] != 'bridge' and attrs['type'] != 'bond':
+            ignore.add('attached_devices')
+        return super(Interface, self).read(entity, attrs, ignore)
+
+    def search_normalize(self, results):
+        """Append host id to search results to be able to initialize found
+        :class:`Interface` successfully
+        """
+        for interface in results:
+            interface[u'host_id'] = self.host.id  # pylint:disable=no-member
+        return super(Interface, self).search_normalize(results)
 
 
 class LifecycleEnvironment(

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -124,7 +124,6 @@ class InitTestCase(TestCase):
                 entities.HostCollectionPackage,
                 entities.HostGroup,
                 entities.Image,
-                entities.Interface,
                 entities.LibvirtComputeResource,
                 entities.LifecycleEnvironment,
                 entities.Location,
@@ -176,6 +175,7 @@ class InitTestCase(TestCase):
             (entities.ContentViewPuppetModule, {'content_view': 1}),
             (entities.HostPackage, {'host': 1}),
             (entities.HostSubscription, {'host': 1}),
+            (entities.Interface, {'host': 1}),
             (entities.OperatingSystemParameter, {'operatingsystem': 1}),
             (entities.OverrideValue, {'smart_class_parameter': 1}),
             (entities.OverrideValue, {'smart_variable': 1}),
@@ -870,6 +870,7 @@ class ReadTestCase(TestCase):
                     content_view_filter=2,
                 ),
                 entities.ContentViewPuppetModule(self.cfg, content_view=2),
+                entities.Interface(self.cfg, host=2),
                 entities.OperatingSystemParameter(self.cfg, operatingsystem=2),
                 entities.OverrideValue(self.cfg, smart_class_parameter=2),
                 entities.OverrideValue(self.cfg, smart_variable=2),
@@ -1046,6 +1047,66 @@ class ReadTestCase(TestCase):
                 # `call_args` is a two-tuple of (positional, keyword) args.
                 self.assertEqual(actual_ignore, read.call_args[0][2])
 
+    def test_interface_ignore_arg(self):
+        """Call :meth:`nailgun.entities.Interface.read`.
+
+        Assert that entity`s predefined values of ``ignore`` are always
+        correctly passed on.
+        """
+        for input_type, actual_ignore in (
+                ('interface', {'host', 'username', 'password', 'provider',
+                               'mode', 'bond_options', 'attached_to', 'tag',
+                               'attached_devices'}),
+                ('bmc', {'host', 'mode', 'bond_options', 'attached_to', 'tag',
+                         'attached_devices'}),
+                ('bond', {'host', 'username', 'password', 'provider',
+                          'attached_to', 'tag'}),
+                ('bridge', {'host', 'username', 'password', 'provider', 'mode',
+                            'bond_options', 'attached_to', 'tag'}),
+                ('virtual', {'host', 'username', 'password', 'provider',
+                             'mode', 'bond_options', 'attached_devices'}),
+        ):
+            with self.subTest(input_type):
+                with mock.patch.object(EntityReadMixin, 'read') as read:
+                    with mock.patch.object(
+                        EntityReadMixin,
+                        'read_json',
+                        return_value={'type': input_type},
+                    ):
+                        entities.Interface(
+                            self.cfg, id=2, host=2, type=input_type).read()
+                # `call_args` is a two-tuple of (positional, keyword) args.
+                self.assertEqual(actual_ignore, read.call_args[0][2])
+
+    def test_host_with_interface(self):
+        """Call :meth:`nailgun.entities.Host.read`.
+
+        Assert that host will have interfaces initialized and assigned
+        correctly.
+        """
+        with mock.patch.object(
+            EntityReadMixin,
+            'read',
+            return_value=entities.Host(self.cfg, id=2),
+        ):
+            with mock.patch.object(
+                EntityReadMixin,
+                'read_json',
+                return_value={
+                    'interfaces': [{'id': 2}, {'id': 3}],
+                    'parameters': None,
+                },
+            ):
+                host = entities.Host(self.cfg, id=2).read()
+        self.assertTrue(hasattr(host, 'interface'))
+        self.assertTrue(isinstance(host.interface, list))
+        for interface in host.interface:
+            self.assertTrue(isinstance(interface, entities.Interface))
+        self.assertEqual(
+            {interface.id for interface in host.interface},
+            {2, 3}
+        )
+
     def test_discovery_rule(self):
         """Call :meth:`nailgun.entities.DiscoveryRule.read`.
 
@@ -1094,6 +1155,36 @@ class ReadTestCase(TestCase):
                 entities.HostGroup(self.cfg).read()
         # `call_args` is a two-tuple of (positional, keyword) args.
         self.assertIn('root_pass', read.call_args[0][2])
+
+
+class SearchNormalizeTestCase(TestCase):
+    """Tests for
+    :meth:`nailgun.entity_mixins.EntitySearchMixin.search_normalize`.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Set a server configuration at ``cls.cfg``."""
+        cls.cfg = config.ServerConfig('http://example.com')
+
+    def test_interface(self):
+        """Test :meth:`nailgun.entities.Interface.search_normalize`.
+
+        Assert that ``host_id`` was added with correct host's id to search
+        results.
+        """
+        results = [
+            {'id': 1, 'name': 'foo'},
+            {'id': 2, 'name': 'bar'},
+        ]
+        with mock.patch.object(
+            EntitySearchMixin,
+            'search_normalize',
+        ) as search_normalize:
+            entities.Interface(self.cfg, host=3).search_normalize(results)
+            for args in search_normalize.call_args[0][0]:
+                self.assertIn('host_id', args)
+                self.assertEqual(args['host_id'], 3)
 
 
 class SearchRawTestCase(TestCase):


### PR DESCRIPTION
* Implemented Interface entity (as before it was basically a stub with
no available operations and even wrong path)
* Added all possible fields variations
* Implemented unit tests

Key features:
* Interface requires a host id in its path, so some additional logic
was required for initialization, `read()` and `search()`
* Set of available Interface fields depends on Interface's ``type``
(some fields are only returned for specific type), extra logic was
requred here too