### PR TITLE
Fix update_payload method for ConfigTemplate/ProvisioningTemplate

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -981,7 +981,7 @@ class ConfigTemplate(
 
     def update_payload(self, fields=None):
         """Wrap submitted data within an extra dict."""
-        payload = super(ConfigTemplate, self).update_payload()
+        payload = super(ConfigTemplate, self).update_payload(fields)
         if 'template_combinations' in payload:
             payload['template_combinations_attributes'] = payload.pop(
                 'template_combinations')
@@ -1104,7 +1104,7 @@ class ProvisioningTemplate(
 
     def update_payload(self, fields=None):
         """Wrap submitted data within an extra dict."""
-        payload = super(ProvisioningTemplate, self).update_payload()
+        payload = super(ProvisioningTemplate, self).update_payload(fields)
         if 'template_combinations' in payload:
             payload['template_combinations_attributes'] = payload.pop(
                 'template_combinations')


### PR DESCRIPTION
```python
Making HTTP PUT request to https://sat6.com/api/v2/config_templates/73 with options {'verify': False, 'auth': ('admin', 'changeme'), 'headers': {'content-type': 'application/json'}} and data {"config_template": {"operatingsystem_ids": [5, 5, 5]}}.
Received HTTP 200 response: [... skipped ...]
```