### PR TITLE
Cherry-picked from master [Added a new field root_pass to hostgroup entity (#336)]

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2114,6 +2114,7 @@ class HostGroup(
             'environment': entity_fields.OneToOneField(Environment),
             'location': entity_fields.OneToManyField(Location),
             'medium': entity_fields.OneToOneField(Media),
+            'root_pass': entity_fields.StringField(),
             'name': entity_fields.StringField(
                 required=True,
                 str_type='alpha',
@@ -2168,6 +2169,10 @@ class HostGroup(
           <https://bugzilla.redhat.com/show_bug.cgi?id=1235379>`_
 
         """
+        if ignore is None:
+            ignore = set()
+        ignore.add('root_pass')
+
         if attrs is None:
             attrs = self.read_json()
         attrs['parent_id'] = attrs.pop('ancestry')  # either an ID or None

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1141,6 +1141,18 @@ class ReadTestCase(TestCase):
                 # pylint:disable=no-member
                 self.assertEqual(product.sync_plan.id, sync_plan.id)
 
+    def test_hostgroup_ignore_root_pass(self):
+        """Call :meth:`nailgun.entities.HostGroup.read`.
+
+        Assert that the entity ignores the ``root_pass`` field.
+
+        """
+        with mock.patch.object(EntityReadMixin, 'read') as read:
+            with mock.patch.object(EntityReadMixin, 'read_json'):
+                entities.HostGroup(self.cfg).read()
+        # `call_args` is a two-tuple of (positional, keyword) args.
+        self.assertIn('root_pass', read.call_args[0][2])
+
     def test_host_with_image(self):
         """Call :meth:`nailgun.entities.Host.read` for a host with image
         assigned.


### PR DESCRIPTION
(cherry picked from commit 12875cacfe2af68e55e504cd6ac004a61c2dab17)