### PR TITLE
[6.2.z] Cherry-pick changes related to ConfigTemplates/ProvisioningTemplates

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -957,32 +957,10 @@ class ConfigTemplate(
 
         """
         payload = super(ConfigTemplate, self).create_payload()
-        return {
-            u'config_template': self._fix_payload(payload)
-        }
-
-    # pylint: disable=no-self-use
-    def _fix_payload(self, payload):
-        """Fix the payload, parses TemplateCombination and
-        changes dict key name from template_combinations to
-        template_combinations_attributes
-        """
         if 'template_combinations' in payload:
-            def to_dict(combination):
-                """return dict or parsed TemplateCombination"""
-                if isinstance(combination, dict):
-                    return combination
-                return {
-                    'hostgroup_id': combination.hostgroup.id,
-                    'environment_id': combination.environment.id
-                }
-
-            combinations = payload.pop('template_combinations')
-            payload['template_combinations_attributes'] = [
-                to_dict(comb) for comb in combinations
-            ]
-
-        return payload
+            payload['template_combinations_attributes'] = payload.pop(
+                'template_combinations')
+        return {u'config_template': payload}
 
     @signals.emit(sender=signals.SENDER_CLASS, post_result_name='entity')
     def update(self, fields=None):
@@ -998,9 +976,10 @@ class ConfigTemplate(
     def update_payload(self, fields=None):
         """Wrap submitted data within an extra dict."""
         payload = super(ConfigTemplate, self).update_payload()
-        return {
-            u'config_template': self._fix_payload(payload)
-        }
+        if 'template_combinations' in payload:
+            payload['template_combinations_attributes'] = payload.pop(
+                'template_combinations')
+        return {u'config_template': payload}
 
     def path(self, which=None):
         """Extend ``nailgun.entity_mixins.Entity.path``.

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -957,7 +957,7 @@ class ConfigTemplate(
 
     def update_payload(self, fields=None):
         """Wrap submitted data within an extra dict."""
-        payload = super(ConfigTemplate, self).update_payload()
+        payload = super(ConfigTemplate, self).update_payload(fields)
         if 'template_combinations' in payload:
             payload['template_combinations_attributes'] = payload.pop(
                 'template_combinations')
@@ -1080,7 +1080,7 @@ class ProvisioningTemplate(
 
     def update_payload(self, fields=None):
         """Wrap submitted data within an extra dict."""
-        payload = super(ProvisioningTemplate, self).update_payload()
+        payload = super(ProvisioningTemplate, self).update_payload(fields)
         if 'template_combinations' in payload:
             payload['template_combinations_attributes'] = payload.pop(
                 'template_combinations')

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -5100,7 +5100,7 @@ class System(
         return super(System, self).read(entity, attrs, ignore)
 
 
-class TemplateCombination(Entity):
+class TemplateCombination(Entity, EntityDeleteMixin, EntityReadMixin):
     """A representation of a Template Combination entity."""
 
     def __init__(self, server_config=None, **kwargs):
@@ -5113,11 +5113,8 @@ class TemplateCombination(Entity):
             'hostgroup': entity_fields.OneToOneField(HostGroup),
         }
         self._meta = {
-            'api_path': (
-                'api/v2/config_templates/:config_template_id/'
-                'template_combinations'
-            ),
-            'server_modes': ('sat'),
+            'api_path': 'api/v2/template_combinations',
+            'server_modes': 'sat',
         }
         super(TemplateCombination, self).__init__(server_config, **kwargs)
 

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -5119,13 +5119,16 @@ class TemplateCombination(Entity, EntityDeleteMixin, EntityReadMixin):
         super(TemplateCombination, self).__init__(server_config, **kwargs)
 
 
-class TemplateKind(Entity, EntityReadMixin):
+class TemplateKind(Entity, EntityReadMixin, EntitySearchMixin):
     """A representation of a Template Kind entity.
 
     Unusually, the ``/api/v2/template_kinds/:id`` path is totally unsupported.
 
     """
     def __init__(self, server_config=None, **kwargs):
+        self._fields = {
+            'name': entity_fields.StringField(),
+        }
         self._meta = {
             'api_path': 'api/v2/template_kinds',
             'num_created_by_default': 8,

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -956,9 +956,33 @@ class ConfigTemplate(
         <https://bugzilla.redhat.com/show_bug.cgi?id=1151220>`_.
 
         """
+        payload = super(ConfigTemplate, self).create_payload()
         return {
-            u'config_template': super(ConfigTemplate, self).create_payload()
+            u'config_template': self._fix_payload(payload)
         }
+
+    # pylint: disable=no-self-use
+    def _fix_payload(self, payload):
+        """Fix the payload, parses TemplateCombination and
+        changes dict key name from template_combinations to
+        template_combinations_attributes
+        """
+        if 'template_combinations' in payload:
+            def to_dict(combination):
+                """return dict or parsed TemplateCombination"""
+                if isinstance(combination, dict):
+                    return combination
+                return {
+                    'hostgroup_id': combination.hostgroup.id,
+                    'environment_id': combination.environment.id
+                }
+
+            combinations = payload.pop('template_combinations')
+            payload['template_combinations_attributes'] = [
+                to_dict(comb) for comb in combinations
+            ]
+
+        return payload
 
     @signals.emit(sender=signals.SENDER_CLASS, post_result_name='entity')
     def update(self, fields=None):
@@ -973,11 +997,9 @@ class ConfigTemplate(
 
     def update_payload(self, fields=None):
         """Wrap submitted data within an extra dict."""
+        payload = super(ConfigTemplate, self).update_payload()
         return {
-            u'config_template': super(
-                ConfigTemplate,
-                self
-            ).update_payload(fields)
+            u'config_template': self._fix_payload(payload)
         }
 
     def path(self, which=None):

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1602,6 +1602,53 @@ class ForemanTaskTestCase(TestCase):
                 )
 
 
+class ConfigTemplateTestCase(TestCase):
+    """Tests for :class:`nailgun.entities.ConfigTemplate`."""
+
+    def test_creation_and_update(self):
+        """Check template combinations as json or entity is set on correct
+        attribute template_combinations_attributes ( check #333)
+        """
+        cfg = config.ServerConfig(url='foo')
+        env = entities.Environment(cfg, id=2, name='env')
+        hostgroup = entities.HostGroup(cfg, id=2, name='hgroup')
+        combination = entities.TemplateCombination(
+            cfg,
+            hostgroup=hostgroup,
+            environment=env)
+        template_combinations = [
+            {'hostgroup_id': 1, 'environment_id': 1},
+            combination]
+        cfg_template = entities.ConfigTemplate(
+            cfg, name='cfg',
+            snippet=False,
+            template='cat',
+            template_kind=8,
+            template_combinations=template_combinations)
+        expected_dct = {
+            u'config_template': {
+                'name': 'cfg', 'snippet': False, 'template': 'cat',
+                'template_kind_id': 8, 'template_combinations_attributes': [
+                    {'environment_id': 1, 'hostgroup_id': 1},
+                    {'environment_id': 2, 'hostgroup_id': 2}]
+            }
+        }
+        self.assertEqual(expected_dct, cfg_template.create_payload())
+        # Testing update
+        env3 = entities.Environment(cfg, id=3, name='env3')
+        combination3 = entities.TemplateCombination(
+            cfg,
+            hostgroup=hostgroup,
+            environment=env3)
+        # pylint: disable=no-member
+        cfg_template.template_combinations.append(combination3)
+        attrs = expected_dct[u'config_template']
+        attrs['template_combinations_attributes'].append(
+            {'environment_id': 3, 'hostgroup_id': 2}
+        )
+        self.assertEqual(expected_dct, cfg_template.update_payload())
+
+
 class HostGroupTestCase(TestCase):
     """Tests for :class:`nailgun.entities.HostGroup`."""
     def setUp(self):

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -103,6 +103,7 @@ class InitTestCase(TestCase):
                 entities.ComputeProfile,
                 entities.ConfigGroup,
                 entities.ConfigTemplate,
+                entities.ProvisioningTemplate,
                 entities.ContentUpload,
                 entities.ContentView,
                 entities.ContentViewVersion,
@@ -236,6 +237,7 @@ class PathTestCase(TestCase):
                 (entities.AbstractDockerContainer, '/containers'),
                 (entities.ActivationKey, '/activation_keys'),
                 (entities.ConfigTemplate, '/config_templates'),
+                (entities.ProvisioningTemplate, '/provisioning_templates'),
                 (entities.ContentView, '/content_views'),
                 (entities.ContentViewVersion, '/content_view_versions'),
                 (entities.DiscoveredHost, '/discovered_hosts'),
@@ -281,6 +283,7 @@ class PathTestCase(TestCase):
                 (entities.ActivationKey, 'remove_subscriptions'),
                 (entities.ActivationKey, 'subscriptions'),
                 (entities.ConfigTemplate, 'clone'),
+                (entities.ProvisioningTemplate, 'clone'),
                 (entities.ContentView, 'available_puppet_module_names'),
                 (entities.ContentView, 'content_view_puppet_modules'),
                 (entities.ContentView, 'content_view_versions'),
@@ -318,6 +321,8 @@ class PathTestCase(TestCase):
         for entity, which in (
                 (entities.ConfigTemplate, 'build_pxe_default'),
                 (entities.ConfigTemplate, 'revision'),
+                (entities.ProvisioningTemplate, 'build_pxe_default'),
+                (entities.ProvisioningTemplate, 'revision'),
                 (entities.ContentViewVersion, 'incremental_update'),
                 (entities.DiscoveredHost, 'facts'),
                 (entities.ForemanTask, 'bulk_resume'),
@@ -534,6 +539,7 @@ class CreatePayloadTestCase(TestCase):
                 entities.Architecture,
                 entities.ConfigGroup,
                 entities.ConfigTemplate,
+                entities.ProvisioningTemplate,
                 entities.DiscoveredHost,
                 entities.DiscoveryRule,
                 entities.Domain,
@@ -681,6 +687,46 @@ class CreateMissingTestCase(TestCase):
         """Test ``ConfigTemplate(snippet=False, template_kind=…)``."""
         tk_id = gen_integer()
         entity = entities.ConfigTemplate(
+            self.cfg,
+            snippet=False,
+            template_kind=tk_id,
+        )
+        with mock.patch.object(EntityCreateMixin, 'create_raw'):
+            with mock.patch.object(EntityReadMixin, 'read_raw'):
+                entity.create_missing()
+        self.assertEqual(
+            _get_required_field_names(entity).union(['template_kind']),
+            set(entity.get_values().keys()),
+        )
+        # pylint:disable=no-member
+        self.assertEqual(entity.template_kind.id, tk_id)
+
+    def test_provisioning_template_v1(self):
+        """Test ``ProvisioningTemplate(snippet=True)``."""
+        entity = entities.ProvisioningTemplate(self.cfg, snippet=True)
+        with mock.patch.object(EntityCreateMixin, 'create_raw'):
+            with mock.patch.object(EntityReadMixin, 'read_raw'):
+                entity.create_missing()
+        self.assertEqual(
+            _get_required_field_names(entity),
+            set(entity.get_values().keys()),
+        )
+
+    def test_provisioning_template_v2(self):
+        """Test ``ProvisioningTemplate(snippet=False)``."""
+        entity = entities.ProvisioningTemplate(self.cfg, snippet=False)
+        with mock.patch.object(EntityCreateMixin, 'create_raw'):
+            with mock.patch.object(EntityReadMixin, 'read_raw'):
+                entity.create_missing()
+        self.assertEqual(
+            _get_required_field_names(entity).union(['template_kind']),
+            set(entity.get_values().keys()),
+        )
+
+    def test_provisioning_template_v3(self):
+        """Test ``ProvisioningTemplate(snippet=False, template_kind=…)``."""
+        tk_id = gen_integer()
+        entity = entities.ProvisioningTemplate(
             self.cfg,
             snippet=False,
             template_kind=tk_id,
@@ -1326,6 +1372,7 @@ class UpdatePayloadTestCase(TestCase):
         entities_payloads = [
             (entities.AbstractComputeResource, {'compute_resource': {}}),
             (entities.ConfigTemplate, {'config_template': {}}),
+            (entities.ProvisioningTemplate, {'provisioning_template': {}}),
             (entities.DiscoveredHost, {'discovered_host': {}}),
             (entities.DiscoveryRule, {'discovery_rule': {}}),
             (entities.Domain, {'domain': {}}),
@@ -1455,8 +1502,13 @@ class GenericTestCase(TestCase):
             (entities.ActivationKey(**generic).add_subscriptions, 'put'),
             (entities.ActivationKey(**generic).content_override, 'put'),
             (entities.ActivationKey(**generic).remove_host_collection, 'put'),
-            (entities.ConfigTemplate(**generic).build_pxe_default, 'get'),
+            (entities.ConfigTemplate(**generic).build_pxe_default, 'post'),
             (entities.ConfigTemplate(**generic).clone, 'post'),
+            (
+                entities.ProvisioningTemplate(**generic).build_pxe_default,
+                'post'
+            ),
+            (entities.ProvisioningTemplate(**generic).clone, 'post'),
             (entities.ContentView(**generic).available_puppet_modules, 'get'),
             (entities.ContentView(**generic).copy, 'post'),
             (entities.ContentView(**generic).publish, 'post'),
@@ -1643,6 +1695,53 @@ class ConfigTemplateTestCase(TestCase):
         # pylint: disable=no-member
         cfg_template.template_combinations.append(combination3)
         attrs = expected_dct[u'config_template']
+        attrs['template_combinations_attributes'].append(
+            {'environment_id': 3, 'hostgroup_id': 2}
+        )
+        self.assertEqual(expected_dct, cfg_template.update_payload())
+
+
+class ProvisioningTemplateTestCase(TestCase):
+    """Tests for :class:`nailgun.entities.ProvisioningTemplate`."""
+
+    def test_creation_and_update(self):
+        """Check template combinations as json or entity is set on correct
+        attribute template_combinations_attributes ( check #333)
+        """
+        cfg = config.ServerConfig(url='foo')
+        env = entities.Environment(cfg, id=2, name='env')
+        hostgroup = entities.HostGroup(cfg, id=2, name='hgroup')
+        combination = entities.TemplateCombination(
+            cfg,
+            hostgroup=hostgroup,
+            environment=env)
+        template_combinations = [
+            {'hostgroup_id': 1, 'environment_id': 1},
+            combination]
+        cfg_template = entities.ProvisioningTemplate(
+            cfg, name='cfg',
+            snippet=False,
+            template='cat',
+            template_kind=8,
+            template_combinations=template_combinations)
+        expected_dct = {
+            u'provisioning_template': {
+                'name': 'cfg', 'snippet': False, 'template': 'cat',
+                'template_kind_id': 8, 'template_combinations_attributes': [
+                    {'environment_id': 1, 'hostgroup_id': 1},
+                    {'environment_id': 2, 'hostgroup_id': 2}]
+            }
+        }
+        self.assertEqual(expected_dct, cfg_template.create_payload())
+        # Testing update
+        env3 = entities.Environment(cfg, id=3, name='env3')
+        combination3 = entities.TemplateCombination(
+            cfg,
+            hostgroup=hostgroup,
+            environment=env3)
+        # pylint: disable=no-member
+        cfg_template.template_combinations.append(combination3)
+        attrs = expected_dct[u'provisioning_template']
         attrs['template_combinations_attributes'].append(
             {'environment_id': 3, 'hostgroup_id': 2}
         )
@@ -2402,7 +2501,7 @@ class JsonSerializableTestCase(TestCase):
 
         cfg_kwargs = {'id': 5, 'snippet': False, 'template': 'cat'}
         cfg_template = make_entity(
-            entities.ConfigTemplate,
+            entities.ProvisioningTemplate,
             template_combinations=combinations,
             **cfg_kwargs)
 


### PR DESCRIPTION
Cherry-picked from #334, #342, #365, #366, #380

Results for 6.2.8:
#334 / Create:
```python
>>> env=entities.Environment(name='env2').create()
>>> hostgroup=entities.HostGroup(name='hgroup2').create()
>>> combination=entities.TemplateCombination(hostgroup=hostgroup, environment=env)
>>> cfg_template=entities.ConfigTemplate(
    name='cfg2', snippet=False,
    template='cat', template_kind=8,
    template_combinations=[combination]
)
>>> cfg_template.create()
>>> print(cfg_template.template_combinations)
[nailgun.entities.TemplateCombination(..., environment=nailgun.entities.Environment(..., name=u'env2', organization=[], id=80, location=[]), hostgroup=nailgun.entities.HostGroup(...), domain=None, medium=None, parent=None, ptable=None, content_source=None, lifecycle_environment=None, operatingsystem=None, name=u'hgroup2', subnet=None, puppet_proxy=None, realm=None, content_view=None, id=21, environment=None, location=[], organization=[], puppet_ca_proxy=None, architecture=None))]
```
#334 / Update:
```python
>>> cfg_template=entities.ConfigTemplate(
    name='to_update', snippet=False,
    template='cat', template_kind=8
).create()
>>> cfg_template.template_combinations
>>> env=entities.Environment(name='env').create()
>>> hostgroup=entities.HostGroup(name='hg').create()
>>> cfg_template.template_combinations.append(
   entities.TemplateCombination(hostgroup=hostgroup, environment=env)
)
>>> cfg_template = cfg_template.update()
>>> print(cfg_template.template_combinations)
[{u'environment_id': 81, u'provisioning_template_name': u'to_update', u'environment_name': u'env', u'hostgroup_id': 22, u'config_template_name': u'to_update', u'hostgroup_name': u'hg', u'provisioning_template_id': 144, u'id': 2, u'config_template_id': 144}]
```
#365 / build_pxe_default:
```python
entities.ConfigTemplate().build_pxe_default()
Received HTTP 200 response: {"message":"PXE Default file has been deployed to all Capsules"}
entities.ProvisioningTemplate().build_pxe_default()
Eeceived HTTP 200 response: {"message":"PXE Default file has been deployed to all Capsules"}
```
#366:
```python
tk = entities.TemplateKind().search(query={'search': 'name=PXELinux'})
print(tk[0].name)
PXELinux
```
#380:
```python
provisioning_template = provisioning_template.update(['operatingsystem'])
nailgun.client - DEBUG - Making HTTP PUT request to https://sat6.com/api/v2/config_templates/73 with options {'verify': False, 'auth': ('admin', 'changeme'), 'headers': {'content-type': 'application/json'}} and data {"config_template": {"operatingsystem_ids": [1, 1]}}.
nailgun.client - DEBUG - Received HTTP 200 response
```