### PR TITLE
Drop ServerConfig from Entity's __repr__

### DIFF
--- a/nailgun/entity_mixins.py
+++ b/nailgun/entity_mixins.py
@@ -512,12 +512,12 @@ class Entity(object):
         return attrs
 
     def __repr__(self):
-        return '{0}.{1}({2}{3})'.format(
+        # pylint: disable=duplicate-code
+        return u'{0}.{1}({2})'.format(
             self.__module__,
             type(self).__name__,
-            repr(self._server_config),
-            ''.join(
-                ', {0}={1}'.format(key, repr(value))
+            u', '.join(
+                u'{0}={1}'.format(key, repr(value))
                 for key, value
                 in self.get_values().items()
             )

--- a/tests/test_entity_mixins.py
+++ b/tests/test_entity_mixins.py
@@ -436,10 +436,13 @@ class EntityTestCase(TestCase):
 
         """
         entity = SampleEntityTwo(self.cfg)
-        target = 'tests.test_entity_mixins.SampleEntityTwo({0})'.format(
-            repr(self.cfg)
-        )
+        target = 'tests.test_entity_mixins.SampleEntityTwo()'
         self.assertEqual(repr(entity), target)
+        # create default config if it does not exist
+        try:
+            config.ServerConfig.get()
+        except (KeyError, config.ConfigFileError):
+            self.cfg.save()
         import nailgun  # noqa pylint:disable=unused-variable
         import tests  # noqa pylint:disable=unused-variable
         # pylint:disable=eval-used
@@ -454,10 +457,15 @@ class EntityTestCase(TestCase):
         """
         entity = SampleEntityTwo(self.cfg, id=gen_integer())
         target = (
-            'tests.test_entity_mixins.SampleEntityTwo({0}, id={1})'
-            .format(repr(self.cfg), entity.id)  # pylint:disable=no-member
+            'tests.test_entity_mixins.SampleEntityTwo(id={0})'
+            .format(entity.id)  # pylint:disable=no-member
         )
         self.assertEqual(repr(entity), target)
+        # create default config if it does not exist
+        try:
+            config.ServerConfig.get()
+        except (KeyError, config.ConfigFileError):
+            self.cfg.save()
         import nailgun  # noqa pylint:disable=unused-variable
         import tests  # noqa pylint:disable=unused-variable
         # pylint:disable=eval-used
@@ -473,16 +481,20 @@ class EntityTestCase(TestCase):
         entity_id = gen_integer()
         target = (
             'tests.test_entity_mixins.SampleEntityTwo('
-            '{0}, '
-            'one_to_many=[tests.test_entity_mixins.SampleEntity({0}, id={1})]'
+            'one_to_many=[tests.test_entity_mixins.SampleEntity(id={0})]'
             ')'
-            .format(self.cfg, entity_id)
+            .format(entity_id)
         )
         entity = SampleEntityTwo(
             self.cfg,
             one_to_many=[SampleEntity(self.cfg, id=entity_id)]
         )
         self.assertEqual(repr(entity), target)
+        # create default config if it does not exist
+        try:
+            config.ServerConfig.get()
+        except (KeyError, config.ConfigFileError):
+            self.cfg.save()
         import nailgun  # noqa pylint:disable=unused-variable
         import tests  # noqa pylint:disable=unused-variable
         # pylint:disable=eval-used


### PR DESCRIPTION
Please see #378 for more details 

# Sample output before change
In [2]: entities.Host().create(True)
Out[2]: nailgun.entities.Host(nailgun.config.ServerConfig(url=u'https://very-long-server-name.here.with.subdomains.com', verify=False, auth=(u'admin', u'password')), comment=None, domain=nailgun.entities.Domain(nailgun.config.ServerConfig(url=u'https://very-long-server-name.here.with.subdomains.com', verify=False, auth=(u'admin', u'password')), id=7), managed=True, ip=None, image=None, provision_method=u'build', hostgroup=None, owner=nailgun.entities.User(nailgun.config.ServerConfig(url=u'https://very-long-server-name.here.with.subdomains.com', verify=False, auth=(u'admin', u'password')), id=3), operatingsystem=nailgun.entities.OperatingSystem(nailgun.config.ServerConfig(url=u'https://very-long-server-name.here.with.subdomains.com', verify=False, auth=(u'admin', u'password')), id=7), subnet=None, realm=None, capabilities=[u'build'], id=7, environment=nailgun.entities.Environment(nailgun.config.ServerConfig(url=u'https://very-long-server-name.here.with.subdomains.com', verify=False, auth=(u'admin', u'password')), id=7), build=False, host_parameters_attributes=[], puppet_ca_proxy=None, ptable=nailgun.entities.PartitionTable(nailgun.config.ServerConfig(url=u'https://very-long-server-name.here.with.subdomains.com', verify=False, auth=(u'admin', u'password')), id=112), location=nailgun.entities.Location(nailgun.config.ServerConfig(url=u'https://very-long-server-name.here.with.subdomains.com', verify=False, auth=(u'admin', u'password')), id=14), medium=nailgun.entities.Media(nailgun.config.ServerConfig(url=u'https://very-long-server-name.here.with.subdomains.com', verify=False, auth=(u'admin', u'password')), id=14), puppetclass=[], compute_profile=None, mac=u'b7:34:f5:32:ac:ff', interface=[nailgun.entities.Interface(nailgun.config.ServerConfig(url=u'https://very-long-server-name.here.with.subdomains.com', verify=False, auth=(u'admin', u'password')), host=nailgun.entities.Host(nailgun.config.ServerConfig(url=u'https://very-long-server-name.here.with.subdomains.com', verify=False, auth=(u'admin', u'password')), id=7), id=14)], puppet_proxy=None, owner_type=u'User', name=u'xrgmstxvip.helug5troh', enabled=True, compute_resource=None, architecture=nailgun.entities.Architecture(nailgun.config.ServerConfig(url=u'https://very-long-server-name.here.with.subdomains.com', verify=False, auth=(u'admin', u'password')), id=8), organization=nailgun.entities.Organization(nailgun.config.ServerConfig(url=u'https://very-long-server-name.here.with.subdomains.com', verify=False, auth=(u'admin', u'password')), id=15), model=None)

# Sample output after the change
In [2]: entities.Host().create(True)
Out[2]: nailgun.entities.Host(comment=None, domain=nailgun.entities.Domain(id=109), managed=True, ip=None, image=None, provision_method=u'build', hostgroup=None, owner=nailgun.entities.User(id=3), operatingsystem=nailgun.entities.OperatingSystem(id=140), subnet=None, realm=None, capabilities=[u'build'], id=80, environment=nailgun.entities.Environment(id=119), location=nailgun.entities.Location(id=651), host_parameters_attributes=[], puppet_ca_proxy=None, ptable=nailgun.entities.PartitionTable(id=243), build=False, medium=nailgun.entities.Media(id=117), puppetclass=[], compute_profile=None, mac=u'e5:15:36:ce:56:5a', interface=[nailgun.entities.Interface(host=nailgun.entities.Host(id=80), id=81)], puppet_proxy=None, owner_type=u'User', name=u'zgzvil.8zcr20ipkz', enabled=True, compute_resource=None, architecture=nailgun.entities.Architecture(id=107), organization=nailgun.entities.Organization(id=652), model=None)

# 

Closes #378 