### PR TITLE
Fix Subscription entity and add ActivationKey.product_content helper

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -35,7 +35,6 @@ from nailgun.entity_mixins import (
     EntityReadMixin,
     EntitySearchMixin,
     EntityUpdateMixin,
-    MissingValueError,
     _poll_task,
     to_json_serializable as to_json
 )

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -250,6 +250,8 @@ class ActivationKey(
             /activation_keys/<id>/add_subscriptions
         content_override
             /activation_keys/<id>/content_override
+        product_content
+            /activation_keys/<id>/product_content
         releases
             /activation_keys/<id>/releases
         remove_subscriptions
@@ -264,6 +266,7 @@ class ActivationKey(
                 'add_subscriptions',
                 'content_override',
                 'host_collections',
+                'product_content',
                 'releases',
                 'remove_subscriptions',
                 'subscriptions'):
@@ -322,6 +325,23 @@ class ActivationKey(
         kwargs = kwargs.copy()  # shadow the passed-in kwargs
         kwargs.update(self._server_config.get_client_kwargs())
         response = client.put(self.path('content_override'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous)
+
+    def product_content(self, synchronous=True, **kwargs):
+        """Helper for showing content available for activation key.
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+
+        """
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.get(self.path('product_content'), **kwargs)
         return _handle_response(response, self._server_config, synchronous)
 
     def remove_host_collection(self, synchronous=True, **kwargs):
@@ -5117,16 +5137,14 @@ class Subscription(
 
     def __init__(self, server_config=None, **kwargs):
         self._fields = {
-            'activation_key': entity_fields.OneToOneField(ActivationKey),
-            'host': entity_fields.OneToOneField(Host),
+            'activation_key': entity_fields.OneToManyField(ActivationKey),
+            'name': entity_fields.StringField(),
             'organization': entity_fields.OneToOneField(Organization),
+            'provided_product': entity_fields.OneToManyField(Product),
             'quantity': entity_fields.IntegerField(),
-            'subscriptions': entity_fields.OneToManyField(Subscription),
+            'subscription': entity_fields.OneToOneField(Subscription),
+            'system': entity_fields.OneToManyField(Host),
         }
-        # Before Satellite 6.2 System entity was used instead of Host
-        if _get_version(server_config) < Version('6.2'):
-            self._fields['system'] = entity_fields.OneToOneField(System)
-            self._fields.pop('host')
         self._meta = {
             'api_path': 'katello/api/v2/subscriptions',
             'server_modes': ('sat', 'sam'),
@@ -5157,44 +5175,6 @@ class Subscription(
             # pylint:disable=no-member
             return self.organization.path('subscriptions/{0}'.format(which))
         return super(Subscription, self).path(which)
-
-    def search_raw(self, fields=None, query=None):
-        """Completely override the inherited ``search_raw`` method for older
-        Satellite versions.
-
-        The ``GET /katello/api/v2/subscriptions`` API call is not available.
-        Instead, one of the following must be used:
-
-        * ``GET /katello/api/v2/activation_keys/<id>/subscriptions``
-        * ``GET /katello/api/v2/organizations/<id>/subscriptions``
-        * ``GET /katello/api/v2/systems/<id>/subscriptions``
-
-        Use the activation key path if ``self.activation_key`` is set, use the
-        organization path if ``self.organization`` is set, use the system path
-        if ``self.system`` is set, or raise an exception otherwise.
-
-        """
-        if _get_version(self._server_config) >= Version('6.2'):
-            return super(Subscription, self).search_raw(fields, query)
-        path = None
-        attrs = ('activation_key', 'organization', 'system')
-        for attr in attrs:
-            if hasattr(self, attr):
-                path = getattr(self, attr).path('subscriptions')
-                break
-        if path is None:
-            raise MissingValueError(
-                'A value must be provided for one of the following fields: '
-                '{0}. This is because the "GET /katello/api/v2/subscriptions" '
-                'API call is not available. See the documentation for method '
-                '`nailgun.entities.Subscription.search_raw` for details.'
-                .format(attrs)
-            )
-        return client.get(
-            path,
-            data=self.search_payload(fields, query),
-            **self._server_config.get_client_kwargs()
-        )
 
     def _org_path(self, which, payload):
         """A helper method for generating paths with organization IDs in them.
@@ -5254,6 +5234,16 @@ class Subscription(
             **kwargs
         )
         return _handle_response(response, self._server_config, synchronous)
+
+    def read(self, entity=None, attrs=None, ignore=None):
+        """Ignore ``organization`` field as it's never returned by the server
+        and is only added to entity to be able to use organization path
+        dependent helpers.
+        """
+        if ignore is None:
+            ignore = set()
+        ignore.add('organization')
+        return super(Subscription, self).read(entity, attrs, ignore)
 
     def refresh_manifest(self, synchronous=True, **kwargs):
         """Refresh previously imported manifest for Red Hat provider.

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -9,7 +9,6 @@ from nailgun.entity_mixins import (
     EntityReadMixin,
     EntitySearchMixin,
     EntityUpdateMixin,
-    MissingValueError,
     NoSuchPathError,
 )
 import inspect
@@ -1276,46 +1275,6 @@ class SearchNormalizeTestCase(TestCase):
                 self.assertIsNone(host.image)
 
 
-class SearchRawTestCase(TestCase):
-    """Tests for :meth:`nailgun.entity_mixins.EntitySearchMixin.search_raw`."""
-
-    @classmethod
-    def setUpClass(cls):
-        """Set a server configuration at ``cls.cfg``."""
-        cls.cfg_610 = config.ServerConfig(
-            'http://example.com', version='6.1.0')
-
-    def test_subscription_v1(self):
-        """Test :meth:`nailgun.entities.Subscription.search_raw`.
-
-        Successfully call the ``search_raw`` method.
-
-        """
-        kwargs_iter = (
-            {'activation_key': entities.ActivationKey(self.cfg_610, id=1)},
-            {'organization': entities.Organization(self.cfg_610, id=1)},
-            {'system': entities.System(self.cfg_610, uuid=1)},
-        )
-        for kwargs in kwargs_iter:
-            sub = entities.Subscription(self.cfg_610, **kwargs)
-            with self.subTest(sub):
-                with mock.patch.object(client, 'get') as get:
-                    with mock.patch.object(sub, 'search_payload'):
-                        sub.search_raw()
-                self.assertEqual(get.call_count, 1)
-                self.assertIn('subscriptions', get.call_args[0][0])
-
-    def test_subscription_v2(self):
-        """Test :meth:`nailgun.entities.Subscription.search_raw`.
-
-        Raise a :class:`nailgun.entity_mixins.MissingValueError` by failing to
-        provide necessary values.
-
-        """
-        with self.assertRaises(MissingValueError):
-            entities.Subscription(self.cfg_610).search_raw()
-
-
 class UpdateTestCase(TestCase):
     """Tests for :meth:`nailgun.entity_mixins.EntityUpdateMixin.update`."""
 
@@ -2555,15 +2514,6 @@ class VersionTestCase(TestCase):
         """
         with self.assertRaises(NotImplementedError):
             entities.HostSubscription(self.cfg_610, host=1)
-
-    def test_subscription_search(self):
-        """Verify :meth:`nailgun.entities.Subscription.search_raw` calls
-        :meth:`nailgun.entity_mixins.EntitySearchMixin.search_raw` for
-        Satellite 6.2.
-        """
-        with mock.patch.object(EntitySearchMixin, 'search_raw') as search_raw:
-            entities.Subscription(self.cfg_620).search_raw()
-        self.assertEqual(search_raw.call_count, 1)
 
     def test_system(self):
         """Attempt to create a :class:`nailgun.entities.System` for the

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1476,6 +1476,7 @@ class GenericTestCase(TestCase):
             (entities.ActivationKey(**generic).add_host_collection, 'post'),
             (entities.ActivationKey(**generic).add_subscriptions, 'put'),
             (entities.ActivationKey(**generic).content_override, 'put'),
+            (entities.ActivationKey(**generic).product_content, 'get'),
             (entities.ActivationKey(**generic).remove_host_collection, 'put'),
             (entities.ConfigTemplate(**generic).build_pxe_default, 'post'),
             (entities.ConfigTemplate(**generic).clone, 'post'),

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1053,6 +1053,7 @@ class ReadTestCase(TestCase):
                 (entities.Errata,
                  {'content_view_version', 'environment', 'repository'}),
                 (entities.Subnet, {'discovery'}),
+                (entities.Subscription, {'organization'}),
                 (entities.User, {'password'}),
         ):
             with self.subTest(entity):


### PR DESCRIPTION
Basically wanted to introduce `ActivationKey.product_content()` helper but found out that Subscription entity is implemented with numerous incorrect field names and outdated workarounds. None of our tests use `Subscription().read()` as apparently it was failing (`Subscription().read_json()` is used instead).

```python
In [3]: entities.Subscription(id=28).read()

Out[3]: nailgun.entities.Subscription(nailgun.config.ServerConfig(url='https://example.redhat.com', verify=False, auth=('admin', 'changeme')), activation_key=[nailgun.entities.ActivationKey(nailgun.config.ServerConfig(url='https://example.redhat.com', verify=False, auth=('admin', 'changeme')), id=10)], system=[], name=u'Red Hat Enterprise Linux Server, Premium (Physical or Virtual Nodes)', provided_product=[nailgun.entities.Product(nailgun.config.ServerConfig(url='https://example.redhat.com', verify=False, auth=('admin', 'changeme')), id=115), nailgun.entities.Product(nailgun.config.ServerConfig(url='https://example.redhat.com', verify=False, auth=('admin', 'changeme')), id=116), nailgun.entities.Product(nailgun.config.ServerConfig(url='https://example.redhat.com', verify=False, auth=('admin', 'changeme')), id=117), nailgun.entities.Product(nailgun.config.ServerConfig(url='https://example.redhat.com', verify=False, auth=('admin', 'changeme')), id=118), nailgun.entities.Product(nailgun.config.ServerConfig(url='https://example.redhat.com', verify=False, auth=('admin', 'changeme')), id=119), nailgun.entities.Product(nailgun.config.ServerConfig(url='https://example.redhat.com', verify=False, auth=('admin', 'changeme')), id=120), nailgun.entities.Product(nailgun.config.ServerConfig(url='https://example.redhat.com', verify=False, auth=('admin', 'changeme')), id=121), nailgun.entities.Product(nailgun.config.ServerConfig(url='https://example.redhat.com', verify=False, auth=('admin', 'changeme')), id=122), nailgun.entities.Product(nailgun.config.ServerConfig(url='https://example.redhat.com', verify=False, auth=('admin', 'changeme')), id=123), nailgun.entities.Product(nailgun.config.ServerConfig(url='https://example.redhat.com', verify=False, auth=('admin', 'changeme')), id=124), nailgun.entities.Product(nailgun.config.ServerConfig(url='https://example.redhat.com', verify=False, auth=('admin', 'changeme')), id=127), nailgun.entities.Product(nailgun.config.ServerConfig(url='https://example.redhat.com', verify=False, auth=('admin', 'changeme')), id=141), nailgun.entities.Product(nailgun.config.ServerConfig(url='https://example.redhat.com', verify=False, auth=('admin', 'changeme')), id=142), nailgun.entities.Product(nailgun.config.ServerConfig(url='https://example.redhat.com', verify=False, auth=('admin', 'changeme')), id=143), nailgun.entities.Product(nailgun.config.ServerConfig(url='https://example.redhat.com', verify=False, auth=('admin', 'changeme')), id=144), nailgun.entities.Product(nailgun.config.ServerConfig(url='https://example.redhat.com', verify=False, auth=('admin', 'changeme')), id=145), nailgun.entities.Product(nailgun.config.ServerConfig(url='https://example.redhat.com', verify=False, auth=('admin', 'changeme')), id=146), nailgun.entities.Product(nailgun.config.ServerConfig(url='https://example.redhat.com', verify=False, auth=('admin', 'changeme')), id=147), nailgun.entities.Product(nailgun.config.ServerConfig(url='https://example.redhat.com', verify=False, auth=('admin', 'changeme')), id=148), nailgun.entities.Product(nailgun.config.ServerConfig(url='https://example.redhat.com', verify=False, auth=('admin', 'changeme')), id=149), nailgun.entities.Product(nailgun.config.ServerConfig(url='https://example.redhat.com', verify=False, auth=('admin', 'changeme')), id=150)], id=28, quantity=25, subscription=nailgun.entities.Subscription(nailgun.config.ServerConfig(url='https://example.redhat.com', verify=False, auth=('admin', 'changeme')), id=19))
```