### PR TITLE
[6.2.z][Cherry-pick] Dropped ServerConfig from Entity's __repr__

### DIFF
--- a/nailgun/entity_mixins.py
+++ b/nailgun/entity_mixins.py
@@ -512,12 +512,12 @@ class Entity(object):
         return attrs
 
     def __repr__(self):
-        return '{0}.{1}({2}{3})'.format(
+        # pylint: disable=duplicate-code
+        return u'{0}.{1}({2})'.format(
             self.__module__,
             type(self).__name__,
-            repr(self._server_config),
-            ''.join(
-                ', {0}={1}'.format(key, repr(value))
+            u', '.join(
+                u'{0}={1}'.format(key, repr(value))
                 for key, value
                 in self.get_values().items()
             )

--- a/tests/test_entity_mixins.py
+++ b/tests/test_entity_mixins.py
@@ -436,10 +436,13 @@ class EntityTestCase(TestCase):
 
         """
         entity = SampleEntityTwo(self.cfg)
-        target = 'tests.test_entity_mixins.SampleEntityTwo({0})'.format(
-            repr(self.cfg)
-        )
+        target = 'tests.test_entity_mixins.SampleEntityTwo()'
         self.assertEqual(repr(entity), target)
+        # create default config if it does not exist
+        try:
+            config.ServerConfig.get()
+        except (KeyError, config.ConfigFileError):
+            self.cfg.save()
         import nailgun  # noqa pylint:disable=unused-variable
         import tests  # noqa pylint:disable=unused-variable
         # pylint:disable=eval-used
@@ -454,10 +457,15 @@ class EntityTestCase(TestCase):
         """
         entity = SampleEntityTwo(self.cfg, id=gen_integer())
         target = (
-            'tests.test_entity_mixins.SampleEntityTwo({0}, id={1})'
-            .format(repr(self.cfg), entity.id)  # pylint:disable=no-member
+            'tests.test_entity_mixins.SampleEntityTwo(id={0})'
+            .format(entity.id)  # pylint:disable=no-member
         )
         self.assertEqual(repr(entity), target)
+        # create default config if it does not exist
+        try:
+            config.ServerConfig.get()
+        except (KeyError, config.ConfigFileError):
+            self.cfg.save()
         import nailgun  # noqa pylint:disable=unused-variable
         import tests  # noqa pylint:disable=unused-variable
         # pylint:disable=eval-used
@@ -473,16 +481,20 @@ class EntityTestCase(TestCase):
         entity_id = gen_integer()
         target = (
             'tests.test_entity_mixins.SampleEntityTwo('
-            '{0}, '
-            'one_to_many=[tests.test_entity_mixins.SampleEntity({0}, id={1})]'
+            'one_to_many=[tests.test_entity_mixins.SampleEntity(id={0})]'
             ')'
-            .format(self.cfg, entity_id)
+            .format(entity_id)
         )
         entity = SampleEntityTwo(
             self.cfg,
             one_to_many=[SampleEntity(self.cfg, id=entity_id)]
         )
         self.assertEqual(repr(entity), target)
+        # create default config if it does not exist
+        try:
+            config.ServerConfig.get()
+        except (KeyError, config.ConfigFileError):
+            self.cfg.save()
         import nailgun  # noqa pylint:disable=unused-variable
         import tests  # noqa pylint:disable=unused-variable
         # pylint:disable=eval-used


### PR DESCRIPTION
Cherry-pick of #384 
Part of #378 
```python
In [2]: entities.Organization(id=1).read()

Out[2]: nailgun.entities.Organization(domain=[], description=None, default_content_view=nailgun.entities.ContentView(id=1), library=nailgun.entities.LifecycleEnvironment(id=1), user=[], id=1, name=u'Default Organization', subnet=[], title=u'Default Organization', smart_proxy=[nailgun.entities.SmartProxy(id=1)], hostgroup=[], label=u'Default_Organization', environment=[], config_template=[nailgun.entities.ConfigTemplate(id=7), nailgun.entities.ConfigTemplate(id=8), nailgun.entities.ConfigTemplate(id=9), nailgun.entities.ConfigTemplate(id=41), nailgun.entities.ConfigTemplate(id=10), nailgun.entities.ConfigTemplate(id=11), nailgun.entities.ConfigTemplate(id=14), nailgun.entities.ConfigTemplate(id=13), nailgun.entities.ConfigTemplate(id=12), nailgun.entities.ConfigTemplate(id=72), nailgun.entities.ConfigTemplate(id=71), nailgun.entities.ConfigTemplate(id=42), nailgun.entities.ConfigTemplate(id=43), nailgun.entities.ConfigTemplate(id=15), nailgun.entities.ConfigTemplate(id=16), nailgun.entities.ConfigTemplate(id=82), nailgun.entities.ConfigTemplate(id=44), nailgun.entities.ConfigTemplate(id=45), nailgun.entities.ConfigTemplate(id=17), nailgun.entities.ConfigTemplate(id=18), nailgun.entities.ConfigTemplate(id=19), nailgun.entities.ConfigTemplate(id=46), nailgun.entities.ConfigTemplate(id=20), nailgun.entities.ConfigTemplate(id=47), nailgun.entities.ConfigTemplate(id=76), nailgun.entities.ConfigTemplate(id=21), nailgun.entities.ConfigTemplate(id=22), nailgun.entities.ConfigTemplate(id=23), nailgun.entities.ConfigTemplate(id=39), nailgun.entities.ConfigTemplate(id=37), nailgun.entities.ConfigTemplate(id=38), nailgun.entities.ConfigTemplate(id=26), nailgun.entities.ConfigTemplate(id=28), nailgun.entities.ConfigTemplate(id=27), nailgun.entities.ConfigTemplate(id=29), nailgun.entities.ConfigTemplate(id=48), nailgun.entities.ConfigTemplate(id=40), nailgun.entities.ConfigTemplate(id=30), nailgun.entities.ConfigTemplate(id=31), nailgun.entities.ConfigTemplate(id=33), nailgun.entities.ConfigTemplate(id=32), nailgun.entities.ConfigTemplate(id=34), nailgun.entities.ConfigTemplate(id=49), nailgun.entities.ConfigTemplate(id=50), nailgun.entities.ConfigTemplate(id=4), nailgun.entities.ConfigTemplate(id=5), nailgun.entities.ConfigTemplate(id=6), nailgun.entities.ConfigTemplate(id=2), nailgun.entities.ConfigTemplate(id=3), nailgun.entities.ConfigTemplate(id=1), nailgun.entities.ConfigTemplate(id=51), nailgun.entities.ConfigTemplate(id=52), nailgun.entities.ConfigTemplate(id=53), nailgun.entities.ConfigTemplate(id=77), nailgun.entities.ConfigTemplate(id=73), nailgun.entities.ConfigTemplate(id=75), nailgun.entities.ConfigTemplate(id=74), nailgun.entities.ConfigTemplate(id=69), nailgun.entities.ConfigTemplate(id=35), nailgun.entities.ConfigTemplate(id=36)], compute_resource=[], media=[])
```