### PR TITLE
[6.2.z][Cherry-pick] Fix Subscription entity and add ActivationKey.product_content helper

### DIFF
--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -9,7 +9,6 @@ from nailgun.entity_mixins import (
     EntityReadMixin,
     EntitySearchMixin,
     EntityUpdateMixin,
-    MissingValueError,
     NoSuchPathError,
 )
 import inspect
@@ -998,6 +997,7 @@ class ReadTestCase(TestCase):
         for entity, ignored_attrs in (
                 (entities.SmartVariable, {'variable_type'}),
                 (entities.Subnet, {'discovery'}),
+                (entities.Subscription, {'organization'}),
                 (entities.User, {'password'}),
         ):
             with self.subTest(entity):
@@ -1220,46 +1220,6 @@ class SearchNormalizeTestCase(TestCase):
                 self.assertEqual(args['host_id'], 3)
 
 
-class SearchRawTestCase(TestCase):
-    """Tests for :meth:`nailgun.entity_mixins.EntitySearchMixin.search_raw`."""
-
-    @classmethod
-    def setUpClass(cls):
-        """Set a server configuration at ``cls.cfg``."""
-        cls.cfg_610 = config.ServerConfig(
-            'http://example.com', version='6.1.0')
-
-    def test_subscription_v1(self):
-        """Test :meth:`nailgun.entities.Subscription.search_raw`.
-
-        Successfully call the ``search_raw`` method.
-
-        """
-        kwargs_iter = (
-            {'activation_key': entities.ActivationKey(self.cfg_610, id=1)},
-            {'organization': entities.Organization(self.cfg_610, id=1)},
-            {'system': entities.System(self.cfg_610, uuid=1)},
-        )
-        for kwargs in kwargs_iter:
-            sub = entities.Subscription(self.cfg_610, **kwargs)
-            with self.subTest(sub):
-                with mock.patch.object(client, 'get') as get:
-                    with mock.patch.object(sub, 'search_payload'):
-                        sub.search_raw()
-                self.assertEqual(get.call_count, 1)
-                self.assertIn('subscriptions', get.call_args[0][0])
-
-    def test_subscription_v2(self):
-        """Test :meth:`nailgun.entities.Subscription.search_raw`.
-
-        Raise a :class:`nailgun.entity_mixins.MissingValueError` by failing to
-        provide necessary values.
-
-        """
-        with self.assertRaises(MissingValueError):
-            entities.Subscription(self.cfg_610).search_raw()
-
-
 class UpdateTestCase(TestCase):
     """Tests for :meth:`nailgun.entity_mixins.EntityUpdateMixin.update`."""
 
@@ -1459,6 +1419,7 @@ class GenericTestCase(TestCase):
             (entities.ActivationKey(**generic).add_host_collection, 'post'),
             (entities.ActivationKey(**generic).add_subscriptions, 'put'),
             (entities.ActivationKey(**generic).content_override, 'put'),
+            (entities.ActivationKey(**generic).product_content, 'get'),
             (entities.ActivationKey(**generic).remove_host_collection, 'put'),
             (entities.ConfigTemplate(**generic).build_pxe_default, 'get'),
             (entities.ConfigTemplate(**generic).clone, 'post'),
@@ -2362,15 +2323,6 @@ class VersionTestCase(TestCase):
         """
         with self.assertRaises(NotImplementedError):
             entities.HostSubscription(self.cfg_610, host=1)
-
-    def test_subscription_search(self):
-        """Verify :meth:`nailgun.entities.Subscription.search_raw` calls
-        :meth:`nailgun.entity_mixins.EntitySearchMixin.search_raw` for
-        Satellite 6.2.
-        """
-        with mock.patch.object(EntitySearchMixin, 'search_raw') as search_raw:
-            entities.Subscription(self.cfg_620).search_raw()
-        self.assertEqual(search_raw.call_count, 1)
 
     def test_system(self):
         """Attempt to create a :class:`nailgun.entities.System` for the


### PR DESCRIPTION
Cherry-pick of #385 

* Fixed Subscription entity and added ActivationKey.product_content helper
* Removed not used import and outdated tests
* Improved coverage

```python
In [6]: entities.Subscription(id=27).read()
Out[6]: nailgun.entities.Subscription(nailgun.config.ServerConfig(url=u'http://example.com', verify=False, auth=(u'admin', u'changeme')), activation_key=[], system=[], name=u'Red Hat Enterprise Linux for Virtual Datacenters, Premium', provided_product=[nailgun.entities.Product(nailgun.config.ServerConfig(url=u'http://example.com', verify=False, auth=(u'admin', u'changeme')), id=116), nailgun.entities.Product(nailgun.config.ServerConfig(url=u'http://example.com', verify=False, auth=(u'admin', u'changeme')), id=118), nailgun.entities.Product(nailgun.config.ServerConfig(url=u'http://example.com', verify=False, auth=(u'admin', u'changeme')), id=119), nailgun.entities.Product(nailgun.config.ServerConfig(url=u'http://example.com', verify=False, auth=(u'admin', u'changeme')), id=120), nailgun.entities.Product(nailgun.config.ServerConfig(url=u'http://example.com', verify=False, auth=(u'admin', u'changeme')), id=121), nailgun.entities.Product(nailgun.config.ServerConfig(url=u'http://example.com', verify=False, auth=(u'admin', u'changeme')), id=123), nailgun.entities.Product(nailgun.config.ServerConfig(url=u'http://example.com', verify=False, auth=(u'admin', u'changeme')), id=125), nailgun.entities.Product(nailgun.config.ServerConfig(url=u'http://example.com', verify=False, auth=(u'admin', u'changeme')), id=126), nailgun.entities.Product(nailgun.config.ServerConfig(url=u'http://example.com', verify=False, auth=(u'admin', u'changeme')), id=127), nailgun.entities.Product(nailgun.config.ServerConfig(url=u'http://example.com', verify=False, auth=(u'admin', u'changeme')), id=128), nailgun.entities.Product(nailgun.config.ServerConfig(url=u'http://example.com', verify=False, auth=(u'admin', u'changeme')), id=129), nailgun.entities.Product(nailgun.config.ServerConfig(url=u'http://example.com', verify=False, auth=(u'admin', u'changeme')), id=130), nailgun.entities.Product(nailgun.config.ServerConfig(url=u'http://example.com', verify=False, auth=(u'admin', u'changeme')), id=132), nailgun.entities.Product(nailgun.config.ServerConfig(url=u'http://example.com', verify=False, auth=(u'admin', u'changeme')), id=133), nailgun.entities.Product(nailgun.config.ServerConfig(url=u'http://example.com', verify=False, auth=(u'admin', u'changeme')), id=134), nailgun.entities.Product(nailgun.config.ServerConfig(url=u'http://example.com', verify=False, auth=(u'admin', u'changeme')), id=135), nailgun.entities.Product(nailgun.config.ServerConfig(url=u'http://example.com', verify=False, auth=(u'admin', u'changeme')), id=136), nailgun.entities.Product(nailgun.config.ServerConfig(url=u'http://example.com', verify=False, auth=(u'admin', u'changeme')), id=152)], id=27, quantity=4, subscription=nailgun.entities.Subscription(nailgun.config.ServerConfig(url=u'http://example.com', verify=False, auth=(u'admin', u'changeme')), id=20))
```