### PR TITLE
Update Host.create_missing with additional reads.

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2856,6 +2856,9 @@ class Host(  # pylint:disable=too-many-instance-attributes
                  |-> domain
                  '-> environment
 
+        If nested entities were passed by `id` (i.e. entity was only
+        initialized and not read, and therefore contains only `id` field)
+        perform additional read request.
         """
         # pylint:disable=no-member,too-many-branches,too-many-statements
         super(Host, self).create_missing()
@@ -2874,6 +2877,8 @@ class Host(  # pylint:disable=too-many-instance-attributes
                 organization=[self.organization],
             ).create(True)
         else:
+            if not hasattr(self.domain, 'organization'):
+                self.domain = self.domain.read()
             if self.location.id not in [
                     loc.id for loc in self.domain.location]:
                 self.domain.location.append(self.location)
@@ -2889,6 +2894,8 @@ class Host(  # pylint:disable=too-many-instance-attributes
                 organization=[self.organization],
             ).create(True)
         else:
+            if not hasattr(self.environment, 'organization'):
+                self.environment = self.environment.read()
             if self.location.id not in [
                     loc.id for loc in self.environment.location]:
                 self.environment.location.append(self.location)
@@ -2915,6 +2922,8 @@ class Host(  # pylint:disable=too-many-instance-attributes
                 ptable=[self.ptable],
             ).create(True)
         else:
+            if not hasattr(self.operatingsystem, 'architecture'):
+                self.operatingsystem = self.operatingsystem.read()
             if self.architecture.id not in [
                     arch.id for arch in self.operatingsystem.architecture]:
                 self.operatingsystem.architecture.append(self.architecture)
@@ -2931,6 +2940,8 @@ class Host(  # pylint:disable=too-many-instance-attributes
                 organization=[self.organization],
             ).create(True)
         else:
+            if not hasattr(self.medium, 'organization'):
+                self.medium = self.medium.read()
             if self.operatingsystem.id not in [
                     os.id for os in self.medium.operatingsystem]:
                 self.medium.operatingsystem.append(self.operatingsystem)

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -875,6 +875,33 @@ class CreateMissingTestCase(TestCase):
         self.assertIn(ptable.id, [ptable_.id for ptable_ in oper_sys.ptable])
         self.assertIn(oper_sys.id, [os_.id for os_ in media.operatingsystem])
 
+    def test_host_v3(self):
+        """Test ``Host()`` providing optional entities with id only.
+        Check that additional read was called for that entities.
+        """
+        # pylint:disable=no-member,too-many-locals
+        optional = {
+            'domain': entities.Domain(self.cfg, id=1),
+            'env': entities.Environment(self.cfg, id=1),
+            'arch': entities.Architecture(self.cfg, id=1),
+            'oper_sys': entities.OperatingSystem(self.cfg, id=1),
+            'media': entities.Media(self.cfg, id=1),
+        }
+        entity = entities.Host(
+            self.cfg,
+            architecture=optional['arch'],
+            domain=optional['domain'],
+            environment=optional['env'],
+            medium=optional['media'],
+            operatingsystem=optional['oper_sys'],
+        )
+        with mock.patch.object(EntityCreateMixin, 'create_json'):
+            with mock.patch.object(EntityReadMixin, 'read_json'):
+                with mock.patch.object(EntityUpdateMixin, 'update_json'):
+                    with mock.patch.object(EntityReadMixin, 'read') as read:
+                        entity.create_missing()
+        self.assertGreaterEqual(read.call_count, len(optional))
+
     def test_lifecycle_environment_v1(self):
         """Test ``LifecycleEnvironment(name='Library')``."""
         entity = entities.LifecycleEnvironment(self.cfg, name='Library')


### PR DESCRIPTION
Inspired by @abalakh comment in https://github.com/SatelliteQE/robottelo/pull/4458#issuecomment-287330692

`Host`'s `create_missing` helper tried to access to some fields inside nested entities without checking whether these fields actually present. And they don't when passing `id` to `Host` instead of `Entity` object obtained by `read`, so additional read is necessary. 

Before:
```python
In [4]: entities.Host(config, environment=1).create(create_missing=True)
AttributeError: 'Environment' object has no attribute 'location'
In [5]: entities.Host(config, domain=1).create(create_missing=True)
AttributeError: 'Domain' object has no attribute 'location'
In [6]: entities.Host(config, operatingsystem=1).create(create_missing=True)
AttributeError: 'OperatingSystem' object has no attribute 'architecture'
```
After:
```python
In [5]: entities.Host(config, environment=1).create(create_missing=True)
Out[5]: nailgun.entities.Host( environment=nailgun.entities.Environment(nailgun.config.ServerConfig(..., id=1), ...)

In [6]: entities.Host(config, domain=1).create(create_missing=True)
Out[6]: nailgun.entities.Host(domain=nailgun.entities.Domain(nailgun.config.ServerConfig(..., id=1), ...)

In [7]: entities.Host(config, operatingsystem=1).create(create_missing=True)
Out[7]: nailgun.entities.Host(operatingsystem=nailgun.entities.OperatingSystem(nailgun.config.ServerConfig(..., id=1), ...)

In [8]: entities.Host(config, medium=1).create(create_missing=True)
Out[8]: nailgun.entities.Host(medium=nailgun.entities.Media(..., id=1), ...)
```