### PR TITLE
[6.2.z] Use entities.ConfigTemplate for 'config_template' fields.

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -3183,7 +3183,7 @@ class Location(
             'compute_resource': entity_fields.OneToManyField(
                 AbstractComputeResource),
             'config_template': entity_fields.OneToManyField(
-                ProvisioningTemplate),
+                ConfigTemplate),
             'description': entity_fields.StringField(),
             'domain': entity_fields.OneToManyField(Domain),
             'environment': entity_fields.OneToManyField(Environment),
@@ -3400,7 +3400,7 @@ class OperatingSystem(
             ),
             'ptable': entity_fields.OneToManyField(PartitionTable),
             'config_template': entity_fields.OneToManyField(
-                ProvisioningTemplate),
+                ConfigTemplate),
             'provisioning_template': entity_fields.OneToManyField(
                 ProvisioningTemplate),
             'release_name': entity_fields.StringField(),
@@ -3517,7 +3517,7 @@ class Organization(
                 AbstractComputeResource
             ),
             'config_template': entity_fields.OneToManyField(
-                ProvisioningTemplate),
+                ConfigTemplate),
             'description': entity_fields.StringField(),
             'domain': entity_fields.OneToManyField(Domain),
             'environment': entity_fields.OneToManyField(Environment),
@@ -3657,7 +3657,7 @@ class OSDefaultTemplate(Entity):
     def __init__(self, server_config=None, **kwargs):
         self._fields = {
             'config_template': entity_fields.OneToOneField(
-                ProvisioningTemplate),
+                ConfigTemplate),
             'operatingsystem': entity_fields.OneToOneField(
                 OperatingSystem
             ),
@@ -5391,7 +5391,7 @@ class TemplateCombination(Entity, EntityDeleteMixin, EntityReadMixin):
     def __init__(self, server_config=None, **kwargs):
         self._fields = {
             'config_template': entity_fields.OneToOneField(
-                ProvisioningTemplate),
+                ConfigTemplate),
             'environment': entity_fields.OneToOneField(Environment),
             'hostgroup': entity_fields.OneToOneField(HostGroup),
             'provisioning_template': entity_fields.OneToOneField(


### PR DESCRIPTION
Regression added in #382. Original idea of that change was to remove `ConfigTemplate` as deprecated and use new `ProvisioningTemplate` instead. But later it was decided to keep `ConfigTemplate` as it is still supported. Robottelo tests continue using `ConfigTemplate` entities for fields where ProvisioningTemplate` object is expected and that's cause failures.
This change can be reverted later in scope of #375 (should be done on both nailgun and robottelo sides).