### PR TITLE
[6.3] [Cherry-pick] Use entities.ConfigTemplate for 'config_template' fields.

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -3361,8 +3361,7 @@ class Location(
         self._fields = {
             'compute_resource': entity_fields.OneToManyField(
                 AbstractComputeResource),
-            'config_template': entity_fields.OneToManyField(
-                ProvisioningTemplate),
+            'config_template': entity_fields.OneToManyField(ConfigTemplate),
             'description': entity_fields.StringField(),
             'domain': entity_fields.OneToManyField(Domain),
             'environment': entity_fields.OneToManyField(Environment),
@@ -3582,8 +3581,7 @@ class OperatingSystem(
                 unique=True
             ),
             'ptable': entity_fields.OneToManyField(PartitionTable),
-            'config_template': entity_fields.OneToManyField(
-                ProvisioningTemplate),
+            'config_template': entity_fields.OneToManyField(ConfigTemplate),
             'provisioning_template': entity_fields.OneToManyField(
                 ProvisioningTemplate),
             'release_name': entity_fields.StringField(),
@@ -3700,8 +3698,7 @@ class Organization(
             'compute_resource': entity_fields.OneToManyField(
                 AbstractComputeResource
             ),
-            'config_template': entity_fields.OneToManyField(
-                ProvisioningTemplate),
+            'config_template': entity_fields.OneToManyField(ConfigTemplate),
             'description': entity_fields.StringField(),
             'domain': entity_fields.OneToManyField(Domain),
             'environment': entity_fields.OneToManyField(Environment),
@@ -3841,8 +3838,7 @@ class OSDefaultTemplate(Entity):
 
     def __init__(self, server_config=None, **kwargs):
         self._fields = {
-            'config_template': entity_fields.OneToOneField(
-                ProvisioningTemplate),
+            'config_template': entity_fields.OneToOneField(ConfigTemplate),
             'operatingsystem': entity_fields.OneToOneField(
                 OperatingSystem
             ),
@@ -5630,8 +5626,7 @@ class TemplateCombination(Entity, EntityDeleteMixin, EntityReadMixin):
 
     def __init__(self, server_config=None, **kwargs):
         self._fields = {
-            'config_template': entity_fields.OneToOneField(
-                ProvisioningTemplate),
+            'config_template': entity_fields.OneToOneField(ConfigTemplate),
             'environment': entity_fields.OneToOneField(Environment),
             'hostgroup': entity_fields.OneToOneField(HostGroup),
             'provisioning_template': entity_fields.OneToOneField(


### PR DESCRIPTION
Cherry-picked from #394. Change is quite easy so cherry-picking it immediately.
Description copy:
> Regression added in #382. Original idea of that change was to remove ConfigTemplate as deprecated and use new ProvisioningTemplate instead. But later it was decided to keep ConfigTemplate as it is still supported. Robottelo tests continue using ConfigTemplate entities for fields where ProvisioningTemplate` object is expected and that's cause failures.
> This change can be reverted later in scope of #375 (should be done on both nailgun and robottelo sides).