### PR TITLE
[Cherry-pick] Added Capsule entity and its helpers (#396)

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -516,6 +516,117 @@ class Bookmark(
         super(Bookmark, self).__init__(server_config, **kwargs)
 
 
+class Capsule(Entity, EntityReadMixin, EntitySearchMixin):
+    """A representation of a Capsule entity."""
+    # pylint:disable=invalid-name
+
+    def __init__(self, server_config=None, **kwargs):
+        self._fields = {
+            'features': entity_fields.ListField(),
+            'location': entity_fields.OneToManyField(Location),
+            'name': entity_fields.StringField(
+                required=True,
+                str_type='alpha',
+                length=(6, 12),
+            ),
+            'organization': entity_fields.OneToManyField(Organization),
+            'url': entity_fields.StringField(required=True),
+        }
+        self._meta = {
+            'api_path': 'katello/api/capsules',
+            'server_modes': ('sat'),
+        }
+        super(Capsule, self).__init__(server_config, **kwargs)
+
+    def content_add_lifecycle_environment(self, synchronous=True, **kwargs):
+        """Helper to associate lifecycle environment with capsule
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+        """
+        kwargs = kwargs.copy()
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.post(
+            self.path('content_lifecycle_environments'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous)
+
+    def content_lifecycle_environments(self, synchronous=True, **kwargs):
+        """Helper to get all the lifecycle environments, associated with
+        capsule
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+        """
+        kwargs = kwargs.copy()
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.get(
+            self.path('content_lifecycle_environments'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous)
+
+    def content_sync(self, synchronous=True, **kwargs):
+        """Helper to sync content on a capsule
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+        """
+        kwargs = kwargs.copy()
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.post(self.path('content_sync'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous)
+
+    def content_get_sync(self, synchronous=True, **kwargs):
+        """Helper to get content sync status on capsule
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+        """
+        kwargs = kwargs.copy()
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.get(self.path('content_sync'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous)
+
+    def path(self, which=None):
+        """Extend ``nailgun.entity_mixins.Entity.path``.
+
+        The format of the returned path depends on the value of ``which``:
+
+        content_lifecycle_environments
+            /capsules/<id>/content/lifecycle_environments
+        content_sync
+            /capsules/<id>/content/sync
+
+
+        ``super`` is called otherwise.
+
+        """
+        if which and which.startswith('content_'):
+            return '{0}/content/{1}'.format(
+                super(Capsule, self).path(which='self'),
+                which.split('content_')[1]
+            )
+        return super(Capsule, self).path(which)
+
+
 class CommonParameter(Entity):
     """A representation of a Common Parameter entity."""
 
@@ -1395,6 +1506,7 @@ class ContentViewVersion(
             'environment': entity_fields.OneToManyField(Environment),
             'major': entity_fields.IntegerField(),
             'minor': entity_fields.IntegerField(),
+            'package_count': entity_fields.IntegerField(),
             'puppet_module': entity_fields.OneToManyField(PuppetModule),
             'version': entity_fields.StringField(),
         }
@@ -3283,6 +3395,7 @@ class LifecycleEnvironment(
         # NOTE: The "prior" field is unusual. See `create_missing`'s docstring.
         self._fields = {
             'description': entity_fields.StringField(),
+            'label': entity_fields.StringField(),
             'name': entity_fields.StringField(
                 required=True,
                 str_type='alpha',

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -97,6 +97,7 @@ class InitTestCase(TestCase):
                 entities.Architecture,
                 entities.AuthSourceLDAP,
                 entities.Bookmark,
+                entities.Capsule,
                 entities.CommonParameter,
                 entities.ComputeAttribute,
                 entities.ComputeProfile,
@@ -236,6 +237,7 @@ class PathTestCase(TestCase):
         for entity, path in (
                 (entities.AbstractDockerContainer, '/containers'),
                 (entities.ActivationKey, '/activation_keys'),
+                (entities.Capsule, '/capsules'),
                 (entities.ConfigTemplate, '/config_templates'),
                 (entities.ProvisioningTemplate, '/provisioning_templates'),
                 (entities.ContentView, '/content_views'),
@@ -482,6 +484,30 @@ class PathTestCase(TestCase):
                     path
                 )
                 self.assertRegex(path, '{}$'.format(which))
+
+    def test_capsule(self):
+        """Test :meth:`nailgun.entities.Capsule.path`.
+
+        Assert that the following return appropriate paths:
+
+        * ``Capsule().path('content_lifecycle_environments')``
+        * ``Capsule().path('content_sync')``
+
+        """
+        capsule = entities.Capsule(self.cfg, id=gen_integer(1, 100))
+        for which in (
+                'content_lifecycle_environments',
+                'content_sync'):
+            with self.subTest(which):
+                path = capsule.path(which)
+                self.assertIn(
+                    'capsules/{}/content/{}'.format(
+                        capsule.id,  # pylint:disable=no-member
+                        which.split('_', 1)[1],
+                    ),
+                    path
+                )
+                self.assertRegex(path, '{}/{}$'.format(*which.split('_', 1)))
 
 
 class CreateTestCase(TestCase):
@@ -1478,6 +1504,16 @@ class GenericTestCase(TestCase):
             (entities.ActivationKey(**generic).content_override, 'put'),
             (entities.ActivationKey(**generic).product_content, 'get'),
             (entities.ActivationKey(**generic).remove_host_collection, 'put'),
+            (
+                entities.Capsule(**generic).content_add_lifecycle_environment,
+                'post'
+            ),
+            (entities.Capsule(**generic).content_get_sync, 'get'),
+            (
+                entities.Capsule(**generic).content_lifecycle_environments,
+                'get'
+            ),
+            (entities.Capsule(**generic).content_sync, 'post'),
             (entities.ConfigTemplate(**generic).build_pxe_default, 'post'),
             (entities.ConfigTemplate(**generic).clone, 'post'),
             (


### PR DESCRIPTION
Cherry-pick of #396 
```python
In [3]: entities.Capsule(id=1).read()

Out[3]: nailgun.entities.Capsule(url=u'https://example.com:9090', name=u'example.com', location=[nailgun.entities.Location(id=2)], organization=[nailgun.entities.Organization(id=18), nailgun.entities.Organization(id=21), nailgun.entities.Organization(id=12), nailgun.entities.Organization(id=15), nailgun.entities.Organization(id=1), nailgun.entities.Organization(id=19), nailgun.entities.Organization(id=14), nailgun.entities.Organization(id=11), nailgun.entities.Organization(id=20), nailgun.entities.Organization(id=23), nailgun.entities.Organization(id=17), nailgun.entities.Organization(id=3), nailgun.entities.Organization(id=16), nailgun.entities.Organization(id=4), nailgun.entities.Organization(id=9), nailgun.entities.Organization(id=7), nailgun.entities.Organization(id=8), nailgun.entities.Organization(id=24), nailgun.entities.Organization(id=6), nailgun.entities.Organization(id=5), nailgun.entities.Organization(id=22), nailgun.entities.Organization(id=25), nailgun.entities.Organization(id=13), nailgun.entities.Organization(id=10)], id=1, features=[{u'name': u'Pulp', u'id': 2}, {u'name': u'TFTP', u'id': 4}, {u'name': u'DNS', u'id': 5}, {u'name': u'DHCP', u'id': 6}, {u'name': u'Puppet', u'id': 7}, {u'name': u'Puppet CA', u'id': 8}, {u'name': u'Logs', u'id': 12}, {u'name': u'Dynflow', u'id': 13}, {u'name': u'SSH', u'id': 14}, {u'name': u'Discovery', u'id': 15}, {u'name': u'Openscap', u'id': 17}])

In [4]: entities.Capsule().search()

Out[4]: [nailgun.entities.Capsule(features=[{u'name': u'Pulp', u'id': 2}], url=u'https://example.com:9090', id=1, name=u'example.com')]
```