### PR TITLE
added JobInvocation and JobTemplate entities

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -3270,6 +3270,68 @@ class Interface(
         return super(Interface, self).search_normalize(results)
 
 
+class JobInvocation(
+        Entity,
+        EntityCreateMixin,
+        EntityReadMixin,
+        EntitySearchMixin):
+    """A representation of a Job invocation entity."""
+
+    def __init__(self, server_config=None, **kwargs):
+        self._fields = {
+            'description': entity_fields.StringField(),
+            'dynflow_task': entity_fields.OneToOneField(ForemanTask),
+            'failed': entity_fields.IntegerField(),
+            'job_category': entity_fields.StringField(),
+            'pending': entity_fields.IntegerField(),
+            'start_at': entity_fields.DateTimeField(),
+            'status': entity_fields.IntegerField(),
+            'status_label': entity_fields.StringField(),
+            'succeeded': entity_fields.IntegerField(),
+            'task': entity_fields.OneToOneField(ForemanTask),
+            'targeting': entity_fields.DictField(),
+            'targeting_id': entity_fields.IntegerField(),
+            'template_invocations': entity_fields.ListField(),
+            'total': entity_fields.IntegerField(),
+        }
+        self._meta = {
+            'api_path': 'api/v2/job_invocations',
+            'server_modes': ('sat')}
+        super(JobInvocation, self).__init__(server_config, **kwargs)
+
+
+class JobTemplate(
+        Entity,
+        EntityCreateMixin,
+        EntityDeleteMixin,
+        EntityReadMixin,
+        EntitySearchMixin,
+        EntityUpdateMixin):
+    """A representation of a Job invocation entity."""
+
+    def __init__(self, server_config=None, **kwargs):
+        self._fields = {
+            'audit_comment': entity_fields.StringField(),
+            'created_at': entity_fields.DateTimeField(),
+            'description_format': entity_fields.StringField(),
+            'effective_user': entity_fields.DictField(),
+            'job_category': entity_fields.StringField(),
+            'location': entity_fields.OneToManyField(Location),
+            'locked': entity_fields.BooleanField(),
+            'name': entity_fields.StringField(),
+            'organization': entity_fields.OneToManyField(Organization),
+            'provider_type': entity_fields.StringField(),
+            'snippet': entity_fields.BooleanField(),
+            'template': entity_fields.StringField(),
+            'template_inputs': entity_fields.ListField(),
+            'updated_at': entity_fields.DateTimeField(),
+        }
+        self._meta = {
+            'api_path': 'api/v2/job_templates',
+            'server_modes': ('sat')}
+        super(JobTemplate, self).__init__(server_config, **kwargs)
+
+
 class LifecycleEnvironment(
         Entity,
         EntityCreateMixin,

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -123,6 +123,8 @@ class InitTestCase(TestCase):
                 entities.HostCollectionErrata,
                 entities.HostCollectionPackage,
                 entities.HostGroup,
+                entities.JobInvocation,
+                entities.JobTemplate,
                 entities.LibvirtComputeResource,
                 entities.LifecycleEnvironment,
                 entities.Location,


### PR DESCRIPTION
Added basic entities for job templates and job invocations, related to #400 

```
In [4]: tmp = entities.JobTemplate(id=121)
In [5]: tmp.read_json()
Out[5]:
{u'audit_comment': None,
 u'created_at': u'2017-04-11 11:18:35 UTC',
 u'description_format': None,
 u'effective_user': {u'current_user': False,
  u'overridable': True,
  u'value': None},
 u'id': 121,
 u'job_category': u'Miscellaneous',
 u'locations': [],
 u'locked': False,
 u'name': u'wvbuPgW',
 u'organizations': [{u'description': None,
   u'id': 31,
   u'name': u'oPIrBo',
   u'title': u'oPIrBo'}],
 u'provider_type': u'SSH',
 u'snippet': False,
 u'template': u'getenforce\n',
 u'template_inputs': [],
 u'updated_at': u'2017-04-11 11:18:35 UTC'}
```
```
In [6]: inv = entities.JobInvocation(id=20)
In [7]: inv.read_json()
Out[7]: 
{u'description': u'Run ls',
 u'dynflow_task': {u'id': u'5fdc935f-c83a-46e0-8c99-5ed61a103194',
  u'state': u'stopped'},
 u'failed': 0,
 u'id': 20,
 u'job_category': u'Commands',
 u'pending': 0,
 u'start_at': u'2017-04-12 09:36:52 UTC',
 u'status': 0,
 u'status_label': u'succeeded',
 u'succeeded': 1,
 u'targeting': {u'bookmark_id': None,
  u'hosts': [{u'id': 1, u'name': u'xxx'}],
  u'search_query': u'name ~ xxx or name ~ xxx',
  u'targeting_type': u'static_query',
  u'user_id': 3},
 u'targeting_id': 20,
 u'task': {u'id': u'5fdc935f-c83a-46e0-8c99-5ed61a103194',
  u'state': u'stopped'},
 u'template_invocations': [{u'template_id': 97,
   u'template_invocation_input_values': [{u'template_input_id': 7,
     u'template_input_name': u'command',
     u'value': u'ls'}],
   u'template_name': u'Run Command - SSH Default'}],
 u'total': 1}

```