### PR TITLE
Update Host.read to check if host_parameters_attributes really was sent

### DIFF
--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -526,6 +526,7 @@ class CreateTestCase(TestCase):
             entities.DiscoveryRule(self.cfg),
             entities.DockerComputeResource(self.cfg),
             entities.Domain(self.cfg),
+            entities.Host(self.cfg),
             entities.HostGroup(self.cfg),
             entities.Location(self.cfg),
             entities.Media(self.cfg),


### PR DESCRIPTION
`POST` request doesn't return `host_parameters_attributes` nor `parameters`. `GET` request still returns `parameters` instead of `host_parameters_attributes`. So workaround for the second problem should not just rename field but also check that it exists. Also additional read is required to obtain all parameters.

```python
host = entities.Host(host_parameters_attributes=parameters).create()
self.assertEqual(host.host_parameters_attributes[0]['name'], parameters[0]['name'])
self.assertEqual(host.host_parameters_attributes[0]['value'], parameters[0]['value'])

=================== 1 passed, 69 deselected in 67.52 seconds ===================
```
```
2017-05-08 17:51:18 - nailgun.client - DEBUG - Making HTTP POST request to https://sat6.com/api/v2/hosts with options {'verify': False, 'auth': ('admin', 'changeme'), 'headers': {'content-type': 'application/json'}} and data {"host": {..., "host_parameters_attributes": [{"name": "BPqCcCyzGF", "value": "nNCFdQGoUN"}], ...}}.

2017-05-08 17:51:19 - nailgun.client - DEBUG - Received HTTP 201 response: {"ip":null,"ip6":null,"environment_id":51,"environment_name":"1Dzek1AK","last_report":null,"mac":"0a:04:2c:ec:0a:3a","realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":48,"domain_name":"anlhrno7qa","architecture_id":51,"architecture_name":"reSqlsv","operatingsystem_id":51,"operatingsystem_name":"mYQdoVI 9","subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":167,"ptable_name":"OMCnwondeJFTgxw","medium_id":53,"medium_name":"CxMmstzPgSa","pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":3,"owner_type":"User","enabled":true,"managed":true,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"mjqxuu.anlhrno7qa","image_id":null,"image_name":null,"created_at":"2017-05-08 14:51:19 UTC","updated_at":"2017-05-08 14:51:19 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","organization_id":134,"organization_name":"jzakOTEpPwss","location_id":135,"location_name":"XHHsHvUr","puppet_status":0,"model_name":null,"build_status":0,"build_status_label":"Installed","name":"mjqxuu.anlhrno7qa","id":51,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"interfaces":[{"id":58,"name":"mjqxuu.anlhrno7qa","ip":null,"ip6":null,"mac":"0a:04:2c:ec:0a:3a","identifier":null,"primary":true,"provision":true,"type":"interface"}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"puppetrun_hosts":true,"play_roles":true,"view_discovered_hosts":true,"submit_discovered_hosts":true,"auto_provision_discovered_hosts":true,"provision_discovered_hosts":true,"edit_discovered_hosts":true,"destroy_discovered_hosts":true}}

2017-05-08 17:51:19 - nailgun.client - DEBUG - Making HTTP GET request to https://sat6.com/api/v2/hosts/51 with options {'verify': False, 'auth': ('admin', 'changeme'), 'headers': {'content-type': 'application/json'}} and no data.

2017-05-08 17:51:20 - nailgun.client - DEBUG - Received HTTP 200 response: {...,"parameters":[{"priority":70,"created_at":"2017-05-08 14:51:19 UTC","updated_at":"2017-05-08 14:51:19 UTC","id":3,"name":"BPqCcCyzGF","value":"nNCFdQGoUN"}],"all_parameters":[{"priority":70,"created_at":"2017-05-08 14:51:19 UTC","updated_at":"2017-05-08 14:51:19 UTC","id":3,"name":"BPqCcCyzGF","value":"nNCFdQGoUN"},{"priority":0,"created_at":"2017-05-04 13:43:06 UTC","updated_at":"2017-05-04 13:43:06 UTC","id":1,"name":"remote_execution_connect_by_ip","value":"true"}],...}}
```
