### PR TITLE
Add some missing fields to the HostGroup and ContentView entities

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -1795,6 +1795,7 @@ class ContentView(
             'composite': entity_fields.BooleanField(),
             'content_host_count': entity_fields.IntegerField(),
             'description': entity_fields.StringField(),
+            'environment': entity_fields.OneToManyField(LifecycleEnvironment),
             'label': entity_fields.StringField(unique=True),
             'last_published': entity_fields.StringField(),
             'name': entity_fields.StringField(
@@ -2458,6 +2459,9 @@ class HostGroup(
             'puppet_ca_proxy': entity_fields.OneToOneField(SmartProxy),
             'content_source': entity_fields.OneToOneField(SmartProxy),
             'environment': entity_fields.OneToOneField(Environment),
+            'kickstart_repository': entity_fields.OneToOneField(Repository),
+            'lifecycle_environment': entity_fields.OneToOneField(
+                LifecycleEnvironment),
             'location': entity_fields.OneToManyField(Location),
             'medium': entity_fields.OneToOneField(Media),
             'root_pass': entity_fields.StringField(),
@@ -2514,11 +2518,14 @@ class HostGroup(
           <https://bugzilla.redhat.com/show_bug.cgi?id=1235377>`_
         * `Bugzilla #1235379
           <https://bugzilla.redhat.com/show_bug.cgi?id=1235379>`_
+        * `Bugzilla #1450379
+          <https://bugzilla.redhat.com/show_bug.cgi?id=1450379>`_
 
         """
         if ignore is None:
             ignore = set()
         ignore.add('root_pass')
+        ignore.add('kickstart_repository')
 
         if attrs is None:
             attrs = self.read_json()

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1077,6 +1077,7 @@ class ReadTestCase(TestCase):
         for entity, ignored_attrs in (
                 (entities.Errata,
                  {'content_view_version', 'environment', 'repository'}),
+                (entities.HostGroup, {'kickstart_repository'})
                 (entities.Subnet, {'discovery'}),
                 (entities.Subscription, {'organization'}),
                 (entities.User, {'password'}),

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1077,7 +1077,6 @@ class ReadTestCase(TestCase):
         for entity, ignored_attrs in (
                 (entities.Errata,
                  {'content_view_version', 'environment', 'repository'}),
-                (entities.HostGroup, {'kickstart_repository'})
                 (entities.Subnet, {'discovery'}),
                 (entities.Subscription, {'organization'}),
                 (entities.User, {'password'}),
@@ -2475,19 +2474,6 @@ class VersionTestCase(TestCase):
         ).create_payload()
         self.assertNotIn('prior', payload)
         self.assertIn('prior_id', payload)
-
-    def test_hostgroup_fields(self):
-        """Check :class:`nailgun.entities.HostGroup`'s fields.
-
-        Assert that version 6.1.0 adds the ``content_view`` and
-        ``lifecycle_environment`` fields.
-
-        """
-        entity_608 = entities.HostGroup(self.cfg_608)
-        entity_610 = entities.HostGroup(self.cfg_610)
-        for field_name in ('content_view', 'lifecycle_environment'):
-            self.assertNotIn(field_name, entity_608.get_fields())
-            self.assertIn(field_name, entity_610.get_fields())
 
     def test_repository_fields(self):
         """Check :class:`nailgun.entities.Repository`'s fields.


### PR DESCRIPTION
Unit test is removed as it checks specific cases for Sat 6.0.8 and 6.1.0 but now branch separation method is used for different versions.

Quick example from the in-progress robottelo test:
```python
        hg = entities.HostGroup(
            organization=[org],
            content_view=content_view,
            kickstart_repository=repo_id,
            lifecycle_environment=content_view.environment[0].read(),
            content_source=1,
            architecture=entities.Architecture().search(query={'search': 'name=x86_64'})[0],
            operatingsystem=entities.OperatingSystem().search(query={'search': 'name=RedHat 7.0'})[0],
        ).create()
```
```
2017-05-12 15:21:13 - nailgun.client - DEBUG - Making HTTP POST request to https://sat6.com/api/v2/hostgroups with options {'verify': False, 'auth': ('admin', 'changeme'), 'headers': {'content-type': 'application/json'}} and data {"hostgroup": {"kickstart_repository_id": 112, "operatingsystem_id": 63, "content_source_id": 1, "content_view_id": 166, "lifecycle_environment_id": 142, "architecture_id": 1, "organization_ids": [183], "name": "zDnNFfLRyV"}}.

2017-05-12 15:21:14 - nailgun.client - DEBUG - Received HTTP 201 response: {"subnet_id":null,"subnet_name":null,"operatingsystem_id":63,"operatingsystem_name":"RedHat 7.0","domain_id":null,"domain_name":null,"environment_id":null,"environment_name":null,"compute_profile_id":null,"compute_profile_name":null,"ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"architecture_id":1,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2017-05-12 12:21:14 UTC","updated_at":"2017-05-12 12:21:14 UTC","id":10,"name":"zDnNFfLRyV","title":"zDnNFfLRyV","puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"template_combinations":[],"puppetclasses":[],"config_groups":[],"parameters":[],"all_puppetclasses":{},"locations":[],"organizations":[{"id":183,"name":"AUkedSQ","title":"AUkedSQ","description":null}]}

2017-05-12 15:21:14 - nailgun.client - DEBUG - Making HTTP GET request to https://sat6.com/api/v2/hostgroups/10 with options {'verify': False, 'auth': ('admin', 'changeme'), 'headers': {'content-type': 'application/json'}} and no data.

2017-05-12 15:21:15 - nailgun.client - DEBUG - Received HTTP 200 response: {"content_source_id":1,"content_source_name":"sat6.com","content_view_id":166,"content_view_name":"McdJFIMVH","lifecycle_environment_id":142,"lifecycle_environment_name":"Library","subnet_id":null,"subnet_name":null,"operatingsystem_id":63,"operatingsystem_name":"RedHat 7.0","domain_id":null,"domain_name":null,"environment_id":null,"environment_name":null,"compute_profile_id":null,"compute_profile_name":null,"ancestry":null,"parent_id":null,"parent_name":null,"ptable_id":null,"ptable_name":null,"medium_id":null,"medium_name":null,"architecture_id":1,"architecture_name":"x86_64","realm_id":null,"realm_name":null,"created_at":"2017-05-12 12:21:14 UTC","updated_at":"2017-05-12 12:21:14 UTC","id":10,"name":"zDnNFfLRyV","title":"zDnNFfLRyV","puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"template_combinations":[],"puppetclasses":[],"config_groups":[],"parameters":[],"all_puppetclasses":{},"locations":[],"organizations":[{"id":183,"name":"AUkedSQ","title":"AUkedSQ","description":null}]}
```