### PR TITLE
[6.2.z] Added 'mirror_on_sync' field to Repository entity

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -4276,6 +4276,7 @@ class Repository(
             ),
             'gpg_key': entity_fields.OneToOneField(GPGKey),
             'label': entity_fields.StringField(),
+            'mirror_on_sync': entity_fields.BooleanField(),
             'name': entity_fields.StringField(
                 required=True,
                 str_type='alpha',


### PR DESCRIPTION
```python
In [2]: from nailgun import entities

In [3]: repo = entities.Repository(mirr
   ...: or_on_sync=True).create(True)

In [4]: repo.mirror_on_sync
Out[4]: True
```