### PR TITLE
Update SmartClassParameters and SmartVariables entities

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -4020,6 +4020,7 @@ class OverrideValue(
                 SmartClassParameters),
             'smart_variable': entity_fields.OneToOneField(SmartVariable),
             'use_puppet_default': entity_fields.BooleanField(),
+            'omit': entity_fields.BooleanField(),
         }
         super(OverrideValue, self).__init__(server_config, **kwargs)
         # Create an override value for a specific smart class parameter
@@ -5229,6 +5230,7 @@ class SmartClassParameters(
             'merge_overrides': entity_fields.BooleanField(),
             'merge_default': entity_fields.BooleanField(),
             'avoid_duplicates': entity_fields.BooleanField(),
+            'override_value_order': entity_fields.StringField(),
             'override_values': entity_fields.DictField()
         }
         self._meta = {
@@ -5236,6 +5238,13 @@ class SmartClassParameters(
             'server_modes': ('sat'),
         }
         super(SmartClassParameters, self).__init__(server_config, **kwargs)
+
+    def read(self, entity=None, attrs=None, ignore=None):
+        """Do not read the ``hidden_value`` attribute."""
+        if ignore is None:
+            ignore = set()
+        ignore.add('hidden_value')
+        return super(SmartClassParameters, self).read(entity, attrs, ignore)
 
 
 class SmartVariable(
@@ -5251,7 +5260,6 @@ class SmartVariable(
         self._fields = {
             'default_value': entity_fields.StringField(),
             'description': entity_fields.StringField(),
-            'override_value_order': entity_fields.StringField(),
             'puppetclass': entity_fields.OneToOneField(PuppetClass),
             'validator_rule': entity_fields.StringField(),
             'validator_type': entity_fields.StringField(),
@@ -5262,6 +5270,7 @@ class SmartVariable(
             'merge_overrides': entity_fields.BooleanField(),
             'merge_default': entity_fields.BooleanField(),
             'avoid_duplicates': entity_fields.BooleanField(),
+            'override_value_order': entity_fields.StringField(),
             'override_values': entity_fields.DictField(),
         }
         self._meta = {
@@ -5269,6 +5278,13 @@ class SmartVariable(
             'server_modes': ('sat'),
         }
         super(SmartVariable, self).__init__(server_config, **kwargs)
+
+    def read(self, entity=None, attrs=None, ignore=None):
+        """Do not read the ``hidden_value`` attribute."""
+        if ignore is None:
+            ignore = set()
+        ignore.add('hidden_value')
+        return super(SmartVariable, self).read(entity, attrs, ignore)
 
     def create_payload(self):
         """Wrap submitted data within an extra dict."""

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1106,6 +1106,8 @@ class ReadTestCase(TestCase):
         for entity, ignored_attrs in (
                 (entities.Errata,
                  {'content_view_version', 'environment', 'repository'}),
+                (entities.SmartClassParameters, {'hidden_value'}),
+                (entities.SmartVariable, {'hidden_value'}),
                 (entities.Subnet, {'discovery'}),
                 (entities.Subscription, {'organization'}),
                 (entities.User, {'password'}),


### PR DESCRIPTION
Changes:
* `use_puppet_default` now is deprecated, `omit` should be used
* `hidden_value` now is used only to set boolean flag and `hidden_value?` is used to read it back, so `hidden_value` is missing in POST/GET response and should be ignored. Actual value now can be read from `default_value` instead of `hidden_value`: `u'*****'` when using GET without parameters and actual value when using GET with `show_hidden` parameter.

```
In [9]: entities.SmartVariable(server_config, puppetclass=10, variable='123', default_value='123', hidden_value=True).create()
Out[9]: nailgun.entities.SmartVariable(merge_overrides=False, override_value_order=u'fqdn\nhostgroup\nos\ndomain', puppetclass=nailgun.entities.PuppetClass(id=10), override_values=[], validator_type=None, variable=u'123', id=3072, description=None, default_value=u'*****', validator_rule=None, avoid_duplicates=False, merge_default=False, variable_type=None, hidden_value?=True)

In [11]: entities.SmartVariable(server_config, id=3072).read()
Out[11]: nailgun.entities.SmartVariable(merge_overrides=False, override_value_order=u'fqdn\nhostgroup\nos\ndomain', puppetclass=nailgun.entities.PuppetClass(id=10), override_values=[], validator_type=None, variable=u'123', id=3072, description=None, default_value=u'*****', validator_rule=None, avoid_duplicates=False, merge_default=False, variable_type=None, hidden_value?=True)

In [13]: sv.default_value
Out[13]: u'*****'

In [15]: getattr(sv, 'hidden_value?')
Out[15]: True
```
```
