### PR TITLE
Added `date_type` field to ContentViewFilterRule entity and updated default login for User

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -1597,6 +1597,9 @@ class ContentViewFilterRule(
                 AbstractContentViewFilter,
                 required=True
             ),
+            'date_type': entity_fields.StringField(
+                choices=('issued', 'updated'),
+            ),
             'end_date': entity_fields.DateField(),
             'errata': entity_fields.OneToOneField(Errata),
             'max_version': entity_fields.StringField(),
@@ -5994,9 +5997,9 @@ class User(
             'lastname': entity_fields.StringField(length=(1, 50)),
             'location': entity_fields.OneToManyField(Location),
             'login': entity_fields.StringField(
-                length=(1, 100),
+                length=(6, 12),
                 required=True,
-                str_type=('alpha', 'alphanumeric', 'cjk', 'latin1'),
+                str_type='alpha',
             ),
             'mail': entity_fields.EmailField(required=True),
             'organization': entity_fields.OneToManyField(Organization),


### PR DESCRIPTION
```python
In [5]: entities.ContentViewFilterRule(content_view_filter=109, date_type='issue
   ...: d', end_date='2017-06-26', start_date='2017-06-21').create()
2017-06-21 17:26:06 - nailgun.client - DEBUG - Making HTTP POST request to https://example.com/katello/api/v2/content_view_filters/109/rules with options {'verify': False, 'auth': ('admin', '*********'), 'headers': {'content-type': 'application/json'}} and data {"end_date": "2017-06-26", "content_view_filter_id": 109, "date_type": "issued", "start_date": "2017-06-21"}.
2017-06-21 17:26:07 - nailgun.client - DEBUG - Received HTTP 200 response:   {"content_view_filter_id":109,"start_date":"2017-06-21","end_date":"2017-06-26","types":["bugfix","enhancement","security"],"date_type":"issued","id":18,"created_at":"2017-06-21 14:26:07 UTC","updated_at":"2017-06-21 14:26:07 UTC"}

Out[5]: nailgun.entities.ContentViewFilterRule(end_date=u'2017-06-26', date_type=u'issued', start_date=u'2017-06-21', content_view_filter=nailgun.entities.AbstractContentViewFilter(id=109), id=18, types=[u'bugfix', u'enhancement', u'security'])

In [6]: entities.ContentViewFilterRule(id=18, content_view_filter=109).read().da
   ...: te_type
2017-06-21 17:26:52 - nailgun.client - DEBUG - Making HTTP GET request to https://example.com/katello/api/v2/content_view_filters/109/rules/18 with options {'verify': False, 'auth': ('admin', '*********'), 'headers': {'content-type': 'application/json'}} and no data.
2017-06-21 17:26:54 - nailgun.client - DEBUG - Received HTTP 200 response:   {"content_view_filter_id":109,"start_date":"2017-06-21","end_date":"2017-06-26","types":["bugfix","enhancement","security"],"date_type":"issued","id":18,"created_at":"2017-06-21 14:26:07 UTC","updated_at":"2017-06-21 14:26:07 UTC"}

Out[6]: u'issued'
```