### PR TITLE
Add docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3
+MAINTAINER https://github.com/SatelliteQE
+
+RUN mkdir nailgun
+COPY / /root/nailgun
+RUN cd /root/nailgun && python3 setup.py install
+
+ENV HOME /root/nailgun
+WORKDIR /root/nailgun
+
+CMD ["python"]


### PR DESCRIPTION
This change will allow us to make automated docker builds of nailgun.
Since nailgun is run from a python interpreter, the default behavior is
to run an interpreter upon initialization. From there, a user can
interact with nailgun as usual.
Alternatively, someone developing code for nailgun can make changes
locally, then build their own images using the Dockerfile.