### PR TITLE
Update read method to accept params

### DIFF
--- a/nailgun/client.py
+++ b/nailgun/client.py
@@ -84,7 +84,7 @@ def _set_content_type(kwargs):
     kwargs['headers'] = headers
 
 
-def _log_request(method, url, kwargs, data=None):
+def _log_request(method, url, kwargs, data=None, params=None):
     """Log out information about the arguments given.
 
     The arguments provided to this function correspond to the arguments that
@@ -94,10 +94,11 @@ def _log_request(method, url, kwargs, data=None):
 
     """
     logger.debug(
-        'Making HTTP %s request to %s with %s and %s.',
+        'Making HTTP %s request to %s with %s, %s and %s.',
         method,
         url,
         'options {0}'.format(kwargs) if len(kwargs) > 0 else 'no options',
+        'params {0}'.format(params) if params else 'no params',
         'data {0}'.format(data) if data is not None else 'no data',
     )
 
@@ -149,7 +150,7 @@ def get(url, params=None, **kwargs):
     _set_content_type(kwargs)
     if _content_type_is_json(kwargs) and kwargs.get('data') is not None:
         kwargs['data'] = dumps(kwargs['data'])
-    _log_request('GET', url, kwargs)
+    _log_request('GET', url, kwargs, params=params)
     response = requests.get(url, params, **kwargs)
     _log_response(response)
     return response

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -476,7 +476,7 @@ class AuthSourceLDAP(
                 if not hasattr(self, field):
                     setattr(self, field, self._fields[field].gen_value())
 
-    def read(self, entity=None, attrs=None, ignore=None):
+    def read(self, entity=None, attrs=None, ignore=None, params=None):
         """Do not read the ``account_password`` attribute. Work around a bug.
 
         For more information, see `Bugzilla #1243036
@@ -488,7 +488,7 @@ class AuthSourceLDAP(
         if ignore is None:
             ignore = set()
         ignore.add('account_password')
-        return super(AuthSourceLDAP, self).read(entity, attrs, ignore)
+        return super(AuthSourceLDAP, self).read(entity, attrs, ignore, params)
 
 
 class Bookmark(
@@ -928,7 +928,7 @@ class DiscoveryRule(
             id=self.create_json(create_missing)['id'],
         ).read()
 
-    def read(self, entity=None, attrs=None, ignore=None):
+    def read(self, entity=None, attrs=None, ignore=None, params=None):
         """Work around a bug. Rename ``search`` to ``search_``.
 
         For more information on the bug, see `Bugzilla #1257255
@@ -950,7 +950,7 @@ class DiscoveryRule(
                 self._server_config,
                 id=attrs['id'],
             ).update_json([])[attr]
-        return super(DiscoveryRule, self).read(entity, attrs, ignore)
+        return super(DiscoveryRule, self).read(entity, attrs, ignore, params)
 
     def update(self, fields=None):
         """Fetch a complete set of attributes for this entity.
@@ -998,7 +998,7 @@ class DockerComputeResource(AbstractComputeResource):  # pylint:disable=R0901
             id=self.create_json(create_missing)['id'],
         ).read()
 
-    def read(self, entity=None, attrs=None, ignore=None):
+    def read(self, entity=None, attrs=None, ignore=None, params=None):
         """Do extra work to fetch a complete set of attributes for this entity.
 
         For more information, see `Bugzilla #1223540
@@ -1021,7 +1021,8 @@ class DockerComputeResource(AbstractComputeResource):  # pylint:disable=R0901
             )
             response.raise_for_status()
             attrs['email'] = response.json().get('email')
-        return super(DockerComputeResource, self).read(entity, attrs, ignore)
+        return super(DockerComputeResource, self).read(
+            entity, attrs, ignore, params)
 
 
 class LibvirtComputeResource(AbstractComputeResource):  # pylint:disable=R0901
@@ -1619,7 +1620,7 @@ class ContentViewFilterRule(
             )
         }
 
-    def read(self, entity=None, attrs=None, ignore=None):
+    def read(self, entity=None, attrs=None, ignore=None, params=None):
         """Do not read certain fields.
 
         Do not expect the server to return the ``content_view_filter``
@@ -1650,7 +1651,8 @@ class ContentViewFilterRule(
         ])
         if 'errata_id' in attrs:
             ignore.discard('errata')  # pylint:disable=no-member
-        return super(ContentViewFilterRule, self).read(entity, attrs, ignore)
+        return super(ContentViewFilterRule, self).read(
+            entity, attrs, ignore, params)
 
 
 class AbstractContentViewFilter(
@@ -1757,7 +1759,7 @@ class ContentViewPuppetModule(
             )
         }
 
-    def read(self, entity=None, attrs=None, ignore=None):
+    def read(self, entity=None, attrs=None, ignore=None, params=None):
         """Provide a default value for ``entity``.
 
         By default, ``nailgun.entity_mixins.EntityReadMixin.read provides a
@@ -1783,7 +1785,8 @@ class ContentViewPuppetModule(
         if ignore is None:
             ignore = set()
         ignore.add('content_view')
-        return super(ContentViewPuppetModule, self).read(entity, attrs, ignore)
+        return super(ContentViewPuppetModule, self).read(
+            entity, attrs, ignore, params)
 
 
 class ContentView(
@@ -1825,7 +1828,7 @@ class ContentView(
         }
         super(ContentView, self).__init__(server_config, **kwargs)
 
-    def read(self, entity=None, attrs=None, ignore=None):
+    def read(self, entity=None, attrs=None, ignore=None, params=None):
         """Fetch an attribute missing from the server's response.
 
         For more information, see `Bugzilla #1237257
@@ -1837,7 +1840,7 @@ class ContentView(
                 attrs = self.read_json()
             org = _get_org(self._server_config, attrs['organization']['label'])
             attrs['organization'] = org.get_values()
-        return super(ContentView, self).read(entity, attrs, ignore)
+        return super(ContentView, self).read(entity, attrs, ignore, params)
 
     def path(self, which=None):
         """Extend ``nailgun.entity_mixins.Entity.path``.
@@ -2010,7 +2013,7 @@ class Domain(
             id=self.create_json(create_missing)['id'],
         ).read()
 
-    def read(self, entity=None, attrs=None, ignore=None):
+    def read(self, entity=None, attrs=None, ignore=None, params=None):
         """Deal with weirdly named data returned from the server.
 
         For more information, see `Bugzilla #1233245
@@ -2020,7 +2023,7 @@ class Domain(
         if attrs is None:
             attrs = self.read_json()
         attrs['domain_parameters_attributes'] = attrs.pop('parameters')
-        return super(Domain, self).read(entity, attrs, ignore)
+        return super(Domain, self).read(entity, attrs, ignore, params)
 
     @signals.emit(sender=signals.SENDER_CLASS, post_result_name='entity')
     def update(self, fields=None):
@@ -2192,7 +2195,7 @@ class Errata(Entity, EntityReadMixin, EntitySearchMixin):
             return '{0}/{1}'.format(super(Errata, self).path('base'), which)
         return super(Errata, self).path(which)
 
-    def read(self, entity=None, attrs=None, ignore=None):
+    def read(self, entity=None, attrs=None, ignore=None, params=None):
         """Following fields are only accessible for filtering search results
         and are never returned by the server: ``content_view_version_id``,
         ``environment_id``, ``repository_id``.
@@ -2202,7 +2205,7 @@ class Errata(Entity, EntityReadMixin, EntitySearchMixin):
         ignore.add('content_view_version')
         ignore.add('environment')
         ignore.add('repository')
-        return super(Errata, self).read(entity, attrs, ignore)
+        return super(Errata, self).read(entity, attrs, ignore, params)
 
 
 class Filter(
@@ -2515,7 +2518,7 @@ class HostGroup(
         """
         return {u'hostgroup': super(HostGroup, self).create_payload()}
 
-    def read(self, entity=None, attrs=None, ignore=None):
+    def read(self, entity=None, attrs=None, ignore=None, params=None):
         """Deal with several bugs.
 
         For more information, see:
@@ -2548,7 +2551,7 @@ class HostGroup(
                          'content_view_id',
                          'lifecycle_environment_id'):
                 attrs[attr] = attrs2.get(attr)
-        return super(HostGroup, self).read(entity, attrs, ignore)
+        return super(HostGroup, self).read(entity, attrs, ignore, params)
 
     @signals.emit(sender=signals.SENDER_CLASS, post_result_name='entity')
     def update(self, fields=None):
@@ -3040,7 +3043,7 @@ class Host(  # pylint:disable=too-many-instance-attributes
         response = client.put(self.path('bulk/install_content'), **kwargs)
         return _handle_response(response, self._server_config, synchronous)
 
-    def read(self, entity=None, attrs=None, ignore=None):
+    def read(self, entity=None, attrs=None, ignore=None, params=None):
         """Deal with oddly named and structured data returned by the server.
 
         For more information, see `Bugzilla #1235019
@@ -3075,7 +3078,7 @@ class Host(  # pylint:disable=too-many-instance-attributes
         ignore.add('image')
         # host id is required for interface initialization
         ignore.add('interface')
-        result = super(Host, self).read(entity, attrs, ignore)
+        result = super(Host, self).read(entity, attrs, ignore, params)
         if attrs.get('image_id'):
             result.image = Image(
                 server_config=self._server_config,
@@ -3281,7 +3284,7 @@ class Image(
         """Wrap submitted data within an extra dict."""
         return {u'image': super(Image, self).update_payload(fields)}
 
-    def read(self, entity=None, attrs=None, ignore=None):
+    def read(self, entity=None, attrs=None, ignore=None, params=None):
         """Provide a default value for ``entity``.
 
         By default, ``nailgun.entity_mixins.EntityReadMixin.read`` provides a
@@ -3307,7 +3310,7 @@ class Image(
         if ignore is None:
             ignore = set()
         ignore.add('compute_resource')
-        return super(Image, self).read(entity, attrs, ignore)
+        return super(Image, self).read(entity, attrs, ignore, params)
 
 
 class Interface(
@@ -3368,7 +3371,7 @@ class Interface(
             'server_modes': ('sat'),
         }
 
-    def read(self, entity=None, attrs=None, ignore=None):
+    def read(self, entity=None, attrs=None, ignore=None, params=None):
         """Provide a default value for ``entity``.
 
         By default, ``nailgun.entity_mixins.EntityReadMixin.read`` provides a
@@ -3412,7 +3415,7 @@ class Interface(
             ignore.add('tag')
         if attrs['type'] != 'bridge' and attrs['type'] != 'bond':
             ignore.add('attached_devices')
-        return super(Interface, self).read(entity, attrs, ignore)
+        return super(Interface, self).read(entity, attrs, ignore, params)
 
     def search_normalize(self, results):
         """Append host id to search results to be able to initialize found
@@ -3560,7 +3563,7 @@ class Location(
         attrs = self.create_json(create_missing)
         return Location(self._server_config, id=attrs['id']).read()
 
-    def read(self, entity=None, attrs=None, ignore=None):
+    def read(self, entity=None, attrs=None, ignore=None, params=None):
         """Work around a bug in the server's response.
 
         Do not read the ``realm`` attribute. See `Bugzilla #1216234
@@ -3570,7 +3573,7 @@ class Location(
         if ignore is None:
             ignore = set()
         ignore.add('realm')
-        return super(Location, self).read(entity, attrs, ignore)
+        return super(Location, self).read(entity, attrs, ignore, params)
 
     @signals.emit(sender=signals.SENDER_CLASS, post_result_name='entity')
     def update(self, fields=None):
@@ -3647,12 +3650,12 @@ class Media(
             id=self.create_json(create_missing)['id'],
         ).read()
 
-    def read(self, entity=None, attrs=None, ignore=None):
+    def read(self, entity=None, attrs=None, ignore=None, params=None):
         """Rename ``path`` to ``path_``."""
         if attrs is None:
             attrs = self.read_json()
         attrs['path_'] = attrs.pop('path')
-        return super(Media, self).read(entity, attrs, ignore)
+        return super(Media, self).read(entity, attrs, ignore, params)
 
     @signals.emit(sender=signals.SENDER_CLASS, post_result_name='entity')
     def update(self, fields=None):
@@ -3805,7 +3808,7 @@ class OperatingSystemParameter(
             'server_modes': ('sat'),
         }
 
-    def read(self, entity=None, attrs=None, ignore=None):
+    def read(self, entity=None, attrs=None, ignore=None, params=None):
         """Provide a default value for ``entity``.
 
         By default, ``nailgun.entity_mixins.EntityReadMixin.read`` provides a
@@ -3834,7 +3837,8 @@ class OperatingSystemParameter(
         return super(OperatingSystemParameter, self).read(
             entity,
             attrs,
-            ignore
+            ignore,
+            params
         )
 
 
@@ -3935,7 +3939,7 @@ class Organization(
             id=self.create_json(create_missing)['id'],
         ).read()
 
-    def read(self, entity=None, attrs=None, ignore=None):
+    def read(self, entity=None, attrs=None, ignore=None, params=None):
         """Fetch as many attributes as possible for this entity.
 
         Do not read the ``realm`` attribute. For more information, see
@@ -3946,7 +3950,7 @@ class Organization(
         if ignore is None:
             ignore = set()
         ignore.add('realm')
-        return super(Organization, self).read(entity, attrs, ignore)
+        return super(Organization, self).read(entity, attrs, ignore, params)
 
     @signals.emit(sender=signals.SENDER_CLASS, post_result_name='entity')
     def update(self, fields=None):
@@ -4047,7 +4051,7 @@ class OverrideValue(
             'server_modes': ('sat'),
         }
 
-    def read(self, entity=None, attrs=None, ignore=None):
+    def read(self, entity=None, attrs=None, ignore=None, params=None):
         """Provide a default value for ``entity``.
 
         By default, ``nailgun.entity_mixins.EntityReadMixin.read provides a
@@ -4083,7 +4087,7 @@ class OverrideValue(
         if ignore is None:
             ignore = set()
         ignore.update(['smart_class_parameter', 'smart_variable'])
-        return super(OverrideValue, self).read(entity, attrs, ignore)
+        return super(OverrideValue, self).read(entity, attrs, ignore, params)
 
 
 class Permission(Entity, EntityReadMixin, EntitySearchMixin):
@@ -4168,7 +4172,7 @@ class Product(
             )
         return super(Product, self).path(which)
 
-    def read(self, entity=None, attrs=None, ignore=None):
+    def read(self, entity=None, attrs=None, ignore=None, params=None):
         """Fetch an attribute missing from the server's response.
 
         Also add sync plan to the responce if needed, as
@@ -4188,7 +4192,7 @@ class Product(
         if ignore is None:
             ignore = set()
         ignore.add('sync_plan')
-        result = super(Product, self).read(entity, attrs, ignore)
+        result = super(Product, self).read(entity, attrs, ignore, params)
         if 'sync_plan' in attrs:
             result.sync_plan = SyncPlan(
                 server_config=self._server_config,
@@ -4898,7 +4902,7 @@ class RepositorySet(
             )
         return super(RepositorySet, self).path(which)
 
-    def read(self, entity=None, attrs=None, ignore=None):
+    def read(self, entity=None, attrs=None, ignore=None, params=None):
         """Provide a default value for ``entity``.
 
         By default, ``nailgun.entity_mixins.EntityReadMixin.read`` provides a
@@ -4923,7 +4927,7 @@ class RepositorySet(
         if ignore is None:
             ignore = set()
         ignore.add('product')
-        return super(RepositorySet, self).read(entity, attrs, ignore)
+        return super(RepositorySet, self).read(entity, attrs, ignore, params)
 
     def search_normalize(self, results):
         """Provide a value for `product` field.
@@ -4971,7 +4975,7 @@ class RHCIDeployment(
         }
         super(RHCIDeployment, self).__init__(server_config, **kwargs)
 
-    def read(self, entity=None, attrs=None, ignore=None):
+    def read(self, entity=None, attrs=None, ignore=None, params=None):
         """Normalize the data returned by the server.
 
         The server's JSON response is in this form::
@@ -4994,7 +4998,7 @@ class RHCIDeployment(
         if ignore is None:
             ignore = set()
         ignore.add('rhev_engine_host')
-        return super(RHCIDeployment, self).read(entity, attrs, ignore)
+        return super(RHCIDeployment, self).read(entity, attrs, ignore, params)
 
     def path(self, which=None):
         """Extend ``nailgun.entity_mixins.Entity.path``.
@@ -5245,12 +5249,13 @@ class SmartClassParameters(
         }
         super(SmartClassParameters, self).__init__(server_config, **kwargs)
 
-    def read(self, entity=None, attrs=None, ignore=None):
+    def read(self, entity=None, attrs=None, ignore=None, params=None):
         """Do not read the ``hidden_value`` attribute."""
         if ignore is None:
             ignore = set()
         ignore.add('hidden_value')
-        return super(SmartClassParameters, self).read(entity, attrs, ignore)
+        return super(SmartClassParameters, self).read(
+            entity, attrs, ignore, params)
 
 
 class SmartVariable(
@@ -5285,12 +5290,12 @@ class SmartVariable(
         }
         super(SmartVariable, self).__init__(server_config, **kwargs)
 
-    def read(self, entity=None, attrs=None, ignore=None):
+    def read(self, entity=None, attrs=None, ignore=None, params=None):
         """Do not read the ``hidden_value`` attribute."""
         if ignore is None:
             ignore = set()
         ignore.add('hidden_value')
-        return super(SmartVariable, self).read(entity, attrs, ignore)
+        return super(SmartVariable, self).read(entity, attrs, ignore, params)
 
     def create_payload(self):
         """Wrap submitted data within an extra dict."""
@@ -5373,7 +5378,7 @@ class Subnet(
         """
         return {u'subnet': super(Subnet, self).create_payload()}
 
-    def read(self, entity=None, attrs=None, ignore=None):
+    def read(self, entity=None, attrs=None, ignore=None, params=None):
         """Fetch as many attributes as possible for this entity.
 
         Do not read the ``discovery`` attribute. For more information, see
@@ -5385,7 +5390,7 @@ class Subnet(
         if ignore is None:
             ignore = set()
         ignore.add('discovery')
-        return super(Subnet, self).read(entity, attrs, ignore)
+        return super(Subnet, self).read(entity, attrs, ignore, params)
 
     def update_payload(self, fields=None):
         """Wrap submitted data within an extra dict."""
@@ -5498,7 +5503,7 @@ class Subscription(
         )
         return _handle_response(response, self._server_config, synchronous)
 
-    def read(self, entity=None, attrs=None, ignore=None):
+    def read(self, entity=None, attrs=None, ignore=None, params=None):
         """Ignore ``organization`` field as it's never returned by the server
         and is only added to entity to be able to use organization path
         dependent helpers.
@@ -5506,7 +5511,7 @@ class Subscription(
         if ignore is None:
             ignore = set()
         ignore.add('organization')
-        return super(Subscription, self).read(entity, attrs, ignore)
+        return super(Subscription, self).read(entity, attrs, ignore, params)
 
     def refresh_manifest(self, synchronous=True, **kwargs):
         """Refresh previously imported manifest for Red Hat provider.
@@ -5609,7 +5614,7 @@ class SyncPlan(
             'api_path': '{0}/sync_plans'.format(self.organization.path()),
         }
 
-    def read(self, entity=None, attrs=None, ignore=None):
+    def read(self, entity=None, attrs=None, ignore=None, params=None):
         """Provide a default value for ``entity``.
 
         By default, ``nailgun.entity_mixins.EntityReadMixin.read`` provides a
@@ -5634,7 +5639,7 @@ class SyncPlan(
         if ignore is None:
             ignore = set()
         ignore.add('organization')
-        return super(SyncPlan, self).read(entity, attrs, ignore)
+        return super(SyncPlan, self).read(entity, attrs, ignore, params)
 
     def create_payload(self):
         """Convert ``sync_date`` to a string.
@@ -5826,7 +5831,7 @@ class System(
             )
         return super(System, self).path(which)
 
-    def read(self, entity=None, attrs=None, ignore=None):
+    def read(self, entity=None, attrs=None, ignore=None, params=None):
         """Fetch as many attributes as possible for this entity.
 
         Do not read the ``facts``, ``organization`` or ``type`` attributes.
@@ -5842,7 +5847,7 @@ class System(
         if ignore is None:
             ignore = set()
         ignore.update(['facts', 'organization', 'type'])
-        return super(System, self).read(entity, attrs, ignore)
+        return super(System, self).read(entity, attrs, ignore, params)
 
 
 class TemplateCombination(Entity, EntityDeleteMixin, EntityReadMixin):
@@ -5938,7 +5943,7 @@ class UserGroup(
             id=self.create_json(create_missing)['id'],
         ).read()
 
-    def read(self, entity=None, attrs=None, ignore=None):
+    def read(self, entity=None, attrs=None, ignore=None, params=None):
         """Work around `Redmine #9594`_.
 
         An HTTP GET request to ``path('self')`` does not return the ``admin``
@@ -5961,7 +5966,7 @@ class UserGroup(
             )
             response.raise_for_status()
             attrs['admin'] = response.json()['admin']
-        return super(UserGroup, self).read(entity, attrs, ignore)
+        return super(UserGroup, self).read(entity, attrs, ignore, params)
 
 
 class User(
@@ -6018,12 +6023,12 @@ class User(
         """
         return {u'user': super(User, self).create_payload()}
 
-    def read(self, entity=None, attrs=None, ignore=None):
+    def read(self, entity=None, attrs=None, ignore=None, params=None):
         """Do not read the ``password`` argument."""
         if ignore is None:
             ignore = set()
         ignore.add('password')
-        return super(User, self).read(entity, attrs, ignore)
+        return super(User, self).read(entity, attrs, ignore, params)
 
     def update_payload(self, fields=None):
         """Wrap submitted data within an extra dict."""

--- a/nailgun/entity_mixins.py
+++ b/nailgun/entity_mixins.py
@@ -709,7 +709,7 @@ class EntityReadMixin(object):
 
     """
 
-    def read_raw(self):
+    def read_raw(self, params=None):
         """Get information about the current entity.
 
         Make an HTTP PUT call to ``self.path('self')``. Return the response.
@@ -719,10 +719,11 @@ class EntityReadMixin(object):
         """
         return client.get(
             self.path('self'),
+            params=params,
             **self._server_config.get_client_kwargs()
         )
 
-    def read_json(self):
+    def read_json(self, params=None):
         """Get information about the current entity.
 
         Call :meth:`read_raw`. Check the response status code, decode JSON and
@@ -734,11 +735,11 @@ class EntityReadMixin(object):
         :raises: ``ValueError`` If the response JSON can not be decoded.
 
         """
-        response = self.read_raw()
+        response = self.read_raw(params=params)
         response.raise_for_status()
         return response.json()
 
-    def read(self, entity=None, attrs=None, ignore=None):
+    def read(self, entity=None, attrs=None, ignore=None, params=None):
         """Get information about the current entity.
 
         1. Create a new entity of type ``type(self)``.
@@ -784,7 +785,7 @@ class EntityReadMixin(object):
         if entity is None:
             entity = type(self)(self._server_config)
         if attrs is None:
-            attrs = self.read_json()
+            attrs = self.read_json(params=params)
         if ignore is None:
             ignore = set()
 

--- a/tests/test_entity_mixins.py
+++ b/tests/test_entity_mixins.py
@@ -730,7 +730,7 @@ class EntityReadMixinTestCase(TestCase):
         self.assertEqual(
             get.call_args[1],
             # pylint:disable=protected-access
-            self.entity._server_config.get_client_kwargs(),
+            dict(params=None, **self.entity._server_config.get_client_kwargs())
         )
 
     def test_read_json(self):


### PR DESCRIPTION
Update `read` method to accept `params` and send it to `requests.get`, allows passing parameters in URLs.

```
# Read without parameters
In [7]: entities.SmartVariable(server_config, id=28).read()
Out[7]: nailgun.entities.SmartVariable(merge_overrides=False, override_value_order=u'fqdn\nhostgroup\nos\ndomain', puppetclass=nailgun.entities.PuppetClass(id=1), override_values=[], validator_type=None, variable=u'\u4498\ubae1\U000239ee\U00023218', id=28, description=None, default_value=u'*****', validator_rule=None, avoid_duplicates=False, merge_default=False, variable_type=None, hidden_value?=True)

In [8]: getattr(entities.SmartVariable(server_config, id=28).read(), 'hidden_value?')
Out[8]: True

# Pass params to show hidden values
In [5]: entities.SmartVariable(server_config, id=28).read(params={'show_hidden': 'true'})
Out[5]: nailgun.entities.SmartVariable(merge_overrides=False, override_value_order=u'fqdn\nhostgroup\nos\ndomain', puppetclass=nailgun.entities.PuppetClass(id=1), override_values=[], validator_type=None, variable=u'\u4498\ubae1\U000239ee\U00023218', id=28, description=None, default_value=u'LadRcsEpuC', validator_rule=None, avoid_duplicates=False, merge_default=False, variable_type=None, hidden_value?=True)

In [15]: entities.SmartVariable(server_config, id=28).read(params={'show_hidden': 'true'}).default_value
Out[15]: u'LadRcsEpuC

# Pass params to hide hidden values
In [6]: entities.SmartVariable(server_config, id=28).read(params={'show_hidden': 'false'})
Out[6]: nailgun.entities.SmartVariable(merge_overrides=False, override_value_order=u'fqdn\nhostgroup\nos\ndomain', puppetclass=nailgun.entities.PuppetClass(id=1), override_values=[], validator_type=None, variable=u'\u4498\ubae1\U000239ee\U00023218', id=28, description=None, default_value=u'*****', validator_rule=None, avoid_duplicates=False, merge_default=False, variable_type=None, hidden_value?=True)

In [16]: entities.SmartVariable(server_config, id=28).read(params={'show_hidden': 'false'}).default_value
Out[16]: u'*****'
```

Debug output:
```
2017-06-29 18:56:44 - nailgun.client - DEBUG - Making HTTP GET request to https://sat6.com/api/v2/smart_variables/29 with options {'verify': False, 'auth': ('admin', 'changeme'), 'headers': {'content-type': 'application/json'}}, params {'show_hidden': 'true'} and no data.
2017-06-29 18:56:45 - nailgun.client - DEBUG - Received HTTP 200 response: {"description":null,"parameter_type":null,"variable_type":null,"hidden_value?":true,"validator_type":null,"validator_rule":null,"override_value_order":"fqdn\nhostgroup\nos\ndomain","merge_overrides":false,"merge_default":false,"avoid_duplicates":false,"puppetclass_id":1,"puppetclass_name":"api_test_variables","created_at":"2017-06-29 15:56:31 UTC","updated_at":"2017-06-29 15:56:32 UTC","variable":"宠𧇐𢜯ꕇ埏𪴸廎𤖖텴𪢀鈯갷","id":29,"default_value":"WgdKPtGynR","override_values_count":0,"override_values":[]}
```
Results for entities with overridden read:
```
In [45]: for e in (
    ...: AuthSourceLDAP,
    ...: DiscoveryRule,
    ...: DockerComputeResource,
    ...: ContentViewPuppetModule,
    ...: ContentView,
    ...: Domain,
    ...: Errata,
    ...: HostGroup,
    ...: Image,
    ...: Location,
    ...: Media,
    ...: Organization,
    ...: OverrideValue,
    ...: RHCIDeployment,
    ...: SmartClassParameters,
    ...: SmartVariable,
    ...: Subnet,
    ...: Subscription,
    ...: UserGroup,
    ...: User,
    ...: ):
    ...:     if issubclass(e, EntitySearchMixin):
    ...:         s = e(server_config).search()
    ...:         if len(s) > 0:
    ...:            print('{} id is {}'.format(e, s[0].read().id))
    ...:         else:
    ...:             print('{} not found'.format(e))
    ...:     else:
    ...:         print('{} does not support search'.format(e))
    ...:         
<class 'nailgun.entities.AuthSourceLDAP'> does not support search
<class 'nailgun.entities.DiscoveryRule'> id is 1
<class 'nailgun.entities.DockerComputeResource'> id is 1
<class 'nailgun.entities.ContentViewPuppetModule'> does not support search
<class 'nailgun.entities.ContentView'> id is 19
<class 'nailgun.entities.Domain'> id is 1
<class 'nailgun.entities.Errata'> id is fe884adf-ff73-407e-90d0-39a97a957632
<class 'nailgun.entities.HostGroup'> id is 1
<class 'nailgun.entities.Image'> does not support search
<class 'nailgun.entities.Location'> id is 2
<class 'nailgun.entities.Media'> id is 1
<class 'nailgun.entities.Organization'> id is 1
<class 'nailgun.entities.OverrideValue'> does not support search
<class 'nailgun.entities.RHCIDeployment'> does not support search
<class 'nailgun.entities.SmartClassParameters'> id is 3
<class 'nailgun.entities.SmartVariable'> id is 28
<class 'nailgun.entities.Subnet'> id is 1
<class 'nailgun.entities.Subscription'> id is 1
<class 'nailgun.entities.UserGroup'> does not support search
<class 'nailgun.entities.User'> id is 3

In [48]: AuthSourceLDAP(server_config, id=3).read()
Out[48]: nailgun.entities.AuthSourceLDAP(attr_mail=None, server_type=u'posix', groups_base=None, attr_photo=None, attr_firstname=None, base_dn=None, id=3, name=u'rWIspOJWQOyZiRoffgshbqjFFsJGcTWnlgjGKusplBSnlXyjZgzdDeINR', tls=False, account=None, host=u'dHytGzEJcJaZmNydKAOnYTAftACqFUFWJiqkWvRLRP', port=389, onthefly_register=False, attr_lastname=None, attr_login=None)

In [53]: Image(server_config, compute_resource=1, id=1).read()
Out[53]: nailgun.entities.Image(username=u'\U00021350\U000223fe\U00028515\U000209f1\U00022836\U0002ab8f\U00021b98\U00025112\u156d\U00024440\ua397\u0239\U0002b4c1', uuid=u'\U000230d5\U00029f0f\U00023923\U0002a0b8\ub2a3\u4a9b\U00021e56\uc28c\U0002274f\U0002734d\U00023d98\uacf6\u8c00\uce09\U00026bc0\ua13c\U00023d8f\u5da1\u3466\u014a', compute_resource=nailgun.entities.AbstractComputeResource(id=1), operatingsystem=nailgun.entities.OperatingSystem(id=2), architecture=nailgun.entities.Architecture(id=3), id=1, name=u'jjnkInzjv')

In [57]: UserGroup(server_config, id=1).read()
Out[57]: nailgun.entities.UserGroup(admin=False, role=[], user=[], usergroup=[], id=1, name=u'VEYOceews')

In [67]: Interface(server_config,id=5,host=1).read()
Out[67]: nailgun.entities.Interface(domain=None, managed=True, ip=u'26.64.7.220', primary=False, mac=u'4a:f4:a3:55:43:bf', provision=False, id=5, name=u'qzpsxlwbxnx', subnet=None, host=nailgun.entities.Host(id=1), virtual=False, identifier=None, type=u'interface')

In [72]: OperatingSystemParameter(server_config, id=1, operatingsystem=1).read()
Out[72]: nailgun.entities.OperatingSystemParameter(name=u'GDuKCs', operatingsystem=nailgun.entities.OperatingSystem(id=1), value=u'\u7bc9\U00024031\ubc0a', id=1)

```