### PR TITLE
Allow getting and deleting AK subscriptions

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -310,6 +310,40 @@ class ActivationKey(
         response = client.put(self.path('add_subscriptions'), **kwargs)
         return _handle_response(response, self._server_config, synchronous)
 
+    def remove_subscriptions(self, synchronous=True, **kwargs):
+        """Helper for removing subscriptions from an activation key.
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+
+        """
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.put(self.path('remove_subscriptions'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous)
+
+    def subscriptions(self, synchronous=True, **kwargs):
+        """Helper for retrieving subscriptions on an activation key.
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+
+        """
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.get(self.path('subscriptions'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous)
+
     def content_override(self, synchronous=True, **kwargs):
         """Override the content of an activation key.
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1532,6 +1532,8 @@ class GenericTestCase(TestCase):
             (entities.AbstractDockerContainer(**generic).power, 'put'),
             (entities.ActivationKey(**generic).add_host_collection, 'post'),
             (entities.ActivationKey(**generic).add_subscriptions, 'put'),
+            (entities.ActivationKey(**generic).remove_subscriptions, 'put'),
+            (entities.ActivationKey(**generic).subscriptions, 'get'),
             (entities.ActivationKey(**generic).content_override, 'put'),
             (entities.ActivationKey(**generic).product_content, 'get'),
             (entities.ActivationKey(**generic).remove_host_collection, 'put'),


### PR DESCRIPTION
For example:

```python
activation_key = ActivationKey(self._server_config, id=3)
subs = activation_key.subscriptions() # {... u'product_name': u'Employee SKU', u'instance_multiplier': 1, u'stacking_id': None, u'account_number': 1212729, u'cores': None, u'quantity': 5}], u'error': None, u'per_page': 20, u'organization': {}, u'total': 2, u'subtotal': 2, u'page': 1}
activation_key.remove_subscriptions(data={'subscription_id': subs['results'][0]['id']})
```