### PR TITLE
Check for r[field + '_id'] if not 'id' in r[field]

### DIFF
--- a/nailgun/entity_mixins.py
+++ b/nailgun/entity_mixins.py
@@ -245,9 +245,9 @@ def _get_entity_id(field_name, attrs):
     if field_name in attrs:
         if attrs[field_name] is None:
             return None
-        else:
+        elif 'id' in attrs[field_name]:
             return attrs[field_name]['id']
-    elif field_name_id in attrs:
+    if field_name_id in attrs:
         return attrs[field_name_id]
     else:
         raise MissingValueError(


### PR DESCRIPTION
This format of attrs currently breaks the `_get_entity_id` function:

Check out the example inputs to this function below (unnecessary data left out with '...').

```python
field_name = 'sync_plan'
attrs = {..., u'sync_plan_id': 10, ..., u'sync_plan': {u'name': u'Weekly RHEL Sync', u'interval': u'weekly', u'sync_date': u'2017-01-01 00:00:00 UTC', u'next_sync': None, u'description': None}, ...}
```

Note the absence of `attrs['sync_plan']['id']`