### PR TITLE
last_sync added to repo read output

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -4621,6 +4621,7 @@ class Repository(
             ),
             'gpg_key': entity_fields.OneToOneField(GPGKey),
             'label': entity_fields.StringField(),
+            'last_sync': entity_fields.OneToOneField(ForemanTask),
             'mirror_on_sync': entity_fields.BooleanField(),
             'name': entity_fields.StringField(
                 required=True,


### PR DESCRIPTION
Needed for enhancing robottelo syncplan tests


> In [8]: repo.read()

> Out[8]: nailgun.entities.Repository(product=nailgun.entities.Product(id=3), gpg_key=None, name=u'lswliVTpzf', mirror_on_sync=True, content_counts={u'puppet_module': 0, u'erratum': 0, u'package': 0, u'docker_manifest': 0, u'ostree_branch': 0, u'package_group': 0, u'file': 0, u'docker_tag': 0, u'rpm': 0}, unprotected=True, content_type=u'yum', label=u'lswliVTpzf', id=5, container_repository_name=None, docker_upstream_name=None, url=u'...', **last_sync=None**, download_policy=u'on_demand', checksum_type=None)

> In [9]: repo.sync()

>In [10]: repo.read()
>Out[10]:` nailgun.entities.Repository(product=nailgun.entities.Product(id=3), gpg_key=None, name=u'GHrRpq', mirror_on_sync=True, content_counts={u'puppet_module': 0, u'erratum': 4, u'package': 32, u'docker_manifest': 0, u'ostree_branch': 0, u'package_group': 2, u'file': 0, u'docker_tag': 0, u'rpm': 32}, unprotected=True, content_type=u'yum', label=u'GHrRpq', id=4, container_repository_name=None, docker_upstream_name=None, url=u'...', **last_sync={u'username': u'admin', u'ended_at': u'2017-07-17 11:27:07 UTC', u'state': u'stopped', u'result': u'success', u'progress': 1.0, u'started_at': u'2017-07-17 11:26:54 UTC', u'id': u'cb9f9c7f-a43e-4633-99e9-f73684d8d480'}**, download_policy=u'on_demand', checksum_type=u'sha256')
