### PR TITLE
[6.2.z] cherry-pick last_sync added to repo read output

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -4276,6 +4276,7 @@ class Repository(
             ),
             'gpg_key': entity_fields.OneToOneField(GPGKey),
             'label': entity_fields.StringField(),
+            'last_sync': entity_fields.OneToOneField(ForemanTask),
             'mirror_on_sync': entity_fields.BooleanField(),
             'name': entity_fields.StringField(
                 required=True,


### PR DESCRIPTION
Cherry pick of #425 

> repo.read()
> Out[8]: nailgun.entities.Repository(product=nailgun.entities.Product(id=5), gpg_key=None, name=u'shxCnQlZISbz', mirror_on_sync=True, content_counts={u'puppet_module': 0, u'erratum': 0, u'package': 0, u'docker_manifest': 0, u'ostree_branch': 0, u'package_group': 0, u'file': 0, u'docker_tag': 0, u'rpm': 0}, unprotected=True, content_type=u'yum', label=u'shxCnQlZISbz', id=7, container_repository_name=None, docker_upstream_name=None, url=u'...', **last_sync=None**, download_policy=u'on_demand', checksum_type=None)

> repo.sync()

> repo.read()
> nailgun.entities.Repository(product=nailgun.entities.Product(id=5), gpg_key=None, name=u'shxCnQlZISbz', mirror_on_sync=True, content_counts={u'puppet_module': 0, u'erratum': 4, u'package': 32, u'docker_manifest': 0, u'ostree_branch': 0, u'package_group': 2, u'file': 0, u'docker_tag': 0, u'rpm': 32}, unprotected=True, content_type=u'yum', label=u'shxCnQlZISbz', id=7, container_repository_name=None, docker_upstream_name=None, url=u'...', **last_sync=nailgun.entities.ForemanTask(id=u'f0f43837-752d-41fc-a05f-b55be0265fcc'), download_policy=u'on_demand', checksum_type=u'sha256')**