### PR TITLE
Add RH repository URL to Organization

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -3926,6 +3926,7 @@ class Organization(
             'provisioning_template': entity_fields.OneToManyField(
                 ProvisioningTemplate),
             'realm': entity_fields.OneToManyField(Realm),
+            'redhat_repository_url': entity_fields.URLField(),
             'smart_proxy': entity_fields.OneToManyField(SmartProxy),
             'subnet': entity_fields.OneToManyField(Subnet),
             'title': entity_fields.StringField(),
@@ -4022,9 +4023,12 @@ class Organization(
 
     def update_payload(self, fields=None):
         """Wrap submitted data within an extra dict."""
-        return {
-            u'organization': super(Organization, self).update_payload(fields)
-        }
+        org_payload = super(Organization, self).update_payload(fields)
+        payload = {u'organization': org_payload}
+        if 'redhat_repository_url' in org_payload:
+            rh_repo_url = org_payload.pop('redhat_repository_url')
+            payload['redhat_repository_url'] = rh_repo_url
+        return payload
 
     def download_debug_certificate(self, synchronous=True, **kwargs):
         """Get debug certificate for particular organization.

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1502,6 +1502,20 @@ class UpdatePayloadTestCase(TestCase):
         self.assertNotIn('system_ids', payload)
         self.assertIn('system_uuids', payload)
 
+    def test_organization_rh_repo_url(self):
+        """Check whether ``Organization`` updates its ``redhat_repository_url`` field.
+
+        The field should be copied from
+        ``p['organization']['redhat_repository_url']`` to
+        ``p['redhat_repository_url']``
+        when ``update_payload`` is called.
+        """
+        payload = entities.Organization(
+            self.cfg,
+            redhat_repository_url=["https://cdn.redhat.com"],
+        ).update_payload()
+        self.assertIn('redhat_repository_url', payload)
+
 
 # 2. Tests for entity-specific methods. ---------------------------------- {{{1
 


### PR DESCRIPTION
This allows setting the Red Hat Repository URL (i.e. https://cdn.redhat.com) to an alternate provider (i.e. another katello server or CDN).