### PR TITLE
Increase manifest functions timeout

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -5539,7 +5539,7 @@ class Subscription(
             response,
             self._server_config,
             synchronous,
-            timeout=900,
+            timeout=1500,
         )
 
     def manifest_history(self, synchronous=True, **kwargs):
@@ -5594,7 +5594,7 @@ class Subscription(
             response,
             self._server_config,
             synchronous,
-            timeout=900,
+            timeout=1500,
         )
 
     def upload(self, synchronous=True, **kwargs):
@@ -5626,7 +5626,7 @@ class Subscription(
             response,
             self._server_config,
             synchronous,
-            timeout=900,
+            timeout=1500,
         )
 
 


### PR DESCRIPTION
tested with robottelo subscription tests
```console
(sat-6.3.0) dlezz@elysion:~/projects/robottelo-fork$ py.test -v tests/foreman/api/test_subscription.py
================================================= test session starts ==================================================
platform linux2 -- Python 2.7.13, pytest-3.1.3, py-1.4.34, pluggy-0.4.0 -- /home/dlezz/.pyenv/versions/sat-6.3.0/bin/python2.7
cachedir: .cache
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.15.0, services-1.2.1, mock-1.6.0, cov-2.4.0
collected 4 items 
2017-08-03 15:49:49 - conftest - DEBUG - Found WONTFIX in decorated tests ['1147100', '1269208', '1269196', '1378009', '1245334', '1217635', '1226425', '1156555', '1199150', '1204686', '1267224', '1221971', '1103157', '1230902', '1230865', '1214312', '1079482']

2017-08-03 15:49:49 - conftest - DEBUG - Collected 4 test cases


tests/foreman/api/test_subscription.py::SubscriptionsTestCase::test_negative_upload <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_subscription.py::SubscriptionsTestCase::test_positive_create <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_subscription.py::SubscriptionsTestCase::test_positive_delete <- robottelo/decorators/__init__.py PASSED
tests/foreman/api/test_subscription.py::SubscriptionsTestCase::test_positive_refresh <- robottelo/decorators/__init__.py PASSED

================================================== 0 tests deselected ==================================================
============================================== 4 passed in 375.24 seconds ==============================================
```