### PR TITLE
Update Registry entity / add organization/location fields.

### DIFF
--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -533,6 +533,7 @@ class CreateTestCase(TestCase):
             entities.Media(self.cfg),
             entities.Organization(self.cfg),
             entities.Realm(self.cfg),
+            entities.Registry(self.cfg),
             entities.SmartProxy(self.cfg),
             entities.UserGroup(self.cfg),
         )
@@ -1359,6 +1360,7 @@ class UpdateTestCase(TestCase):
             entities.Media(self.cfg),
             entities.Organization(self.cfg),
             entities.SmartProxy(self.cfg),
+            entities.Registry(self.cfg),
             entities.User(self.cfg),
             entities.UserGroup(self.cfg),
         )


### PR DESCRIPTION
Organization/location fields were missing from Registry entity. But POST request does not return org/loc information, so additional read is needed after create/update [1]. And password is missing from GET response.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1479391

```python
In [6]: entities.Registry(server_config, url='https://registry.access.redhat.com').create(create_missing=True)
Out[6]: nailgun.entities.Registry(username=None, url=u'https://registry.access.redhat.com', description=None, organization=[], id=18, name=u'ZTBnuuXFJj')

In [7]: entities.Registry(server_config, id=18).delete()
Out[7]: 
{u'created_at': u'2017-08-08T13:40:03.199Z',
 u'description': None,
 u'id': 18,
 u'name': u'ZTBnuuXFJj',
 u'password': None,
 u'updated_at': u'2017-08-08T13:40:03.199Z',
 u'url': u'https://registry.access.redhat.com',
 u'username': None}

In [8]: entities.Registry(server_config, url='https://registry.access.redhat.com', organization=[1]).create(create_missing=True)
Out[8]: nailgun.entities.Registry(username=None, url=u'https://registry.access.redhat.com', description=None, organization=[nailgun.entities.Organization(id=1)], id=19, name=u'AvYIWK')

In [9]: reg = entities.Registry(server_config, id=19).read()

In [10]: reg.organization = [entities.Organization(server_config).create(create_missing=True)]

In [11]: reg.update(['organization'])
Out[11]: nailgun.entities.Registry(username=None, url=u'https://registry.access.redhat.com', description=None, organization=[nailgun.entities.Organization(id=28)], id=19, name=u'AvYIWK')

In [7]: entities.Registry(server_config, url='https://registry.access.redhat.com', organization=[1], location=[2]).create(create_missing=True)
Out[7]: nailgun.entities.Registry(username=None, url=u'https://registry.access.redhat.com', description=None, location=[nailgun.entities.Location(id=2)], organization=[nailgun.entities.Organization(id=1)], id=20, name=u'FGyEDBwPoHa')
```