### PR TITLE
repository add backend identifier field

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -4655,6 +4655,7 @@ class Repository(
 
     def __init__(self, server_config=None, **kwargs):
         self._fields = {
+            'backend_identifier': entity_fields.StringField(),
             'checksum_type': entity_fields.StringField(
                 choices=('sha1', 'sha256'),
             ),


### PR DESCRIPTION
```python
In [4]: org = entities.Organization(conf).create(create_missing=True)

In [5]: product = entities.Product(conf, organization=org).create(create_missing=True)

In [6]: repo = entities.Repository(conf, product=product).create(create_missing=True)

In [7]: repo
Out[7]: nailgun.entities.Repository(product=nailgun.entities.Product(id=489), gpg_key=None, mirror_on_sync=True, content_counts={u'puppet_module': 0, u'erratum': 0, u'package': 0, u'docker_manifest': 0, u'ostree_branch': 0, u'package_group': 0, u'file': 0, u'docker_tag': 0, u'rpm': 0}, unprotected=True, content_type=u'yum', label=u'OZUCVndBADM', id=109, name=u'OZUCVndBADM', docker_upstream_name=None, url=u'http://inecas.fedorapeople.org/fakerepos/zoo3/', last_sync=None, download_policy=u'on_demand', backend_identifier=u'455bf359-1597-4b13-934f-cc05928661f5', checksum_type=None, container_repository_name=None)

In [8]: repo.backend_identifier
Out[8]: u'455bf359-1597-4b13-934f-cc05928661f5'


```