### PR TITLE
Add tangible ComputeResource entities for vmware and ovirt

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -1105,6 +1105,56 @@ class LibvirtComputeResource(AbstractComputeResource):  # pylint:disable=R0901
         self._fields['provider_friendly_name'].default = 'Libvirt'
 
 
+class OVirtComputeResource(AbstractComputeResource):
+    # pylint: disable=too-many-ancestors
+    """A representation for compute resources with Ovirt provider
+    """
+    def __init__(self, server_config=None, **kwargs):
+        self._fields = {
+            'password': entity_fields.StringField(),
+            'user': entity_fields.StringField(),
+        }
+        super(OVirtComputeResource, self).__init__(server_config, **kwargs)
+        self._fields['provider'].default = 'Ovirt'
+        self._fields['provider'].required = True
+        self._fields['provider_friendly_name'].default = 'OVirt'
+
+    def read(self, entity=None, attrs=None, ignore=None, params=None):
+        """Make sure, ``password`` is in the ignore list for read
+        """
+        if ignore is None:
+            ignore = set()
+        ignore.add('password')
+        return super(OVirtComputeResource, self).read(
+            entity, attrs, ignore, params)
+
+
+class VMWareComputeResource(AbstractComputeResource):
+    # pylint: disable=too-many-ancestors
+    """A representation for compute resources with Vmware provider
+    """
+    def __init__(self, server_config=None, **kwargs):
+        self._fields = {
+            'datacenter': entity_fields.StringField(),
+            'password': entity_fields.StringField(),
+            'set_console_password': entity_fields.BooleanField(),
+            'user': entity_fields.StringField(),
+        }
+        super(VMWareComputeResource, self).__init__(server_config, **kwargs)
+        self._fields['provider'].default = 'Vmware'
+        self._fields['provider'].required = True
+        self._fields['provider_friendly_name'].default = 'VMware'
+
+    def read(self, entity=None, attrs=None, ignore=None, params=None):
+        """Make sure, ``password`` is in the ignore list for read
+        """
+        if ignore is None:
+            ignore = set()
+        ignore.add('password')
+        return super(VMWareComputeResource, self).read(
+            entity, attrs, ignore, params)
+
+
 class ConfigGroup(
         Entity,
         EntityCreateMixin,

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -136,6 +136,7 @@ class InitTestCase(TestCase):
                 entities.OSDefaultTemplate,
                 entities.OperatingSystem,
                 entities.Organization,
+                entities.OVirtComputeResource,
                 entities.PackageGroupContentViewFilter,
                 entities.PartitionTable,
                 entities.Permission,
@@ -165,6 +166,7 @@ class InitTestCase(TestCase):
                 entities.TemplateKind,
                 entities.User,
                 entities.UserGroup,
+                entities.VMWareComputeResource,
             )
         ]
         entities_.extend([
@@ -1112,12 +1114,14 @@ class ReadTestCase(TestCase):
         for entity, ignored_attrs in (
                 (entities.Errata,
                  {'content_view_version', 'environment', 'repository'}),
+                (entities.OVirtComputeResource, {'password'}),
                 (entities.SmartProxy, {'download_policy'}),
                 (entities.SmartClassParameters, {'hidden_value'}),
                 (entities.SmartVariable, {'hidden_value'}),
                 (entities.Subnet, {'discovery'}),
                 (entities.Subscription, {'organization'}),
                 (entities.User, {'password'}),
+                (entities.VMWareComputeResource, {'password'}),
         ):
             with self.subTest(entity):
                 with mock.patch.object(EntityReadMixin, 'read') as read:


### PR DESCRIPTION
@philippj implemented these two entities within https://github.com/theforeman/foreman-ansible-modules/pull/26
But we think they could be of broader interest.