### PR TITLE
Add ActivationKey service_level field

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -237,6 +237,7 @@ class ActivationKey(
                 Organization,
                 required=True,
             ),
+            'service_level': entity_fields.StringField(),
             'unlimited_hosts': entity_fields.BooleanField(),
         }
         self._meta = {


### PR DESCRIPTION
```console
In[9]: ak = entities.ActivationKey(server_config, service_level='Premium').create(create_missing=True)
In[10]: ak.read()
Out[10]: nailgun.entities.ActivationKey(host_collection=[], service_level=None, max_hosts=None, content_view=None, description=None, unlimited_hosts=True, environment=None, auto_attach=True, organization=nailgun.entities.Organization(id=105), id=65, name=u'ZYbPnwr')
In[11]: ak.service_level
Out[11]: u'Premium'
In[12]: ak2 = entities.ActivationKey(server_config).create(create_missing=True)
In[13]: ak2.service_level

In[14]: ak2.read()
Out[14]: nailgun.entities.ActivationKey(host_collection=[], service_level=None, max_hosts=None, content_view=None, description=None, unlimited_hosts=True, environment=None, auto_attach=True, organization=nailgun.entities.Organization(id=106), id=66, name=u'gIvdXEZLYwKx')
In[15]: ak
Out[15]: nailgun.entities.ActivationKey(host_collection=[], service_level=u'Premium', max_hosts=None, content_view=None, description=None, unlimited_hosts=True, environment=None, auto_attach=True, organization=nailgun.entities.Organization(id=105), id=65, name=u'ZYbPnwr')
```
add this command 
```console
In[39]: ak = ak.read()
In[40]: ak.service_level
In[41]: print ak.service_level
None
```
The service level was silently changed by the server as it make no sense without subscription, and the validation is done when updating the activation with service level, as subscriptions can be added on an already created activation key 
```console
In[42]: ak.service_level = 'Premium'
In[43]: ak.update(['service_level'])
WARNING:nailgun.client:Received HTTP 500 response: {"displayMessage":"Task d4096510-9b11-4088-bbea-9a90beabb9d2: Katello::Errors::CandlepinError: Service level 'Premium' is not available to units of organization pzUUVNtpw.","errors":["Task d4096510-9b11-4088-bbea-9a90beabb9d2: Katello::Errors::CandlepinError: Service level 'Premium' is not available to units of organization pzUUVNtpw."]}
Traceback (most recent call last):
```
when adding the subscription to activation key 
updating:
```
In[19]: ak.service_level = 'Premium'
In[20]: ak.update(['service_level'])
Out[20]: nailgun.entities.ActivationKey(host_collection=[], service_level=u'Premium', max_hosts=None, content_view=None, description=None, unlimited_hosts=True, environment=None, auto_attach=True, organization=nailgun.entities.Organization(id=130), id=91, name=u'NXUVDR')
In[21]: ak.service_level
Out[21]: 'Premium'
In[22]: ak
Out[22]: nailgun.entities.ActivationKey(host_collection=[], service_level='Premium', max_hosts=None, content_view=None, description=None, unlimited_hosts=True, environment=None, auto_attach=True, organization=nailgun.entities.Organization(id=130), id=91, name=u'NXUVDR')
```
reading:
```
In[29]: ak = ak.read()
2017-09-14 15:01:49 - nailgun.client - DEBUG - Making HTTP GET request to https://dell-per415-02.dsal.lab.eng.bos.redhat.com/katello/api/v2/activation_keys/91 with options {'verify': False, 'auth': ('admin', 'changeme'), 'headers': {'content-type': 'application/json'}}, no params and no data.
2017-09-14 15:01:51 - nailgun.client - DEBUG - Received HTTP 200 response:   {"id":91,"name":"NXUVDR","description":null,"unlimited_hosts":true,"auto_attach":true,"content_view_id":null,"environment_id":null,"usage_count":0,"user_id":3,"max_hosts":null,"release_version":null,"service_level":"Premium","content_overrides":[],"organization":{"name":"tXPwCvBPWEVj","label":"tXPwCvBPWEVj","id":130},"created_at":"2017-09-14 10:54:33 UTC","updated_at":"2017-09-14 10:54:34 UTC","content_view":null,"environment":null,"products":[{"id":1989,"name":"Red Hat Enterprise Linux Resilient Storage for RHEL Server - Extended Update Support"},{"id":1990,"name":"Red Hat Software Collections for RHEL Server"},{"id":1992,"name":"Red Hat Enterprise Linux Atomic Host Beta"},{"id":1993,"name":"Red Hat Developer Tools Beta for RHEL Server"},{"id":1994,"name":"Red Hat Enterprise Linux High Availability for RHEL Server - Extended Update Support"},{"id":1995,"name":"Red Hat Developer Tools for RHEL Server"},{"id":1996,"name":"Red Hat EUCJP Support for RHEL Server - Extended Update Support"},{"id":1997,"name":"Red Hat Beta"},{"id":1998,"name":"Red Hat Enterprise Linux Server - Extended Update Support"},{"id":1999,"name":"Oracle Java for RHEL Server - Extended Update Support"},{"id":2000,"name":"Red Hat Enterprise Linux High Performance Networking for RHEL Server - Extended Update Support"},{"id":2001,"name":"Red Hat Enterprise Linux Scalable File System for RHEL Server - Extended Update Support"},{"id":2002,"name":"Oracle Java for RHEL Server"},{"id":2003,"name":"Red Hat Enterprise Linux Load Balancer for RHEL Server - Extended Update Support"},{"id":2004,"name":"Red Hat Enterprise Linux Server"},{"id":2005,"name":"dotNET on RHEL for RHEL Server"},{"id":2006,"name":"Red Hat Software Collections Beta for RHEL Server"},{"id":2007,"name":"Red Hat Enterprise Linux Atomic Host"},{"id":2008,"name":"Red Hat S-JIS Support for RHEL Server - Extended Update Support"},{"id":2009,"name":"Red Hat Developer Toolset for RHEL Server"},{"id":2025,"name":"dotNET on RHEL Beta for RHEL Server"},{"id":2026,"name":"Red Hat Container Images Beta"},{"id":2027,"name":"Red Hat Container Images"}],"host_collections":[],"permissions":{"view_activation_keys":true,"edit_activation_keys":true,"destroy_activation_keys":true}}

In[30]: ak
Out[30]: nailgun.entities.ActivationKey(host_collection=[], service_level=u'Premium', max_hosts=None, content_view=None, description=None, unlimited_hosts=True, environment=None, auto_attach=True, organization=nailgun.entities.Organization(id=130), id=91, name=u'NXUVDR')
In[31]: ak.service_level
Out[31]: u'Premium'
```

Please contact for the full log



