### PR TITLE
Add Audit entity

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -446,6 +446,30 @@ class Architecture(
         return self.read()
 
 
+class Audit(Entity, EntityReadMixin, EntitySearchMixin):
+    """A representation of Audit entity."""
+    def __init__(self, server_config=None, **kwargs):
+        self._fields = {
+            'action': entity_fields.StringField(),
+            'associated_type': entity_fields.StringField(),
+            'associated_name': entity_fields.StringField(),
+            'associated_id': entity_fields.IntegerField(),
+            'audited_changes': entity_fields.DictField(),
+            'auditable_type': entity_fields.StringField(),
+            'auditable_name': entity_fields.StringField(),
+            'auditable_id': entity_fields.IntegerField(),
+            'comment': entity_fields.StringField(),
+            'remote_address': entity_fields.IPAddressField(),
+            'version': entity_fields.StringField(),
+            'user': entity_fields.OneToOneField(User),
+        }
+        self._meta = {
+            'api_path': 'api/v2/audits',
+            'server_modes': ('sat'),
+        }
+        super(Audit, self).__init__(server_config, **kwargs)
+
+
 class AuthSourceLDAP(
         Entity,
         EntityCreateMixin,

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -98,6 +98,7 @@ class InitTestCase(TestCase):
                 entities.AbstractDockerContainer,
                 entities.ActivationKey,
                 entities.Architecture,
+                entities.Audit,
                 entities.AuthSourceLDAP,
                 entities.Bookmark,
                 entities.Capsule,


### PR DESCRIPTION
```
aud = entities.Audit(id=1889).read()
2017-09-15 04:27:55 - nailgun.client - DEBUG - Making HTTP GET request to https://server/api/v2/audits/1889 with options {'verify': False, 'auth': ('admin', 'changeme'), 'headers': {'content-type': 'application/json'}}, no params and no data.
2017-09-15 04:27:56 - nailgun.client - DEBUG - Received HTTP 200 response: {"user_id":3,"user_type":null,"user_name":"admin","version":1,"comment":null,"associated_id":null,"associated_type":null,"remote_address":"10.8.183.246","associated_name":null,"created_at":"2017-09-14 08:02:36 UTC","id":1889,"auditable_id":375,"auditable_name":"HBkSxQ","auditable_type":"Organization","action":"create","audited_changes":{"name":"HBkSxQ","ignore_types":[],"description":"stYWZdGzbCBByJq","label":"YAJBwmpaky","ancestry":null}}

In [2]: aud
Out[2]: nailgun.entities.Audit(comment=None, version=1, associated_id=None, remote_address=u'10.8.183.246', user=nailgun.entities.User(id=3), associated_name=None, id=1889, associated_type=None, audited_changes={u'ignore_types': [], u'label': u'YAJBwmpaky', u'name': u'HBkSxQ', u'ancestry': None, u'description': u'stYWZdGzbCBByJq'}, auditable_type=u'Organization', auditable_name=u'HBkSxQ', auditable_id=375, action=u'create')
```