### PR TITLE
allow DELETE responses with a single blank

### DIFF
--- a/nailgun/entity_mixins.py
+++ b/nailgun/entity_mixins.py
@@ -681,7 +681,7 @@ class EntityDeleteMixin(object):
         elif (response.status_code == http_client.NO_CONTENT or
               (response.status_code == http_client.OK and
                hasattr(response, 'content') and
-               not response.content)):
+               not response.content.strip())):
             # "The server successfully processed the request, but is not
             # returning any content. Usually used as a response to a successful
             # delete request."

--- a/tests/test_entity_mixins.py
+++ b/tests/test_entity_mixins.py
@@ -1060,6 +1060,39 @@ class EntityDeleteMixinTestCase(TestCase):
         ):
             self.assertEqual(self.entity.delete(), response.json.return_value)
 
+    def test_delete_v5(self):
+        """
+        What happens if the server returns an HTTP OK status and empty content?
+        """
+        response = mock.Mock()
+        response.status_code = http_client.OK
+        response.content = ''
+        with mock.patch.object(
+            entity_mixins.EntityDeleteMixin,
+            'delete_raw',
+            return_value=response,
+        ):
+            with mock.patch.object(entity_mixins, '_poll_task') as poll_task:
+                self.assertEqual(self.entity.delete(), None)
+        self.assertEqual(poll_task.call_count, 0)
+
+    def test_delete_v6(self):
+        """
+        What happens if the server returns an HTTP OK status and blank only
+        content?
+        """
+        response = mock.Mock()
+        response.status_code = http_client.OK
+        response.content = ' '
+        with mock.patch.object(
+            entity_mixins.EntityDeleteMixin,
+            'delete_raw',
+            return_value=response,
+        ):
+            with mock.patch.object(entity_mixins, '_poll_task') as poll_task:
+                self.assertEqual(self.entity.delete(), None)
+        self.assertEqual(poll_task.call_count, 0)
+
 
 class EntitySearchMixinTestCase(TestCase):
     """Tests for :class:`nailgun.entity_mixins.EntitySearchMixin`."""


### PR DESCRIPTION
sometimes DELETE returns HTTP 200 with an empty response, but it's not
really empty, but contains only a blank. strip that blank and accept
this response as empty, not trying to parse JSON from it