### PR TITLE
Added Parameter entity and Host.all_parameters field

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2945,6 +2945,7 @@ class Host(  # pylint:disable=too-many-instance-attributes
 
     def __init__(self, server_config=None, **kwargs):
         self._fields = {
+            'all_parameters': entity_fields.ListField(),
             'architecture': entity_fields.OneToOneField(Architecture),
             'build': entity_fields.BooleanField(),
             'capabilities': entity_fields.StringField(),
@@ -4300,6 +4301,64 @@ class OverrideValue(
             ignore = set()
         ignore.update(['smart_class_parameter', 'smart_variable'])
         return super(OverrideValue, self).read(entity, attrs, ignore, params)
+
+
+class Parameter(
+        Entity,
+        EntityCreateMixin,
+        EntityReadMixin):
+    """A representation of a Parameter entity."""
+
+    def __init__(self, server_config=None, **kwargs):
+        self._fields = {
+            'name': entity_fields.StringField(
+                required=True,
+                str_type='alpha',
+                length=(6, 12),
+            ),
+            'priority': entity_fields.IntegerField(),
+            'value': entity_fields.StringField(required=True),
+        }
+        self._path_fields = {
+            'domain': entity_fields.OneToOneField(Domain),
+            'host': entity_fields.OneToOneField(Host),
+            'hostgroup': entity_fields.OneToOneField(HostGroup),
+            'location': entity_fields.OneToOneField(Location),
+            'operatingsystem': entity_fields.OneToOneField(OperatingSystem),
+            'organization': entity_fields.OneToOneField(Organization),
+            'subnet': entity_fields.OneToOneField(Subnet),
+        }
+        self._fields.update(self._path_fields)
+        super(Parameter, self).__init__(server_config, **kwargs)
+        if not any(
+                getattr(self, attr, None) for attr in self._path_fields):
+            raise TypeError(
+                'A value must be provided for any of "{0}" fields.'.format(
+                    self._path_fields.keys())
+            )
+        self._parent_type = next(
+            attr for attr in self._path_fields if getattr(self, attr, None))
+        self._parent_id = getattr(self, self._parent_type).id
+        self._meta = {
+            'api_path': 'api/v2/{}s/{}/parameters'.format(
+                self._parent_type, self._parent_id),
+            'server_modes': ('sat'),
+        }
+
+    def read(self, entity=None, attrs=None, ignore=None, params=None):
+        """Ignore path related fields as they're never returned by the server
+        and are only added to entity to be able to use proper path.
+        """
+        if entity is None:
+            entity = type(self)(
+                self._server_config,
+                **{self._parent_type: self._parent_id}
+            )
+        if ignore is None:
+            ignore = set()
+        for field_name in self._path_fields:
+            ignore.add(field_name)
+        return super(Parameter, self).read(entity, attrs, ignore, params)
 
 
 class Permission(Entity, EntityReadMixin, EntitySearchMixin):

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -4306,7 +4306,9 @@ class OverrideValue(
 class Parameter(
         Entity,
         EntityCreateMixin,
-        EntityReadMixin):
+        EntityDeleteMixin,
+        EntityReadMixin,
+        EntityUpdateMixin):
     """A representation of a Parameter entity."""
 
     def __init__(self, server_config=None, **kwargs):

--- a/nailgun/entity_mixins.py
+++ b/nailgun/entity_mixins.py
@@ -510,6 +510,8 @@ class Entity(object):
         attrs.pop('_server_config')
         attrs.pop('_fields')
         attrs.pop('_meta')
+        if '_path_fields' in attrs:
+            attrs.pop('_path_fields')
         return attrs
 
     def __repr__(self):
@@ -521,6 +523,7 @@ class Entity(object):
                 u'{0}={1}'.format(key, repr(value))
                 for key, value
                 in self.get_values().items()
+                if not key.startswith('_')
             )
         )
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -186,6 +186,13 @@ class InitTestCase(TestCase):
             (entities.OperatingSystemParameter, {'operatingsystem': 1}),
             (entities.OverrideValue, {'smart_class_parameter': 1}),
             (entities.OverrideValue, {'smart_variable': 1}),
+            (entities.Parameter, {'domain': 1}),
+            (entities.Parameter, {'host': 1}),
+            (entities.Parameter, {'hostgroup': 1}),
+            (entities.Parameter, {'location': 1}),
+            (entities.Parameter, {'operatingsystem': 1}),
+            (entities.Parameter, {'organization': 1}),
+            (entities.Parameter, {'subnet': 1}),
             (entities.RepositorySet, {'product': 1}),
             (entities.SyncPlan, {'organization': 1}),
         ])
@@ -219,6 +226,7 @@ class InitTestCase(TestCase):
                 entities.Image,
                 entities.OverrideValue,
                 entities.OperatingSystemParameter,
+                entities.Parameter,
                 entities.RepositorySet,
                 entities.SyncPlan,
         ):
@@ -991,6 +999,13 @@ class ReadTestCase(TestCase):
                 entities.OperatingSystemParameter(self.cfg, operatingsystem=2),
                 entities.OverrideValue(self.cfg, smart_class_parameter=2),
                 entities.OverrideValue(self.cfg, smart_variable=2),
+                entities.Parameter(self.cfg, domain=2),
+                entities.Parameter(self.cfg, host=2),
+                entities.Parameter(self.cfg, hostgroup=2),
+                entities.Parameter(self.cfg, location=2),
+                entities.Parameter(self.cfg, operatingsystem=2),
+                entities.Parameter(self.cfg, organization=2),
+                entities.Parameter(self.cfg, subnet=2),
                 entities.RepositorySet(self.cfg, product=2),
                 entities.SyncPlan(self.cfg, organization=2),
         ):
@@ -1198,6 +1213,29 @@ class ReadTestCase(TestCase):
                             self.cfg, id=2, host=2, type=input_type).read()
                 # `call_args` is a two-tuple of (positional, keyword) args.
                 self.assertEqual(actual_ignore, read.call_args[0][2])
+
+    def test_parameter_ignore_arg(self):
+        """Call :meth:`nailgun.entities.Parameter.read`.
+
+        Assert that entity`s predefined values of ``ignore`` are always
+        correctly passed on.
+        """
+        parents = {
+            'domain', 'host', 'hostgroup', 'location', 'operatingsystem',
+            'organization', 'subnet'
+        }
+        for parent in parents:
+            with self.subTest(parent):
+                with mock.patch.object(EntityReadMixin, 'read') as read:
+                    with mock.patch.object(
+                        EntityReadMixin,
+                        'read_json',
+                        return_value={parent: 3},
+                    ):
+                        entities.Parameter(
+                            self.cfg, id=2, **{parent: 3}).read()
+                # `call_args` is a two-tuple of (positional, keyword) args.
+                self.assertEqual(parents, read.call_args[0][2])
 
     def test_host_with_interface(self):
         """Call :meth:`nailgun.entities.Host.read`.

--- a/tests/test_entity_mixins.py
+++ b/tests/test_entity_mixins.py
@@ -338,6 +338,29 @@ class EntityTestCase(TestCase):
                 values,
             )
 
+    def test_entity_get_values_v2(self):
+        """Test :meth:`nailgun.entity_mixins.Entity.get_values`, ensure
+        ``_path_fields`` are never returned.
+        """
+        for values in (
+                {},
+                {'id': gen_integer()},
+                {'name': gen_integer()},
+                {'number': gen_integer()},
+                {'name': gen_integer(), 'number': gen_integer()},
+                {
+                    'id': gen_integer(),
+                    'name': gen_integer(),
+                    'number': gen_integer(),
+                },
+        ):
+            entity = SampleEntity(self.cfg, **values)
+            entity._path_fields = {'foo': 1}
+            self.assertEqual(
+                entity.get_values(),
+                values,
+            )
+
     def test_path(self):
         """Test :meth:`nailgun.entity_mixins.Entity.path`."""
         # e.g. 'https://sat.example.com/katello/api/v2'

--- a/tests/test_entity_mixins.py
+++ b/tests/test_entity_mixins.py
@@ -355,6 +355,7 @@ class EntityTestCase(TestCase):
                 },
         ):
             entity = SampleEntity(self.cfg, **values)
+            # pylint:disable=protected-access,attribute-defined-outside-init
             entity._path_fields = {'foo': 1}
             self.assertEqual(
                 entity.get_values(),


### PR DESCRIPTION
```python
In [4]: entities.Host(id=46).read().all_parameters

Out[4]:
[{u'created_at': u'2017-09-21 16:13:39 UTC',
  u'id': 52,
  u'name': u'qfjO9vcs69',
  u'priority': 20,
  u'updated_at': u'2017-09-21 16:13:39 UTC',
  u'value': u'WN35rcRpbQ'},
 {u'created_at': u'2017-09-21 16:13:16 UTC',
  u'id': 51,
  u'name': u'4ZRqG21c79',
  u'priority': 10,
  u'updated_at': u'2017-09-21 16:13:16 UTC',
  u'value': u'tU0wjkFVqP'}]

In [5]: entities.Parameter(id=51, organization=126).read()

Out[5]: nailgun.entities.Parameter(value=u'tU0wjkFVqP', priority=10, organization=nailgun.entities.Organization(id=126), id=51, name=u'4ZRqG21c79')

In [9]: entities.Parameter(id=51, organization=126, name='foo', value='bar').cre
   ...: ate()

Out[9]: nailgun.entities.Parameter(value=u'bar', priority=10, organization=nailgun.entities.Organization(id=126), id=53, name=u'foo')
```