### PR TITLE
Automated PyPI deployment based on tagged releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,15 @@ after_success:
     coveralls
 notifications:
     irc: "chat.freenode.net#robottelo"
+
+before_deploy: "echo 'Starting deploy to PyPI...'"
+deploy:
+  provider: pypi
+  user: katelloqa
+  password: $PYPI_PASSWORD
+  distributions: "sdist bdist_wheel"
+  on:
+    condition: $TRAVIS_PYTHON_VERSION == "2.7"
+    tags: true
+    branch: master
+after_deploy: "echo 'Deployment finished!'"


### PR DESCRIPTION
When a tagged commit (e.g: new release on github UI) is done
travis will perform the release to PyPI.

NOTE: The release will only happen if the version is increased.
and also the build passed and only for tagged commits `git push --tags` or UI release is created,