### PR TITLE
filter urllib3.exceptions not requests.urllib3.exceptions

### DIFF
--- a/nailgun/client.py
+++ b/nailgun/client.py
@@ -19,6 +19,7 @@ from json import dumps
 from warnings import simplefilter
 import logging
 import requests
+import urllib3
 
 
 logger = logging.getLogger(__name__)  # pylint:disable=invalid-name
@@ -48,7 +49,7 @@ logger = logging.getLogger(__name__)  # pylint:disable=invalid-name
 # pylint:disable=no-member
 simplefilter(
     'ignore',
-    requests.urllib3.exceptions.InsecureRequestWarning,
+    urllib3.exceptions.InsecureRequestWarning,
 )
 
 


### PR DESCRIPTION
requests.urllib3 exists when you install requests via pip, but it should
not. and it does not exist when you install requests via rpm/deb.

thus let's filter the warnings directly from the urllib3 namespace, thus
making stuff work regardless how requests was installed