### PR TITLE
[6.2.z] Backport Host's errata_apply and install_content helpers

### DIFF
--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -292,6 +292,7 @@ class PathTestCase(TestCase):
                 (entities.ContentView, 'publish'),
                 (entities.ContentViewVersion, 'promote'),
                 (entities.Environment, 'smart_class_parameters'),
+                (entities.Host, 'errata/apply'),
                 (entities.Host, 'smart_class_parameters'),
                 (entities.Host, 'puppetclass_ids'),
                 (entities.Host, 'smart_class_parameters'),
@@ -333,6 +334,7 @@ class PathTestCase(TestCase):
                 (entities.ForemanTask, 'bulk_resume'),
                 (entities.ForemanTask, 'bulk_search'),
                 (entities.ForemanTask, 'summary'),
+                (entities.Host, 'bulk/install_content'),
         ):
             with self.subTest((entity, which)):
                 path = entity(self.cfg).path(which)
@@ -1527,6 +1529,8 @@ class GenericTestCase(TestCase):
                 'get'
             ),
             (entities.Host(**generic).add_puppetclass, 'post'),
+            (entities.Host(**generic).errata_apply, 'put'),
+            (entities.Host(**generic).install_content, 'put'),
             (entities.Host(**generic).list_scparams, 'get'),
             (entities.Host(**generic).list_smart_variables, 'get'),
             (entities.HostGroup(**generic).clone, 'post'),


### PR DESCRIPTION
Since errata and packages installations can't be done 1-linear easily, pls refer to SatelliteQE/robottelo#5575 to see test results. Results of calling `errata_apply()` and `install_content()` in robottelo.log:
<details>
  <summary>robottelo.log</summary>

```
2017-11-14 19:05:47 - nailgun.client - DEBUG - Making HTTP PUT request to https://example.com/api/v2/hosts/5/errata/apply with options {'verify': False, 'auth': ('admin', 'changeme'), 'headers': {'content-type': 'application/json'}} and data {"errata_ids": ["RHEA-2012:0056"]}.
2017-11-14 19:05:48 - nailgun.client - DEBUG - Received HTTP 202 response:   {"id":"54ee31a3-ab4a-41d2-9411-891a8ee123f9","label":"Actions::Katello::Host::Erratum::Install","pending":true,"username":"admin","started_at":"2017-11-14 17:05:48 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"host":{"id":5,"name":"example2.com"},"errata":["RHEA-2012:0056"],"services_checked":["pulp","pulp_auth"]},"output":{},"humanized":{"action":"Install erratum","input":["RHEA-2012:0056"],"output":"","errors":[]},"cli_example":null}

2017-11-14 19:05:48 - nailgun.client - DEBUG - Making HTTP GET request to https://example.com/foreman_tasks/api/tasks/54ee31a3-ab4a-41d2-9411-891a8ee123f9 with options {'verify': False, 'auth': ('admin', 'changeme'), 'headers': {'content-type': 'application/json'}} and no data.
2017-11-14 19:05:49 - nailgun.client - DEBUG - Received HTTP 200 response: {"id":"54ee31a3-ab4a-41d2-9411-891a8ee123f9","label":"Actions::Katello::Host::Erratum::Install","pending":true,"username":"admin","started_at":"2017-11-14 17:05:48 UTC","ended_at":null,"state":"running","result":"pending","progress":0.25,"input":{"host":{"id":5,"name":"example2.com"},"errata":["RHEA-2012:0056"],"services_checked":["pulp","pulp_auth"]},"output":{},"humanized":{"action":"Install erratum","input":["RHEA-2012:0056"],"output":"","errors":[]},"cli_example":null}
2017-11-14 19:05:54 - nailgun.client - DEBUG - Making HTTP GET request to https://example.com/foreman_tasks/api/tasks/54ee31a3-ab4a-41d2-9411-891a8ee123f9 with options {'verify': False, 'auth': ('admin', 'changeme'), 'headers': {'content-type': 'application/json'}} and no data.
2017-11-14 19:05:55 - nailgun.client - DEBUG - Received HTTP 200 response: {"id":"54ee31a3-ab4a-41d2-9411-891a8ee123f9","label":"Actions::Katello::Host::Erratum::Install","pending":true,"username":"admin","started_at":"2017-11-14 17:05:48 UTC","ended_at":null,"state":"running","result":"pending","progress":0.25,"input":{"host":{"id":5,"name":"example2.com"},"errata":["RHEA-2012:0056"],"services_checked":["pulp","pulp_auth"]},"output":{},"humanized":{"action":"Install erratum","input":["RHEA-2012:0056"],"output":"","errors":[]},"cli_example":null}
2017-11-14 19:06:00 - nailgun.client - DEBUG - Making HTTP GET request to https://example.com/foreman_tasks/api/tasks/54ee31a3-ab4a-41d2-9411-891a8ee123f9 with options {'verify': False, 'auth': ('admin', 'changeme'), 'headers': {'content-type': 'application/json'}} and no data.
2017-11-14 19:06:01 - nailgun.client - DEBUG - Received HTTP 200 response: {"id":"54ee31a3-ab4a-41d2-9411-891a8ee123f9","label":"Actions::Katello::Host::Erratum::Install","pending":false,"username":"admin","started_at":"2017-11-14 17:05:48 UTC","ended_at":"2017-11-14 17:05:58 UTC","state":"stopped","result":"success","progress":1.0,"input":{"host":{"id":5,"name":"example2.com"},"errata":["RHEA-2012:0056"],"services_checked":["pulp","pulp_auth"]},"output":{},"humanized":{"action":"Install erratum","input":["RHEA-2012:0056"],"output":"crow-0.8-1.noarch\nduck-0.6-1.noarch\nstork-0.12-2.noarch","errors":[]},"cli_example":null}



2017-11-14 19:53:40 - nailgun.client - DEBUG - Making HTTP PUT request to https://example.com/api/v2/hosts/bulk/install_content with options {'verify': False, 'auth': ('admin', 'changeme'), 'headers': {'content-type': 'application/json'}} and data {"organization_id": 8, "included": {"ids": [6]}, "content": ["bear-4.0-1.noarch"], "content_type": "package"}.
2017-11-14 19:53:41 - nailgun.client - DEBUG - Received HTTP 200 response:   {}
```
</details>
