### PR TITLE
Remove org from sync_plan api_path

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -6170,7 +6170,6 @@ class SyncPlan(
     """
 
     def __init__(self, server_config=None, **kwargs):
-        _check_for_value('organization', kwargs)
         self._fields = {
             'description': entity_fields.StringField(),
             'enabled': entity_fields.BooleanField(required=True),
@@ -6192,9 +6191,13 @@ class SyncPlan(
             'sync_date': entity_fields.DateTimeField(required=True),
         }
         super(SyncPlan, self).__init__(server_config, **kwargs)
-        self._meta = {
+        try:
             # pylint:disable=no-member
-            'api_path': '{0}/sync_plans'.format(self.organization.path()),
+            path_prefix = self.organization.path()
+        except AttributeError:
+            path_prefix = '/katello/api'
+        self._meta = {
+            'api_path': '{0}/sync_plans'.format(path_prefix),
         }
 
     def read(self, entity=None, attrs=None, ignore=None, params=None):

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -232,7 +232,6 @@ class InitTestCase(TestCase):
                 entities.OSDefaultTemplate,
                 entities.Parameter,
                 entities.RepositorySet,
-                entities.SyncPlan,
         ):
             with self.subTest():
                 with self.assertRaises(TypeError):
@@ -455,6 +454,10 @@ class PathTestCase(TestCase):
         self.assertIn(
             'organizations/1/sync_plans/2',
             entities.SyncPlan(self.cfg, id=2, organization=1).path()
+        )
+        self.assertIn(
+            'katello/api/sync_plans/2',
+            entities.SyncPlan(self.cfg, id=2).path()
         )
         for which in ('add_products', 'remove_products'):
             path = entities.SyncPlan(


### PR DESCRIPTION
This fixes:

```
from nailgun import entities, entity_fields
from nailgun.config import ServerConfig

server = ServerConfig(
             url=server_url,
             auth=(username, password),
             verify=False
         )
org = entities.Organization(server).search()[0]
entities.Product(server,name='Red Hat Enterprise Linux Server', organization=org ).search()
Traceback (most recent call last):
  File "tt.py", line 15, in <module>
    entities.Product(server,name='Red Hat Enterprise Linux Server', organization=org ).search()
  File "/usr/lib/python2.7/site-packages/blinker_herald/base.py", line 137, in wrapper
    result = fn(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/nailgun/entity_mixins.py", line 1363, in search
    for result in results
  File "/usr/lib/python2.7/site-packages/nailgun/entities.py", line 4368, in __init__
    super(Product, self).__init__(server_config, **kwargs)
  File "/usr/lib/python2.7/site-packages/nailgun/entity_mixins.py", line 415, in __init__
    self._server_config
  File "/usr/lib/python2.7/site-packages/nailgun/entity_mixins.py", line 138, in _make_entity_from_id
    return entity_cls(server_config, id=entity_obj_or_id)
  File "/usr/lib/python2.7/site-packages/nailgun/entities.py", line 5884, in __init__
    _check_for_value('organization', kwargs)
  File "/usr/lib/python2.7/site-packages/nailgun/entities.py", line 155, in _check_for_value
    'A value must be provided for the "{0}" field.'.format(field_name)
TypeError: A value must be provided for the "organization" field.