### PR TITLE
Host errata applicability

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -3005,7 +3005,7 @@ class HostSubscription(Entity):
         }
 
 
-class Host(  # pylint:disable=too-many-instance-attributes
+class Host(  # pylint:disable=too-many-instance-attributes,R0904
         Entity,
         EntityCreateMixin,
         EntityDeleteMixin,
@@ -3287,6 +3287,23 @@ class Host(  # pylint:disable=too-many-instance-attributes
         response = client.get(self.path('errata'), **kwargs)
         return _handle_response(response, self._server_config, synchronous)
 
+    def errata_applicability(self, synchronous=True, **kwargs):
+        """Force regenerate errata applicability
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all content decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+
+        """
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.put(self.path('errata/applicability'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous)
+
     def errata_apply(self, synchronous=True, **kwargs):
         """Schedule errata for installation
 
@@ -3454,6 +3471,7 @@ class Host(  # pylint:disable=too-many-instance-attributes
                 'enc',
                 'errata',
                 'errata/apply',
+                'errata/applicability',
                 'facts',
                 'power',
                 'puppetclass_ids',

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -317,6 +317,7 @@ class PathTestCase(TestCase):
                 (entities.Host, 'enc'),
                 (entities.Host, 'errata'),
                 (entities.Host, 'errata/apply'),
+                (entities.Host, 'errata/applicability'),
                 (entities.Host, 'puppetclass_ids'),
                 (entities.Host, 'smart_class_parameters'),
                 (entities.Host, 'smart_variables'),


### PR DESCRIPTION
Force regenerate errata applicability
```bash
In[15]: org = entities.Organization(conf).create(create_missing=True)
In[16]: host = entities.Host(conf, organization=org).create(create_missing=True)
In[17]: host.errata_applicability()
Out[17]: 
{u'cli_example': None,
 u'ended_at': u'2017-11-28 09:38:19 UTC',
 u'humanized': {u'action': u'Generate applicability',
  u'errors': [],
  u'input': u'{"current_user_id"=>3}\n',
  u'output': u''},
 u'id': u'8d672137-f81f-4b2c-8184-537e100e49c7',
 u'input': {u'current_user_id': 3},
 u'label': u'Actions::Katello::Host::GenerateApplicability',
 u'output': {},
 u'pending': False,
 u'progress': 1,
 u'result': u'success',
 u'started_at': u'2017-11-28 09:38:19 UTC',
 u'state': u'stopped',
 u'username': u'admin'}
In[18]: host.errata()
Out[18]: 
{u'error': None,
 u'page': 1,
 u'per_page': 20,
 u'results': [],
 u'search': None,
 u'sort': {u'by': u'updated_at', u'order': u'desc'},
 u'subtotal': 0,
 u'total': 0}
```