### PR TITLE
Search subs

### DIFF
--- a/nailgun/entity_mixins.py
+++ b/nailgun/entity_mixins.py
@@ -281,7 +281,10 @@ def _get_entity_ids(field_name, attrs):
     elif field_name in attrs:
         return [entity['id'] for entity in attrs[field_name]]
     elif plural_field_name in attrs:
-        return [entity['id'] for entity in attrs[plural_field_name]]
+        try:
+            return [entity['id'] for entity in attrs[plural_field_name]]
+        except KeyError:
+            return [entity['host_id'] for entity in attrs[plural_field_name]]
     else:
         raise MissingValueError(
             'Cannot find a value for the "{0}" field. Searched for keys named '


### PR DESCRIPTION
This fixes

```
[root@katello ~]# cat tt.py 
from nailgun import entities, entity_fields
from nailgun.config import ServerConfig

server = ServerConfig(
             url=server_url,
             auth=(username, password),
             verify=False
         )
org = entities.Organization(server).search()[0]
entities.Subscription(server, organization=org).search(query={'search': 'name="Red Hat OpenShift Container Platform, Standard (1-2 Sockets)"'})[0].read()
[root@katello ~]# python tt.py 
Traceback (most recent call last):
  File "tt.py", line 15, in <module>
    entities.Subscription(server, organization=org).search(query={'search': 'name="Red Hat OpenShift Container Platform, Standard (1-2 Sockets)"'})[0].read()
  File "/usr/lib/python2.7/site-packages/nailgun/entities.py", line 5809, in read
    return super(Subscription, self).read(entity, attrs, ignore, params)
  File "/usr/lib/python2.7/site-packages/nailgun/entity_mixins.py", line 812, in read
    in _get_entity_ids(field_name, attrs)
  File "/usr/lib/python2.7/site-packages/nailgun/entity_mixins.py", line 284, in _get_entity_ids
    return [entity['id'] for entity in attrs[plural_field_name]]
KeyError: 'id'
```