### PR TITLE
Subscription entity no longer contains content host info

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -5994,7 +5994,6 @@ class Subscription(
             'provided_product': entity_fields.OneToManyField(Product),
             'quantity': entity_fields.IntegerField(),
             'subscription': entity_fields.OneToOneField(Subscription),
-            'system': entity_fields.OneToManyField(Host),
         }
         self._meta = {
             'api_path': 'katello/api/v2/subscriptions',


### PR DESCRIPTION
Issue #451 

Results 

Before

```
>>> from nailgun.entities import Subscription
>>> from nailgun.config import ServerConfig
>>> server_config = ServerConfig(auth=('admin', 'password'),url='http://satellite',verify=False)
>>> org_sub = Subscription(organization='xSxOhmTVNGpG').search()
>>> org_sub[0].read()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "nailgun/entities.py", line 6097, in read
    return super(Subscription, self).read(entity, attrs, ignore, params)
  File "nailgun/entity_mixins.py", line 815, in read
    in _get_entity_ids(field_name, attrs)
  File "nailgun/entity_mixins.py", line 292, in _get_entity_ids
    attrs.keys()
nailgun.entity_mixins.MissingValueError: Cannot find a value for the "system" field. Searched for keys named ('system_ids', 'system', 'systems'), but available keys are [u'host_count', u'support_level', u'ram', u'sockets', u'cp_id', u'provided_products', u'virt_only', u'support_type', u'id', u'virt_who', u'subscription_id', u'type', u'contract_number', u'available', u'description', u'end_date', u'multi_entitlement', u'arch', u'name', u'product_id', u'unmapped_guest', u'product_name', u'consumed', u'start_date', u'instance_multiplier', u'stacking_id', u'account_number', u'activation_keys', u'cores', u'quantity'].
>>>
```
After

```
>>> org_sub[0].read()
nailgun.entities.Subscription(activation_key=[], name=u'Red Hat Enterprise Linux for Virtual Datacenters, Premium', provided_product=[nailgun.entities.Product(id=1), nailgun.entities.Product(id=2), nailgun.entities.Product(id=3), nailgun.entities.Product(id=4), nailgun.entities.Product(id=5), nailgun.entities.Product(id=6), nailgun.entities.Product(id=7), nailgun.entities.Product(id=9), nailgun.entities.Product(id=10), nailgun.entities.Product(id=11), nailgun.entities.Product(id=13), nailgun.entities.Product(id=14), nailgun.entities.Product(id=15), nailgun.entities.Product(id=17), nailgun.entities.Product(id=18), nailgun.entities.Product(id=19), nailgun.entities.Product(id=20), nailgun.entities.Product(id=21), nailgun.entities.Product(id=22), nailgun.entities.Product(id=23), nailgun.entities.Product(id=24)], id=1, quantity=50, subscription=nailgun.entities.Subscription(id=1))
>>>
```
