### PR TITLE
Fix Host search that fail when host contain image

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -3589,6 +3589,41 @@ class Host(  # pylint:disable=too-many-instance-attributes,R0904
         response = client.put(self.path('power'), **kwargs)
         return _handle_response(response, self._server_config, synchronous)
 
+    @signals.emit(sender=signals.SENDER_CLASS, post_result_name='entities')
+    def search(self, fields=None, query=None, filters=None):
+        """Search for entities.
+
+        :param fields: A set naming which fields should be used when generating
+            a search query. If ``None``, all values on the entity are used. If
+            an empty set, no values are used.
+        :param query: A dict containing a raw search query. This is melded in
+            to the generated search query like so:  ``{generated:
+            query}.update({manual: query})``.
+        :param filters: A dict. Used to filter search results locally.
+        :return: A list of entities, all of type ``type(self)``.
+        """
+        results = self.search_json(fields, query)['results']
+        results = self.search_normalize(results)
+        entities = []
+        for result in results:
+            image = result.get('image')
+            if image is not None:
+                del result['image']
+            entity = type(self)(self._server_config, **result)
+            if image:
+                entity.image = Image(
+                    server_config=self._server_config,
+                    id=image,
+                    compute_resource=AbstractComputeResource(
+                        server_config=self._server_config,
+                        id=result.get('compute_resource')
+                    ),
+                )
+            entities.append(entity)
+        if filters is not None:
+            entities = self.search_filter(entities, filters)
+        return entities
+
 
 class Image(
         Entity,


### PR DESCRIPTION
This behavior cause all robottelo RHEV provisioning hosts with images tests to fail when searching for hosts (especially on teardown when searching for the provisioned hosts to delete).
```bash
In[2]: from nailgun import entities, config
In[3]: conf = config.ServerConfig('XXXXXXXXXXXXXXXXXXX', auth=('admin', 'changeme'), verify=False)
In[4]: hosts = entities.Host(conf).search(query=dict(search='name="annie-odear.sjlpfazwcj.mbz"'))
In[5]: len(hosts)
Out[5]: 1
In[6]: hosts[0]
Out[6]: nailgun.entities.Host(comment=u'', domain=nailgun.entities.Domain(id=10), managed=True, content_facet_attributes={u'content_view_id': 11, u'content_view_name': u'Default Organization View', u'content_source_id': None, u'kickstart_repository_id': None, u'uuid': None, u'content_view': {u'id': 11, u'name': u'Default Organization View'}, u'lifecycle_environment_name': u'Library', u'applicable_package_count': 0, u'lifecycle_environment': {u'id': 11, u'name': u'Library'}, u'upgradable_package_count': 0, u'lifecycle_environment_id': 11, u'content_source_name': None, u'content_source': None, u'id': 6, u'errata_counts': {u'bugfix': 0, u'security': 0, u'total': 0, u'enhancement': 0}}, ip=None, image=nailgun.entities.Image(compute_resource=nailgun.entities.AbstractComputeResource(id=7), id=7), provision_method=u'image', compute_resource=nailgun.entities.AbstractComputeResource(id=7), owner=nailgun.entities.User(id=3), id=7, subnet=None, realm=None, capabilities=[u'build', u'image', u'new_volume'], operatingsystem=nailgun.entities.OperatingSystem(id=1), environment=None, location=nailgun.entities.Location(id=22), puppet_ca_proxy=None, ptable=None, build=True, medium=None, compute_profile=nailgun.entities.ComputeProfile(id=1), mac=u'00:1a:4a:3e:a6:3a', puppet_proxy=None, owner_type=u'User', name=u'annie-odear.sjlpfazwcj.mbz', enabled=True, hostgroup=nailgun.entities.HostGroup(id=9), architecture=nailgun.entities.Architecture(id=1), organization=nailgun.entities.Organization(id=21), model=None)
In[7]: host = hosts[0]
In[8]: host.compute_resource
Out[8]: nailgun.entities.AbstractComputeResource(id=7)
In[9]: host.compute_resource.read()
Out[9]: nailgun.entities.AbstractComputeResource(description=u'', url=u'https://rhevm1.satellite.lab.eng.rdu2.redhat.com/api', provider_friendly_name=u'RHEV', location=[nailgun.entities.Location(id=22)], provider=u'Ovirt', organization=[nailgun.entities.Organization(id=1), nailgun.entities.Organization(id=21)], id=7, name=u'yiAeQOmCq')
In[10]: host.image
Out[10]: nailgun.entities.Image(compute_resource=nailgun.entities.AbstractComputeResource(id=7), id=7)
In[11]: host.image.read()
Out[11]: nailgun.entities.Image(username=u'root', uuid=u'09b7babe-4514-4585-9dcc-fbfef071256d', compute_resource=nailgun.entities.AbstractComputeResource(id=7), operatingsystem=nailgun.entities.OperatingSystem(id=1), architecture=nailgun.entities.Architecture(id=1), id=7, name=u'xOYpL')
In[12]: host.image.compute_resource
Out[12]: nailgun.entities.AbstractComputeResource(id=7)
In[13]: host.image.compute_resource.read()
Out[13]: nailgun.entities.AbstractComputeResource(description=u'', url=u'https://rhevm1.satellite.lab.eng.rdu2.redhat.com/api', provider_friendly_name=u'RHEV', location=[nailgun.entities.Location(id=22)], provider=u'Ovirt', organization=[nailgun.entities.Organization(id=1), nailgun.entities.Organization(id=21)], id=7, name=u'yiAeQOmCq')
```