### PR TITLE
Add `network_type` and `remote_execution_proxy` fields to Subnet

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -5996,7 +5996,13 @@ class Subnet(
                     default=u'DHCP',
                 ),
                 'location': entity_fields.OneToManyField(Location),
+                'network_type': entity_fields.StringField(
+                    choices=('IPv4', 'IPv6'),
+                    default='IPv4',
+                ),
                 'organization': entity_fields.OneToManyField(Organization),
+                'remote_execution_proxy':
+                    entity_fields.OneToManyField(SmartProxy),
                 'subnet_parameters_attributes': entity_fields.ListField(),
                 'tftp': entity_fields.OneToOneField(SmartProxy),
             })
@@ -6028,6 +6034,7 @@ class Subnet(
         else:
             ignore.add('subnet_parameters_attributes')
         ignore.add('discovery')
+        ignore.add('remote_execution_proxy')
         return super(Subnet, self).read(entity, attrs, ignore, params)
 
     def update_payload(self, fields=None):

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1163,7 +1163,9 @@ class ReadTestCase(TestCase):
                 (entities.SmartClassParameters, {'hidden_value'}),
                 (entities.SmartVariable, {'hidden_value'}),
                 (entities.Subnet, {
-                    'discovery', 'subnet_parameters_attributes'}),
+                    'discovery',
+                    'remote_execution_proxy',
+                    'subnet_parameters_attributes'}),
                 (entities.Subscription, {'organization'}),
                 (entities.Repository, {'organization'}),
                 (entities.User, {'password'}),


### PR DESCRIPTION
```python
In [2]: sn = entities.Subnet(network_type='IPv4', network='255.255.255.0', remot
   ...: e_execution_proxy=[1]).create()

In [3]: sn
Out[3]: nailgun.entities.Subnet(dns_primary=None, domain=[], name=u'cVinKe', organization=[], cidr=5, id=33, boot_mode=u'DHCP', dns_secondary=None, from=None, network=u'255.255.255.0', subnet_parameters_attributes=[], to=None, ipam=u'None', mask=u'248.0.0.0', vlanid=None, gateway=None, location=[], dns=None, dhcp=None, tftp=None, network_type=u'IPv4')

In [4]: sn.network_type
Out[4]: u'IPv4'
```