### PR TITLE
Add `network_type` and `remote_execution_proxy` fields to Subnet (#477)

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -5096,7 +5096,14 @@ class Subnet(
                     default=u'DHCP',
                 ),
                 'location': entity_fields.OneToManyField(Location),
+                'network_type': entity_fields.StringField(
+                    choices=('IPv4', 'IPv6'),
+                    default='IPv4',
+                ),
                 'organization': entity_fields.OneToManyField(Organization),
+                'remote_execution_proxy':
+                    entity_fields.OneToManyField(SmartProxy),
+                'subnet_parameters_attributes': entity_fields.ListField(),
                 'tftp': entity_fields.OneToOneField(SmartProxy),
             })
         self._meta = {'api_path': 'api/v2/subnets', 'server_modes': ('sat')}
@@ -5123,7 +5130,8 @@ class Subnet(
         if ignore is None:
             ignore = set()
         ignore.add('discovery')
-        return super(Subnet, self).read(entity, attrs, ignore)
+        ignore.add('remote_execution_proxy')
+        return super(Subnet, self).read(entity, attrs, ignore, params)
 
     def update_payload(self, fields=None):
         """Wrap submitted data within an extra dict."""

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1071,9 +1071,17 @@ class ReadTestCase(TestCase):
         Assert that the ``ignore`` argument is correctly passed on.
 
         """
-        for entity_class, ignored_attrs in (
-                (entities.SmartVariable, {'variable_type'}),
-                (entities.Subnet, {'discovery'}),
+        for entity, ignored_attrs in (
+                (entities.Errata,
+                 {'content_view_version', 'environment', 'repository'}),
+                (entities.OVirtComputeResource, {'password'}),
+                (entities.SmartProxy, {'download_policy'}),
+                (entities.SmartClassParameters, {'hidden_value'}),
+                (entities.SmartVariable, {'hidden_value'}),
+                (entities.Subnet, {
+                    'discovery',
+                    'remote_execution_proxy',
+                    'subnet_parameters_attributes'}),
                 (entities.Subscription, {'organization'}),
                 (entities.User, {'password'}),
         ):


### PR DESCRIPTION
backporting changes introduced by https://github.com/SatelliteQE/nailgun/pull/477