### PR TITLE
don't install tests into the binary distribution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
     ],
-    packages=find_packages(),
+    packages=find_packages(exclude=['docs', 'tests']),
     install_requires=[
         'fauxfactory',
         'inflection',


### PR DESCRIPTION
this tries to install a "tests" python package, which we don't own.
at the same time, also exclude docs and contrib as done in the PyPA
sample project [1]

[1] https://github.com/pypa/sampleproject/blob/master/setup.py