### PR TITLE
create_missing only if explicitly True

### DIFF
--- a/nailgun/entity_mixins.py
+++ b/nailgun/entity_mixins.py
@@ -907,7 +907,7 @@ class EntityCreateMixin(object):
         """
         if create_missing is None:
             create_missing = CREATE_MISSING
-        if create_missing:
+        if create_missing is True:
             self.create_missing()
         return client.post(
             self.path('base'),


### PR DESCRIPTION
Current create_missing will run if any non-negative value is passed in.
This change will make it run only if the user passes in True.
This shouldn't affect 'normal' usage, but rizza exploits this to abuse create_missing.
Example:
Executing: ActivationKey create with fields: {} and args {'create_missing': 'e9e5490b-6596-4f1f-817e-11c445c76d63'}