### PR TITLE
Fix fauxfactory compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
     - 2.7
     - 3.4
 install:
-    - pip install -r requirements.txt -r requirements-dev.txt
+    - pip install -r requirements.txt -r requirements-dev.txt --no-cache-dir
 script:
     - make lint
     - make test-coverage

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ For more information, see:
 * https://docs.python.org/distutils/sourcedist.html
 
 """
+import sys
 from setuptools import find_packages, setup  # prefer setuptools over distutils
 
 
@@ -16,6 +17,21 @@ with open('README.rst') as handle:
 
 with open('VERSION') as handle:
     VERSION = handle.read().strip()
+
+requirements = [
+    'inflection',
+    'packaging',
+    'pyxdg',
+    'requests>=2.7',
+    'blinker_herald'
+]
+
+
+if sys.version_info >= (3, 0):
+    requirements.append('fauxfactory')
+else:
+    # Fauxfactory 3.0+ dropped support for Python 2.x
+    requirements.append('fauxfactory<3.0')
 
 
 setup(
@@ -38,12 +54,5 @@ setup(
         'Programming Language :: Python :: 3.4',
     ],
     packages=find_packages(exclude=['docs', 'tests']),
-    install_requires=[
-        'fauxfactory',
-        'inflection',
-        'packaging',
-        'pyxdg',
-        'requests>=2.7',
-        'blinker_herald'
-    ],
+    install_requires=requirements,
 )


### PR DESCRIPTION
Fix travis Ci error.

Fauxfactory now dropped support for Python 2.x

We need to ensure the corrent pinned version in nailgun before release.