### PR TITLE
[WIP] [DNM] Added support for api/v2/organizations/:id:/upstream_subscriptions

### DIFF
--- a/nailgun/entity_mixins.py
+++ b/nailgun/entity_mixins.py
@@ -718,7 +718,7 @@ class EntityReadMixin(object):
     def read_raw(self, params=None):
         """Get information about the current entity.
 
-        Make an HTTP PUT call to ``self.path('self')``. Return the response.
+        Make an HTTP GET call to ``self.path('self')``. Return the response.
 
         :return: A ``requests.response`` object.
 


### PR DESCRIPTION
> NOTE: This implementation is blocked by BZ [1585425](https://bugzilla.redhat.com/show_bug.cgi?id=1585425) because curently the `GET` on upstream_subscriptions is not returning the katello local pool id.

> NOTE 2: This changes are pushed as a branch of the upstream nailgun repository to allow someone else to easily continue the work on this once the BZ is resolved.

# 1. Create Subscription Allocation

## Via API POST to /organizations/:id:/upstream_subscriptions

```bash
curl --request POST \
  --url /katello/api/v2/organizations/1/upstream_subscriptions \
  --header 'authorization: Basic YWRtaW46Y2hhbmdlbWU=' \
  --header 'content-type: application/json' \
  --header 'verify: false' \
  --data '{
    "organization_id": 1,
    "pools": [
		{
		   "id": "8a85f98c60f009560160f04571431a21",
		   "quantity": 7
	   }
	]
}'
```

> NOTE: "id": "8a85f98c60f009560160f04571431a21" is the Candlepin ID and `quantity` is the consumed quantity

**Result**: Async Task ID

## Via Nailgun

```python
from nailgun.entities import UpstreamSubscription

upsub = UpstreamSubscription(
    organization=Org(id=1),
    id="8a85f98c60f009560160f04571431a21",
    quantity=7
).create()
```

**Result**: Async Task ID

> The task creates a new Subscription Entity and allocates upstream.

**From here we use only the `local katello pool id` for operations.**

# 2. Reading Upstream upstream_subscriptions

## Via API GET to organizations/:id:/upstream_subscriptions

```bash
curl --request GET \
  --url '/katello/api/v2/organizations/1/upstream_subscriptions?page=3&per_page=10&sort_by=consumed' \
  --header 'authorization: Basic YWRtaW46Y2hhbmdlbWU=' \
  --header 'content-type: application/json' \
  --header 'verify: false' \
```
```
"results": [
		{
			"id": "8a85f98c60686a2f01606af65b102e91",  # This is the candlepin ID
			"pool_id": "6",   # This is the local katello ID
			"quantity": 400,
			"available": 382,
			"start_date": "2017-12-18T05:00:00+0000",
			"end_date": "2018-12-01T04:59:59+0000",
			"contract_number": "11549879",
			"consumed": 18,
			"product_name": "Oracle Java Add-On (Physical or Virtual Nodes)",
			"product_id": "SER0534",
			"subscription_id": "4974149"
		},
        ....
]
```

To filter results pass  `pool_ids[]=6` note that this is katello local ID

## Via Nailgun

```python
from nailgun.entities import UpstreamSubscription

UpstreamSubscription(organization=Org(id=1)).search()

```
**Result** A list of UpstreamSubscriptions

```python
[
    UpstreamSubscription(
        id='8a85f98c60686a2f01606af65b102e91',  # cp id
        organization=Org(id=1),
        subscription=Subscription(id=6),
        quantity=18  # consumed
    ),
    ...
]
```

# 3. Updating Subscription Allocation

## Via api

```bash
curl --request PUT \
  --url https://ibm-x3550m3-10.lab.eng.brq.redhat.com:443/katello/api/v2/organizations/1/upstream_subscriptions \
  --header 'authorization: Basic YWRtaW46Y2hhbmdlbWU=' \
  --header 'content-type: application/json' \
  --header 'verify: false' \
  --data '{
	"organization_id": 1,
	"pools": [
		{
		   "id": 6,
		   "quantity": 7
	   }
	]
}'
```
> NOTE: in `pools` the `id` is the local katello id (not to confuse with candlepin id). and `quantity` is the `consumed` quantity for that allocation (not confuse with total or available quantity in upstream).

## via nailgun

```python
from nailgun.entities import UpstreamSubscription

UpstreamSubscription(
    organization=Org(id=1),          # required
    subscription=Subscription(id=6), # required
    quantity=7
).update('quantity')
```


# 4. deleting

## via API

```bash
curl --request DELETE \
  --url https://ibm-x3550m3-10.lab.eng.brq.redhat.com:443/katello/api/v2/organizations/1/upstream_subscriptions \
  --header 'authorization: Basic YWRtaW46Y2hhbmdlbWU=' \
  --header 'content-type: application/json' \
  --header 'verify: false' \
  --data '{
	"organization_id": 1,
	"pool_ids": [6]
}'

```

> NOTE: pool_ids is array of local katello ids

## Via nailgun

```python
UpstreamSubscription(org=Org(id=1), subscription=Subscription(id=6)).delete()
```