### PR TITLE
Don't require content_view_version_id kwargs to CVV incremental_update()

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -1942,6 +1942,15 @@ class ContentViewVersion(
 
         """
         kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        if 'data' not in kwargs:
+            # data is required
+            kwargs['data'] = dict()
+        if 'content_view_version_environments' not in kwargs['data'] or \
+           'content_view_version_id' not in \
+           kwargs['data']['content_view_version_environments']:
+                # You dont have to pass in content_view_version_id
+                kwargs['data']['content_view_version_environments'] = \
+                    [dict(content_view_version_id=self.id)]
         kwargs.update(self._server_config.get_client_kwargs())
         response = client.post(self.path('incremental_update'), **kwargs)
         return _handle_response(response, self._server_config, synchronous)

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1837,84 +1837,137 @@ class GenericTestCase(TestCase):
         generic = {'server_config': cfg, 'id': 1}
         repo_set = {'server_config': cfg, 'id': 1, 'product': 2}
         sync_plan = {'server_config': cfg, 'id': 1, 'organization': 2}
+        kwargs = {'kwarg': gen_integer()}
+        cvv_iupdate_kwargs = {'data': {'add_content': {},
+                                       'content_view_version_environments':
+                                       [{'content_view_version_id': 1}]}}
         cls.methods_requests = (
-            (entities.AbstractDockerContainer(**generic).logs, 'get'),
-            (entities.AbstractDockerContainer(**generic).power, 'put'),
-            (entities.ActivationKey(**generic).add_host_collection, 'post'),
-            (entities.ActivationKey(**generic).add_subscriptions, 'put'),
-            (entities.ActivationKey(**generic).remove_subscriptions, 'put'),
-            (entities.ActivationKey(**generic).subscriptions, 'get'),
-            (entities.ActivationKey(**generic).content_override, 'put'),
-            (entities.ActivationKey(**generic).product_content, 'get'),
-            (entities.ActivationKey(**generic).remove_host_collection, 'put'),
+            (entities.AbstractDockerContainer(**generic).logs, 'get', kwargs),
+            (entities.AbstractDockerContainer(**generic).power, 'put', kwargs),
+            (
+                entities.ActivationKey(**generic).add_host_collection,
+                'post',
+                kwargs
+            ),
+            (
+                entities.ActivationKey(**generic).add_subscriptions,
+                'put',
+                kwargs
+            ),
+            (
+                entities.ActivationKey(**generic).remove_subscriptions,
+                'put',
+                kwargs
+            ),
+            (entities.ActivationKey(**generic).subscriptions, 'get', kwargs),
+            (
+                entities.ActivationKey(**generic).content_override,
+                'put',
+                kwargs
+            ),
+            (entities.ActivationKey(**generic).product_content, 'get', kwargs),
+            (
+                entities.ActivationKey(**generic).remove_host_collection,
+                'put',
+                kwargs
+            ),
             (
                 entities.Capsule(**generic).content_add_lifecycle_environment,
-                'post'
+                'post',
+                kwargs
             ),
-            (entities.Capsule(**generic).content_get_sync, 'get'),
+            (entities.Capsule(**generic).content_get_sync, 'get', kwargs),
             (
                 entities.Capsule(**generic).content_lifecycle_environments,
-                'get'
+                'get',
+                kwargs
             ),
-            (entities.Capsule(**generic).content_sync, 'post'),
-            (entities.ConfigTemplate(**generic).build_pxe_default, 'post'),
-            (entities.ConfigTemplate(**generic).clone, 'post'),
-            (entities.Role(**generic).clone, 'post'),
+            (entities.Capsule(**generic).content_sync, 'post', kwargs),
+            (
+                entities.ConfigTemplate(**generic).build_pxe_default,
+                'post',
+                kwargs
+            ),
+            (entities.ConfigTemplate(**generic).clone, 'post', kwargs),
+            (entities.Role(**generic).clone, 'post', kwargs),
             (
                 entities.ProvisioningTemplate(**generic).build_pxe_default,
-                'post'
+                'post',
+                kwargs
             ),
-            (entities.ProvisioningTemplate(**generic).clone, 'post'),
-            (entities.ContentView(**generic).available_puppet_modules, 'get'),
-            (entities.ContentView(**generic).copy, 'post'),
-            (entities.ContentView(**generic).publish, 'post'),
+            (entities.ProvisioningTemplate(**generic).clone, 'post', kwargs),
+            (
+                entities.ContentView(**generic).available_puppet_modules,
+                'get',
+                kwargs
+            ),
+            (entities.ContentView(**generic).copy, 'post', kwargs),
+            (entities.ContentView(**generic).publish, 'post', kwargs),
             (
                 entities.ContentViewVersion(**generic).incremental_update,
-                'post'
+                'post',
+                cvv_iupdate_kwargs
             ),
-            (entities.ContentViewVersion(**generic).promote, 'post'),
-            (entities.DiscoveredHost(cfg).facts, 'post'),
-            (entities.Environment(**generic).list_scparams, 'get'),
-            (entities.Errata(**generic).compare, 'get'),
-            (entities.ForemanTask(cfg).summary, 'get'),
+            (entities.ContentViewVersion(**generic).promote, 'post', kwargs),
+            (entities.DiscoveredHost(cfg).facts, 'post', kwargs),
+            (entities.Environment(**generic).list_scparams, 'get', kwargs),
+            (entities.Errata(**generic).compare, 'get', kwargs),
+            (entities.ForemanTask(cfg).summary, 'get', kwargs),
             (
                 entities.Organization(**generic).download_debug_certificate,
-                'get'
+                'get',
+                kwargs
             ),
-            (entities.Host(**generic).add_puppetclass, 'post'),
-            (entities.Host(**generic).enc, 'get'),
-            (entities.Host(**generic).errata, 'get'),
-            (entities.Host(**generic).errata_apply, 'put'),
-            (entities.Host(**generic).get_facts, 'get'),
-            (entities.Host(**generic).install_content, 'put'),
-            (entities.Host(**generic).list_scparams, 'get'),
-            (entities.Host(**generic).list_smart_variables, 'get'),
-            (entities.Host(**generic).power, 'put'),
-            (entities.Host(**generic).upload_facts, 'post'),
-            (entities.HostGroup(**generic).add_puppetclass, 'post'),
-            (entities.HostGroup(**generic).clone, 'post'),
-            (entities.HostGroup(**generic).list_scparams, 'get'),
-            (entities.HostGroup(**generic).list_smart_variables, 'get'),
-            (entities.Product(**generic).sync, 'post'),
-            (entities.PuppetClass(**generic).list_scparams, 'get'),
-            (entities.PuppetClass(**generic).list_smart_variables, 'get'),
-            (entities.RHCIDeployment(**generic).deploy, 'put'),
-            (entities.RecurringLogic(**generic).cancel, 'post'),
-            (entities.Repository(**generic).errata, 'get'),
-            (entities.Repository(**generic).packages, 'get'),
-            (entities.Repository(**generic).puppet_modules, 'get'),
-            (entities.Repository(**generic).remove_content, 'put'),
-            (entities.Repository(**generic).sync, 'post'),
-            (entities.RepositorySet(**repo_set).available_repositories, 'get'),
-            (entities.RepositorySet(**repo_set).disable, 'put'),
-            (entities.RepositorySet(**repo_set).enable, 'put'),
-            (entities.SmartProxy(**generic).import_puppetclasses, 'post'),
-            (entities.SmartProxy(**generic).refresh, 'put'),
-            (entities.SyncPlan(**sync_plan).add_products, 'put'),
-            (entities.SyncPlan(**sync_plan).remove_products, 'put'),
-            (entities.Template(**generic).imports, 'post'),
-            (entities.Template(**generic).exports, 'post'),
-            (entities.VirtWhoConfig(**generic).deploy_script, 'get')
+            (entities.Host(**generic).add_puppetclass, 'post', kwargs),
+            (entities.Host(**generic).enc, 'get', kwargs),
+            (entities.Host(**generic).errata, 'get', kwargs),
+            (entities.Host(**generic).errata_apply, 'put', kwargs),
+            (entities.Host(**generic).get_facts, 'get', kwargs),
+            (entities.Host(**generic).install_content, 'put', kwargs),
+            (entities.Host(**generic).list_scparams, 'get', kwargs),
+            (entities.Host(**generic).list_smart_variables, 'get', kwargs),
+            (entities.Host(**generic).power, 'put', kwargs),
+            (entities.Host(**generic).upload_facts, 'post', kwargs),
+            (entities.HostGroup(**generic).add_puppetclass, 'post', kwargs),
+            (entities.HostGroup(**generic).clone, 'post', kwargs),
+            (entities.HostGroup(**generic).list_scparams, 'get', kwargs),
+            (
+                entities.HostGroup(**generic).list_smart_variables,
+                'get',
+                kwargs
+            ),
+            (entities.Product(**generic).sync, 'post', kwargs),
+            (entities.PuppetClass(**generic).list_scparams, 'get', kwargs),
+            (
+                entities.PuppetClass(**generic).list_smart_variables,
+                'get',
+                kwargs
+            ),
+            (entities.RHCIDeployment(**generic).deploy, 'put', kwargs),
+            (entities.RecurringLogic(**generic).cancel, 'post', kwargs),
+            (entities.Repository(**generic).errata, 'get', kwargs),
+            (entities.Repository(**generic).packages, 'get', kwargs),
+            (entities.Repository(**generic).puppet_modules, 'get', kwargs),
+            (entities.Repository(**generic).remove_content, 'put', kwargs),
+            (entities.Repository(**generic).sync, 'post', kwargs),
+            (
+                entities.RepositorySet(**repo_set).available_repositories,
+                'get',
+                kwargs
+            ),
+            (entities.RepositorySet(**repo_set).disable, 'put', kwargs),
+            (entities.RepositorySet(**repo_set).enable, 'put', kwargs),
+            (
+                entities.SmartProxy(**generic).import_puppetclasses,
+                'post',
+                kwargs
+            ),
+            (entities.SmartProxy(**generic).refresh, 'put', kwargs),
+            (entities.SyncPlan(**sync_plan).add_products, 'put', kwargs),
+            (entities.SyncPlan(**sync_plan).remove_products, 'put', kwargs),
+            (entities.Template(**generic).imports, 'post', kwargs),
+            (entities.Template(**generic).exports, 'post', kwargs),
+            (entities.VirtWhoConfig(**generic).deploy_script, 'get', kwargs)
         )
 
     def test_generic(self):
@@ -1929,13 +1982,12 @@ class GenericTestCase(TestCase):
         * The result of `_handle_response(…)` is the return value.
 
         """
-        for method, request in self.methods_requests:
+        for method, request, kwargs in self.methods_requests:
             with self.subTest((method, request)):
                 self.assertEqual(
                     inspect.getargspec(method),
                     (['self', 'synchronous'], None, 'kwargs', (True,))
                 )
-                kwargs = {'kwarg': gen_integer()}
                 with mock.patch.object(entities, '_handle_response') as handlr:
                     with mock.patch.object(client, request) as client_request:
                         response = method(**kwargs)


### PR DESCRIPTION
This allows me to just pass in `add_content`:

```
>>> data = dict(data=dict(add_content=dict(package_ids=[1,2])))
>>> ContentViewVersion(config, content_view=cv).search()[0].incremental_update(synchronous=True, **data)
{u'username': u'admin', u'ended_at': u'2018-08-22 16:36:03 UTC', u'output': {u'changed_content': [{u'content_view_version': {u'id': 18}, u'added_units': {u'puppet_module': [], u'rpm': [], u'erratum': []}}]}, u'cli_example': None, u'label': u'Actions::Katello::ContentView::IncrementalUpdates', u'state': u'stopped', u'result': u'success', u'input': {u'services_checked': [u'pulp', u'pulp_auth'], u'version_outputs': [{u'output': {u'added_units': {u'puppet_module': [], u'rpm': [], u'erratum': []}}, u'version_id': 18}]}, u'action': u'Incremental Update of 1 Content View Version(s)', u'progress': 1.0, u'started_at': u'2018-08-22 16:35:54 UTC', u'humanized': {u'action': u'Incremental Update of 1 Content View Version(s) ', u'input': [], u'errors': [], u'output': u'Content View: test version 5.3\nAdded Content:\n'}, u'id': u'bb262c07-1df5-4e9c-bec0-ab348ffd5b2a', u'pending': False}
```

or not add any content at all:

```
>>> data = dict(data=dict(description='sean rocks'))
>>> ContentViewVersion(config, content_view=cv).search()[0].incremental_update(synchronous=True, **data)
{u'username': u'admin', u'ended_at': u'2018-08-22 16:34:14 UTC', u'output': {u'changed_content': [{u'content_view_version': {u'id': 17}, u'added_units': {u'puppet_module': [], u'rpm': [], u'erratum': []}}]}, u'cli_example': None, u'label': u'Actions::Katello::ContentView::IncrementalUpdates', u'state': u'stopped', u'result': u'success', u'input': {u'services_checked': [u'pulp', u'pulp_auth'], u'version_outputs': [{u'output': {u'added_units': {u'puppet_module': [], u'rpm': [], u'erratum': []}}, u'version_id': 17}]}, u'action': u'Incremental Update of 1 Content View Version(s)', u'progress': 1.0, u'started_at': u'2018-08-22 16:34:06 UTC', u'humanized': {u'action': u'Incremental Update of 1 Content View Version(s) ', u'input': [], u'errors': [], u'output': u'Content View: test version 5.2\nAdded Content:\n'}, u'id': u'605612f0-83c6-4243-a01a-ac420a7176ac', u'pending': False}
```

or if im feeling really crazy, create an incremental_update without no changes..

```
>>> ContentViewVersion(config, content_view=cv).search()[0].incremental_update()
{u'username': u'admin', u'ended_at': u'2018-08-22 16:41:37 UTC', u'output': {u'changed_content': [{u'content_view_version': {u'id': 19}, u'added_units': {u'puppet_module': [], u'rpm': [], u'erratum': []}}]}, u'cli_example': None, u'label': u'Actions::Katello::ContentView::IncrementalUpdates', u'state': u'stopped', u'result': u'success', u'input': {u'services_checked': [u'pulp', u'pulp_auth'], u'version_outputs': [{u'output': {u'added_units': {u'puppet_module': [], u'rpm': [], u'erratum': []}}, u'version_id': 19}]}, u'action': u'Incremental Update of 1 Content View Version(s)', u'progress': 1.0, u'started_at': u'2018-08-22 16:41:29 UTC', u'humanized': {u'action': u'Incremental Update of 1 Content View Version(s) ', u'input': [], u'errors': [], u'output': u'Content View: test version 5.4\nAdded Content:\n'}, u'id': u'2ab14db8-9d99-4d9e-97a0-54e1fd46a772', u'pending': False}
```