### PR TITLE
added custom cron field for 6.5 feature in sync plan

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -25,8 +25,7 @@ from datetime import datetime
 from sys import version_info
 import hashlib
 import os.path
-
-from fauxfactory import gen_alphanumeric
+from fauxfactory import gen_alphanumeric, gen_choice
 from packaging.version import Version
 
 from nailgun import client, entity_fields, signals
@@ -6397,7 +6396,8 @@ class SyncPlan(
             'description': entity_fields.StringField(),
             'enabled': entity_fields.BooleanField(required=True),
             'interval': entity_fields.StringField(
-                choices=('hourly', 'daily', 'weekly'),
+                choices=('hourly', 'daily', 'weekly', 'custom cron'),
+                default=gen_choice(('hourly', 'daily', 'weekly')),
                 required=True,
             ),
             'name': entity_fields.StringField(
@@ -6405,6 +6405,9 @@ class SyncPlan(
                 str_type='alpha',
                 length=(6, 12),
                 unique=True
+            ),
+            'cron_expression': entity_fields.StringField(
+                str_type='alpha'
             ),
             'organization': entity_fields.OneToOneField(
                 Organization,


### PR DESCRIPTION
**Test Result:**

```
(robottelo-3y-ct8Zt) [root@okhatavk robottelo]# pytest tests/foreman/api/test_syncplan.py -v -k "test_positive_add_remove_products_custom_cron"
======================================================================== test session starts =========================================================================
platform linux -- Python 3.4.8, pytest-3.6.1, py-1.6.0, pluggy-0.6.0 -- /root/.local/share/virtualenvs/robottelo-3y-ct8Zt/bin/python3.4m
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/okhatavk/Satellite/robottelo, inifile:
plugins: services-1.2.1, mock-1.10.0, cov-2.6.0
collecting 33 items                                                                                                                                                  2018-09-12 13:22:28 - conftest - DEBUG - BZ deselect is disabled in settings

collected 33 items / 32 deselected                                                                                                                                   

tests/foreman/api/test_syncplan.py::SyncPlanProductTestCase::test_positive_add_remove_products_custom_cron <- robottelo/decorators/__init__.py PASSED          [100%]

============================================================== 1 passed, 32 deselected in 10.21 seconds ==============================================================
```
**Some more ouput**
```
>>> sync_plan = SyncPlan(organization=org, name='test200', interval='custom cron', enabled='True', sync_date=datetime.now(), cron_expression='1 2 3 * *').create()
>>> sync_plan.read
<bound method SyncPlan.read of nailgun.entities.SyncPlan(product=[], sync_date='2018/09/14 11:09:31 +0000', cron_expression='1 2 3 * *', organization=nailgun.entities.Organization(domain=[], smart_proxy=[nailgun.entities.SmartProxy(id=1)], default_content_view=nailgun.entities.ContentView(id=52), name='junk org 100', config_template=[nailgun.entities.ConfigTemplate(id=10), nailgun.entities.ConfigTemplate(id=11), 

>>> sync_plan.interval
'custom cron'
>>> sync_plan.cron_expression
'1 2 3 * *'
>>> sync_plan.interval = 'custom cron'
>>> sync_plan.cron_expression = '* * */2 * *'
>>> sync_plan = sync_plan.update(['interval', 'cron_expression']) 
>>> sync_plan.cron_expression == '* * */2 * *'
True
```


currently the test is not present in robottelo (master) as this is part of 6.5 feature branch. 