### PR TITLE
Fix Sphinx deprecated option

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,7 +42,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 exclude_patterns = ['_build']
 nitpicky = True
-autodoc_default_flags = ['members']
+autodoc_default_options = {'members': None}
 
 # Format-Specific Options -----------------------------------------------------
 


### PR DESCRIPTION
This is causing Travis jobs to fail on docs generation
```bash
sphinx-build -b html -d _build/doctrees  -W . _build/html
Running Sphinx v1.8.0
making output directory...

Warning, treated as error:
autodoc_default_flags is now deprecated. Please use autodoc_default_options instead.
Makefile:52: recipe for target 'html' failed
make[1]: *** [html] Error 2
make[1]: Leaving directory '/home/dlezz/projects/nailgun/docs'
Makefile:17: recipe for target 'docs-html' failed
make: *** [docs-html] Error 2
```
