### PR TITLE
lower the chunk size for content uploads to 2MB

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -1732,7 +1732,7 @@ class ContentUpload(
 
         try:
             offset = 0
-            content_chunk_size = 4 * 1024 * 1024
+            content_chunk_size = 2 * 1024 * 1024
 
             with open(filepath, 'rb') as contentfile:
                 chunk = contentfile.read(content_chunk_size)


### PR DESCRIPTION
Pulp/Django limit the upload size to about 2.5MB, so let's play safe and
use 2MB here.