### PR TITLE
Revert "Add more attrs to ContentViewVersion"

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -1771,14 +1771,12 @@ class ContentViewVersion(
     def __init__(self, server_config=None, **kwargs):
         self._fields = {
             'content_view': entity_fields.OneToOneField(ContentView),
-            'environments': entity_fields.OneToManyField(LifecycleEnvironment),
+            'environment': entity_fields.OneToManyField(Environment),
             'major': entity_fields.IntegerField(),
             'minor': entity_fields.IntegerField(),
             'package_count': entity_fields.IntegerField(),
             'puppet_module': entity_fields.OneToManyField(PuppetModule),
             'version': entity_fields.StringField(),
-            'repositories': entity_fields.OneToManyField(Repository),
-            'description': entity_fields.StringField(),
         }
         self._meta = {
             'api_path': 'katello/api/v2/content_view_versions',


### PR DESCRIPTION
Reverts SatelliteQE/nailgun#531

Okay, going to skip all social aspects of previous conversations (and reasons why that PR stayed for so long without review). Here are only technical points for PR revert:

1) Introduce regression for at least one module (https://github.com/SatelliteQE/robottelo/blob/master/tests/foreman/api/test_contentviewversion.py). 
Didn't test more, but there is a chance for more global issues:
Before changes:
===19 passed, 3 skipped in 3110.24 seconds===
After:
===14 failed, 5 passed, 3 skipped in 2084.41 seconds===

It can be not only naming problem, but entity type used for environment

2) We never use plural format for arguments, please refer to:
https://github.com/SatelliteQE/nailgun/blob/master/nailgun/entities.py#L1980
https://github.com/SatelliteQE/nailgun/blob/master/nailgun/entities.py#L2102
https://github.com/SatelliteQE/nailgun/blob/master/nailgun/entities.py#L2117
https://github.com/SatelliteQE/nailgun/blob/master/nailgun/entities.py#L4703
https://github.com/SatelliteQE/nailgun/blob/master/nailgun/entities.py#L4962
...

3) We always try (not always people keep that) to sort all arguments alphabetically


