### PR TITLE
E501: Allow longer lines

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 99


### PR DESCRIPTION
spreading max-line-length = 99 across team's repositories

See SatelliteQE/robottelo#6344