### PR TITLE
[6.4.z] Ignore arguable "W504 line break after binary operator"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ docs-clean:
 	@cd docs; $(MAKE) clean
 
 lint:
-	flake8 --ignore=E731 .
+	flake8 --ignore=W504,E731 .
 	pylint -j $(CPU_COUNT) --reports=n -E \
 		--disable=no-member,no-name-in-module --ignore-imports=y \
 		nailgun tests setup.py docs/conf.py


### PR DESCRIPTION
It started to fail on 4 years old commits.

Some say W503 and W504 are contradictory. We can expect some change regarding these rules. So I better ignore than go fixing it.