### PR TITLE
Fix Product sync_plan field read

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -4749,11 +4749,15 @@ class Product(
         ignore.add('sync_plan')
         result = super(Product, self).read(entity, attrs, ignore, params)
         if 'sync_plan' in attrs:
-            result.sync_plan = SyncPlan(
-                server_config=self._server_config,
-                id=attrs.get('sync_plan_id'),
-                organization=result.organization,
-            )
+            sync_plan_id = attrs.get('sync_plan_id')
+            if sync_plan_id is None:
+                result.sync_plan = None
+            else:
+                result.sync_plan = SyncPlan(
+                    server_config=self._server_config,
+                    id=sync_plan_id,
+                    organization=result.organization,
+                )
         return result
 
     def sync(self, synchronous=True, **kwargs):


### PR DESCRIPTION
product sync plan read result in a sync plan entity with id=None if sync_plan_id=None

test output
suppose this test 
```python 

from nailgun import entities
from pytest import raises
from requests.exceptions import HTTPError


def test_product_sync_plan():
    org = entities.Organization(id=1).read()
    sync_plan = entities.SyncPlan(organization=org).create()
    product = entities.Product(organization=org).create()
    entities.Repository(product=product).create()
    sync_plan.add_products(data={'product_ids': [product.id]})
    product.sync()
    product = product.read()
    assert product.sync_plan.id == sync_plan.id
    sync_plan.delete()
    product = product.read()
    assert product.sync_plan is None
    with raises(HTTPError):
        sync_plan.read()
```

```
(robottelo) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v tests/foreman/draft/test_sync.py 
============================================ test session starts =============================================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.5.4, pluggy-0.6.0 -- /home/dlezz/.pyenv/versions/3.6.6/envs/robottelo/bin/python
cachedir: .pytest_cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: wait-for-1.0.9, xdist-1.22.5, services-1.3.0, mock-1.10.0, forked-0.2, cov-2.5.1
collecting 1 item                                                                                            2018-10-26 16:38:47 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item                                                                                             

tests/foreman/draft/test_sync.py::test_product_sync_plan PASSED                                        [100%]

========================================= 1 passed in 37.28 seconds ==========================================
```

<details><summary>log output:</summary>

```bash
Testing started at 4:37 PM ...
/home/dlezz/.pyenv/versions/robottelo/bin/python3.6 /snap/pycharm-community/85/helpers/pycharm/_jb_pytest_runner.py --target test_sync.py::test_product_sync_plan -- -v -s
Launching pytest with arguments -v -s test_sync.py::test_product_sync_plan in /home/dlezz/projects/robottelo-fork/tests/foreman/draft

2018-10-26 16:37:51 - conftest - DEBUG - Registering custom pytest_namespace

============================= test session starts ==============================
platform linux -- Python 3.6.6, pytest-3.6.1, py-1.5.4, pluggy-0.6.0 -- /home/dlezz/.pyenv/versions/robottelo/bin/python3.6
cachedir: ../../../.pytest_cache
shared_function enabled - ON - scope: ffff - storage: file
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: wait-for-1.0.9, xdist-1.22.5, services-1.3.0, mock-1.10.0, forked-0.2, cov-2.5.1
collecting ... 2018-10-26 16:37:51 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item

test_sync.py::test_product_sync_plan 2018-10-26 16:37:51 - robottelo - INFO - Entities cleaner disabled
2018-10-26 16:37:51 - robottelo - DEBUG - Started Test: tests/foreman/draft/test_sync.py/test_product_sync_plan
2018-10-26 16:37:51 - nailgun.client - DEBUG - Making HTTP GET request to https://server-host/katello/api/v2/organizations/1 with options {'auth': ('admin', 'changeme'), 'verify': False, 'headers': {'content-type': 'application/json'}}, no params and no data.
2018-10-26 16:37:53 - nailgun.client - DEBUG - Received HTTP 200 response: {"label":"Default_Organization","owner_details":{"created":"2018-10-23T09:18:34+0000","updated":"2018-10-23T09:18:34+0000","id":"8a8a33c266a037660166a037f9570001","key":"Default_Organization","displayName":"Default Organization","parentOwner":null,"contentPrefix":"/Default_Organization/$env","defaultServiceLevel":null,"upstreamConsumer":null,"logLevel":null,"autobindDisabled":false,"contentAccessMode":"entitlement","contentAccessModeList":"entitlement","lastRefreshed":null,"href":"/owners/Default_Organization","virt_who":false},"redhat_repository_url":"https://cdn.redhat.com","service_levels":[],"service_level":null,"select_all_types":[],"description":null,"created_at":"2018-10-23 09:18:28 UTC","updated_at":"2018-10-23 09:18:28 UTC","ancestry":null,"parent_id":null,"parent_name":null,"id":1,"name":"Default Organization","title":"Default Organization","users":[],"smart_proxies":[{"name":"server-host","id":1,"url":"https://server-host:9090"}],"subnets":[],"compute_resources":[{"id":47,"name":"bZOZKfCMms","provider":"EC2","provider_friendly_name":"EC2"},{"id":44,"name":"dGSyKUOKeH","provider":"EC2","provider_friendly_name":"EC2"},{"id":10,"name":"dULUSguaXb","provider":"EC2","provider_friendly_name":"EC2"},{"id":55,"name":"hFphzXggmG","provider":"EC2","provider_friendly_name":"EC2"},{"id":6,"name":"hQksgVTiRp-2","provider":"EC2","provider_friendly_name":"EC2"},{"id":8,"name":"KcMEiIEsKt","provider":"EC2","provider_friendly_name":"EC2"},{"id":52,"name":"KkRbQsQsVN","provider":"EC2","provider_friendly_name":"EC2"},{"id":31,"name":"LGzYYVbaIz","provider":"EC2","provider_friendly_name":"EC2"},{"id":12,"name":"MJbLwhxGFZ","provider":"EC2","provider_friendly_name":"EC2"},{"id":39,"name":"VcAStNcaoX","provider":"EC2","provider_friendly_name":"EC2"},{"id":29,"name":"vttjiackZH","provider":"EC2","provider_friendly_name":"EC2"},{"id":9,"name":"WAyGsZKESG","provider":"EC2","provider_friendly_name":"EC2"},{"id":7,"name":"xOXjmWthtx","provider":"EC2","provider_friendly_name":"EC2"},{"id":40,"name":"zcyZQgVwBh","provider":"EC2","provider_friendly_name":"EC2"}],"media":[{"id":1,"name":"CentOS mirror"},{"id":8,"name":"CoreOS mirror"},{"id":2,"name":"Debian mirror"},{"id":4,"name":"Fedora Atomic mirror"},{"id":3,"name":"Fedora mirror"},{"id":5,"name":"FreeBSD mirror"},{"id":6,"name":"OpenSUSE mirror"},{"id":9,"name":"RancherOS mirror"},{"id":7,"name":"Ubuntu mirror"}],"config_templates":[{"id":10,"name":"Alterator default","template_kind_id":6,"template_kind_name":"provision"},{"id":11,"name":"Alterator default finish","template_kind_id":7,"template_kind_name":"finish"},{"id":12,"name":"Alterator default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":54,"name":"alterator_pkglist","template_kind_id":null,"template_kind_name":null},{"id":55,"name":"ansible_provisioning_callback","template_kind_id":null,"template_kind_name":null},{"id":56,"name":"ansible_tower_callback_script","template_kind_id":null,"template_kind_name":null},{"id":57,"name":"ansible_tower_callback_service","template_kind_id":null,"template_kind_name":null},{"id":13,"name":"Atomic Kickstart default","template_kind_id":6,"template_kind_name":"provision"},{"id":14,"name":"AutoYaST default","template_kind_id":6,"template_kind_name":"provision"},{"id":17,"name":"AutoYaST default iPXE","template_kind_id":5,"template_kind_name":"iPXE"},{"id":16,"name":"AutoYaST default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":18,"name":"AutoYaST default user data","template_kind_id":9,"template_kind_name":"user_data"},{"id":15,"name":"AutoYaST SLES default","template_kind_id":6,"template_kind_name":"provision"},{"id":58,"name":"bmc_nic_setup","template_kind_id":null,"template_kind_name":null},{"id":102,"name":"Boot disk iPXE - generic host","template_kind_id":1,"template_kind_name":"Bootdisk"},{"id":101,"name":"Boot disk iPXE - host","template_kind_id":1,"template_kind_name":"Bootdisk"},{"id":59,"name":"chef_client","template_kind_id":null,"template_kind_name":null},{"id":60,"name":"coreos_cloudconfig","template_kind_id":null,"template_kind_name":null},{"id":19,"name":"CoreOS provision","template_kind_id":6,"template_kind_name":"provision"},{"id":20,"name":"CoreOS PXELinux","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":61,"name":"create_users","template_kind_id":null,"template_kind_name":null},{"id":62,"name":"epel","template_kind_id":null,"template_kind_name":null},{"id":63,"name":"fix_hosts","template_kind_id":null,"template_kind_name":null},{"id":21,"name":"FreeBSD (mfsBSD) finish","template_kind_id":7,"template_kind_name":"finish"},{"id":22,"name":"FreeBSD (mfsBSD) provision","template_kind_id":6,"template_kind_name":"provision"},{"id":23,"name":"FreeBSD (mfsBSD) PXELinux","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":64,"name":"freeipa_register","template_kind_id":null,"template_kind_name":null},{"id":24,"name":"Grubby default","template_kind_id":8,"template_kind_name":"script"},{"id":65,"name":"http_proxy","template_kind_id":null,"template_kind_name":null},{"id":25,"name":"Jumpstart default","template_kind_id":6,"template_kind_name":"provision"},{"id":26,"name":"Jumpstart default finish","template_kind_id":7,"template_kind_name":"finish"},{"id":27,"name":"Jumpstart default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub"},{"id":30,"name":"Junos default finish","template_kind_id":7,"template_kind_name":"finish"},{"id":28,"name":"Junos default SLAX","template_kind_id":6,"template_kind_name":"provision"},{"id":29,"name":"Junos default ZTP config","template_kind_id":10,"template_kind_name":"ZTP"},{"id":31,"name":"Kickstart default","template_kind_id":6,"template_kind_name":"provision"},{"id":34,"name":"Kickstart default finish","template_kind_id":7,"template_kind_name":"finish"},{"id":38,"name":"Kickstart default iPXE","template_kind_id":5,"template_kind_name":"iPXE"},{"id":36,"name":"Kickstart default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub"},{"id":37,"name":"Kickstart default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2"},{"id":35,"name":"Kickstart default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":39,"name":"Kickstart default user data","template_kind_id":9,"template_kind_name":"user_data"},{"id":67,"name":"kickstart_ifcfg_bonded_interface","template_kind_id":null,"template_kind_name":null},{"id":66,"name":"kickstart_ifcfg_bond_interface","template_kind_id":null,"template_kind_name":null},{"id":68,"name":"kickstart_ifcfg_generic_interface","template_kind_id":null,"template_kind_name":null},{"id":69,"name":"kickstart_ifcfg_get_identifier_names","template_kind_id":null,"template_kind_name":null},{"id":70,"name":"kickstart_networking_setup","template_kind_id":null,"template_kind_name":null},{"id":32,"name":"Kickstart oVirt-RHVH","template_kind_id":6,"template_kind_name":"provision"},{"id":33,"name":"Kickstart oVirt-RHVH PXELinux","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":40,"name":"NX-OS default POAP setup","template_kind_id":11,"template_kind_name":"POAP"},{"id":41,"name":"Preseed default","template_kind_id":6,"template_kind_name":"provision"},{"id":42,"name":"Preseed default finish","template_kind_id":7,"template_kind_name":"finish"},{"id":45,"name":"Preseed default iPXE","template_kind_id":5,"template_kind_name":"iPXE"},{"id":44,"name":"Preseed default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2"},{"id":43,"name":"Preseed default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":46,"name":"Preseed default user data","template_kind_id":9,"template_kind_name":"user_data"},{"id":71,"name":"preseed_networking_setup","template_kind_id":null,"template_kind_name":null},{"id":72,"name":"puppet.conf","template_kind_id":null,"template_kind_name":null},{"id":74,"name":"puppetlabs_repo","template_kind_id":null,"template_kind_name":null},{"id":73,"name":"puppet_setup","template_kind_id":null,"template_kind_name":null},{"id":75,"name":"pxegrub2_chainload","template_kind_id":null,"template_kind_name":null},{"id":6,"name":"PXEGrub2 default local boot","template_kind_id":4,"template_kind_name":"PXEGrub2"},{"id":76,"name":"pxegrub2_discovery","template_kind_id":null,"template_kind_name":null},{"id":3,"name":"PXEGrub2 global default","template_kind_id":4,"template_kind_name":"PXEGrub2"},{"id":77,"name":"pxegrub_chainload","template_kind_id":null,"template_kind_name":null},{"id":5,"name":"PXEGrub default local boot","template_kind_id":3,"template_kind_name":"PXEGrub"},{"id":78,"name":"pxegrub_discovery","template_kind_id":null,"template_kind_name":null},{"id":2,"name":"PXEGrub global default","template_kind_id":3,"template_kind_name":"PXEGrub"},{"id":8,"name":"PXELinux chain iPXE","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":9,"name":"PXELinux chain iPXE UNDI","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":79,"name":"pxelinux_chainload","template_kind_id":null,"template_kind_name":null},{"id":4,"name":"PXELinux default local boot","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":7,"name":"PXELinux default memdisk","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":80,"name":"pxelinux_discovery","template_kind_id":null,"template_kind_name":null},{"id":1,"name":"PXELinux global default","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":81,"name":"rancheros_cloudconfig","template_kind_id":null,"template_kind_name":null},{"id":48,"name":"RancherOS provision","template_kind_id":6,"template_kind_name":"provision"},{"id":47,"name":"RancherOS PXELinux","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":82,"name":"redhat_register","template_kind_id":null,"template_kind_name":null},{"id":83,"name":"remote_execution_ssh_keys","template_kind_id":null,"template_kind_name":null},{"id":84,"name":"saltstack_minion","template_kind_id":null,"template_kind_name":null},{"id":85,"name":"saltstack_setup","template_kind_id":null,"template_kind_name":null},{"id":49,"name":"UserData default","template_kind_id":9,"template_kind_name":"user_data"},{"id":50,"name":"WAIK default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":51,"name":"XenServer default answerfile","template_kind_id":6,"template_kind_name":"provision"},{"id":52,"name":"XenServer default finish","template_kind_id":7,"template_kind_name":"finish"},{"id":53,"name":"XenServer default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux"}],"ptables":[{"os_family":"Suse","created_at":"2018-10-23 09:18:32 UTC","updated_at":"2018-10-23 09:18:32 UTC","name":"AutoYaST entire SCSI disk","id":86},{"os_family":"Suse","created_at":"2018-10-23 09:18:32 UTC","updated_at":"2018-10-23 09:18:32 UTC","name":"AutoYaST entire virtual disk","id":87},{"os_family":"Suse","created_at":"2018-10-23 09:18:32 UTC","updated_at":"2018-10-23 09:18:32 UTC","name":"AutoYaST LVM","id":88},{"os_family":"Coreos","created_at":"2018-10-23 09:18:32 UTC","updated_at":"2018-10-23 09:18:32 UTC","name":"CoreOS default fake","id":89},{"os_family":"Freebsd","created_at":"2018-10-23 09:18:32 UTC","updated_at":"2018-10-23 09:18:32 UTC","name":"FreeBSD","id":90},{"os_family":"Solaris","created_at":"2018-10-23 09:18:32 UTC","updated_at":"2018-10-23 09:18:32 UTC","name":"Jumpstart default","id":91},{"os_family":"Solaris","created_at":"2018-10-23 09:18:32 UTC","updated_at":"2018-10-23 09:18:32 UTC","name":"Jumpstart mirrored","id":92},{"os_family":"Junos","created_at":"2018-10-23 09:18:32 UTC","updated_at":"2018-10-23 09:18:32 UTC","name":"Junos default fake","id":93},{"os_family":"Redhat","created_at":"2018-10-23 09:18:32 UTC","updated_at":"2018-10-23 09:18:32 UTC","name":"Kickstart default","id":94},{"os_family":"Redhat","created_at":"2018-10-23 09:18:32 UTC","updated_at":"2018-10-23 09:18:32 UTC","name":"Kickstart default thin","id":95},{"os_family":"NXOS","created_at":"2018-10-23 09:18:32 UTC","updated_at":"2018-10-23 09:18:32 UTC","name":"NX-OS default fake","id":96},{"os_family":"Debian","created_at":"2018-10-23 09:18:32 UTC","updated_at":"2018-10-23 09:18:32 UTC","name":"Preseed custom LVM","id":98},{"os_family":"Debian","created_at":"2018-10-23 09:18:32 UTC","updated_at":"2018-10-23 09:18:32 UTC","name":"Preseed default","id":97},{"os_family":"Rancheros","created_at":"2018-10-23 09:18:33 UTC","updated_at":"2018-10-23 09:18:33 UTC","name":"RancherOS empty","id":99},{"os_family":"Xenserver","created_at":"2018-10-23 09:18:33 UTC","updated_at":"2018-10-23 09:18:33 UTC","name":"XenServer default","id":100}],"provisioning_templates":[{"id":10,"name":"Alterator default","template_kind_id":6,"template_kind_name":"provision"},{"id":11,"name":"Alterator default finish","template_kind_id":7,"template_kind_name":"finish"},{"id":12,"name":"Alterator default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":54,"name":"alterator_pkglist","template_kind_id":null,"template_kind_name":null},{"id":55,"name":"ansible_provisioning_callback","template_kind_id":null,"template_kind_name":null},{"id":56,"name":"ansible_tower_callback_script","template_kind_id":null,"template_kind_name":null},{"id":57,"name":"ansible_tower_callback_service","template_kind_id":null,"template_kind_name":null},{"id":13,"name":"Atomic Kickstart default","template_kind_id":6,"template_kind_name":"provision"},{"id":14,"name":"AutoYaST default","template_kind_id":6,"template_kind_name":"provision"},{"id":17,"name":"AutoYaST default iPXE","template_kind_id":5,"template_kind_name":"iPXE"},{"id":16,"name":"AutoYaST default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":18,"name":"AutoYaST default user data","template_kind_id":9,"template_kind_name":"user_data"},{"id":15,"name":"AutoYaST SLES default","template_kind_id":6,"template_kind_name":"provision"},{"id":58,"name":"bmc_nic_setup","template_kind_id":null,"template_kind_name":null},{"id":102,"name":"Boot disk iPXE - generic host","template_kind_id":1,"template_kind_name":"Bootdisk"},{"id":101,"name":"Boot disk iPXE - host","template_kind_id":1,"template_kind_name":"Bootdisk"},{"id":59,"name":"chef_client","template_kind_id":null,"template_kind_name":null},{"id":60,"name":"coreos_cloudconfig","template_kind_id":null,"template_kind_name":null},{"id":19,"name":"CoreOS provision","template_kind_id":6,"template_kind_name":"provision"},{"id":20,"name":"CoreOS PXELinux","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":61,"name":"create_users","template_kind_id":null,"template_kind_name":null},{"id":62,"name":"epel","template_kind_id":null,"template_kind_name":null},{"id":63,"name":"fix_hosts","template_kind_id":null,"template_kind_name":null},{"id":21,"name":"FreeBSD (mfsBSD) finish","template_kind_id":7,"template_kind_name":"finish"},{"id":22,"name":"FreeBSD (mfsBSD) provision","template_kind_id":6,"template_kind_name":"provision"},{"id":23,"name":"FreeBSD (mfsBSD) PXELinux","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":64,"name":"freeipa_register","template_kind_id":null,"template_kind_name":null},{"id":24,"name":"Grubby default","template_kind_id":8,"template_kind_name":"script"},{"id":65,"name":"http_proxy","template_kind_id":null,"template_kind_name":null},{"id":25,"name":"Jumpstart default","template_kind_id":6,"template_kind_name":"provision"},{"id":26,"name":"Jumpstart default finish","template_kind_id":7,"template_kind_name":"finish"},{"id":27,"name":"Jumpstart default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub"},{"id":30,"name":"Junos default finish","template_kind_id":7,"template_kind_name":"finish"},{"id":28,"name":"Junos default SLAX","template_kind_id":6,"template_kind_name":"provision"},{"id":29,"name":"Junos default ZTP config","template_kind_id":10,"template_kind_name":"ZTP"},{"id":31,"name":"Kickstart default","template_kind_id":6,"template_kind_name":"provision"},{"id":34,"name":"Kickstart default finish","template_kind_id":7,"template_kind_name":"finish"},{"id":38,"name":"Kickstart default iPXE","template_kind_id":5,"template_kind_name":"iPXE"},{"id":36,"name":"Kickstart default PXEGrub","template_kind_id":3,"template_kind_name":"PXEGrub"},{"id":37,"name":"Kickstart default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2"},{"id":35,"name":"Kickstart default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":39,"name":"Kickstart default user data","template_kind_id":9,"template_kind_name":"user_data"},{"id":67,"name":"kickstart_ifcfg_bonded_interface","template_kind_id":null,"template_kind_name":null},{"id":66,"name":"kickstart_ifcfg_bond_interface","template_kind_id":null,"template_kind_name":null},{"id":68,"name":"kickstart_ifcfg_generic_interface","template_kind_id":null,"template_kind_name":null},{"id":69,"name":"kickstart_ifcfg_get_identifier_names","template_kind_id":null,"template_kind_name":null},{"id":70,"name":"kickstart_networking_setup","template_kind_id":null,"template_kind_name":null},{"id":32,"name":"Kickstart oVirt-RHVH","template_kind_id":6,"template_kind_name":"provision"},{"id":33,"name":"Kickstart oVirt-RHVH PXELinux","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":40,"name":"NX-OS default POAP setup","template_kind_id":11,"template_kind_name":"POAP"},{"id":41,"name":"Preseed default","template_kind_id":6,"template_kind_name":"provision"},{"id":42,"name":"Preseed default finish","template_kind_id":7,"template_kind_name":"finish"},{"id":45,"name":"Preseed default iPXE","template_kind_id":5,"template_kind_name":"iPXE"},{"id":44,"name":"Preseed default PXEGrub2","template_kind_id":4,"template_kind_name":"PXEGrub2"},{"id":43,"name":"Preseed default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":46,"name":"Preseed default user data","template_kind_id":9,"template_kind_name":"user_data"},{"id":71,"name":"preseed_networking_setup","template_kind_id":null,"template_kind_name":null},{"id":72,"name":"puppet.conf","template_kind_id":null,"template_kind_name":null},{"id":74,"name":"puppetlabs_repo","template_kind_id":null,"template_kind_name":null},{"id":73,"name":"puppet_setup","template_kind_id":null,"template_kind_name":null},{"id":75,"name":"pxegrub2_chainload","template_kind_id":null,"template_kind_name":null},{"id":6,"name":"PXEGrub2 default local boot","template_kind_id":4,"template_kind_name":"PXEGrub2"},{"id":76,"name":"pxegrub2_discovery","template_kind_id":null,"template_kind_name":null},{"id":3,"name":"PXEGrub2 global default","template_kind_id":4,"template_kind_name":"PXEGrub2"},{"id":77,"name":"pxegrub_chainload","template_kind_id":null,"template_kind_name":null},{"id":5,"name":"PXEGrub default local boot","template_kind_id":3,"template_kind_name":"PXEGrub"},{"id":78,"name":"pxegrub_discovery","template_kind_id":null,"template_kind_name":null},{"id":2,"name":"PXEGrub global default","template_kind_id":3,"template_kind_name":"PXEGrub"},{"id":8,"name":"PXELinux chain iPXE","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":9,"name":"PXELinux chain iPXE UNDI","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":79,"name":"pxelinux_chainload","template_kind_id":null,"template_kind_name":null},{"id":4,"name":"PXELinux default local boot","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":7,"name":"PXELinux default memdisk","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":80,"name":"pxelinux_discovery","template_kind_id":null,"template_kind_name":null},{"id":1,"name":"PXELinux global default","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":81,"name":"rancheros_cloudconfig","template_kind_id":null,"template_kind_name":null},{"id":48,"name":"RancherOS provision","template_kind_id":6,"template_kind_name":"provision"},{"id":47,"name":"RancherOS PXELinux","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":82,"name":"redhat_register","template_kind_id":null,"template_kind_name":null},{"id":83,"name":"remote_execution_ssh_keys","template_kind_id":null,"template_kind_name":null},{"id":84,"name":"saltstack_minion","template_kind_id":null,"template_kind_name":null},{"id":85,"name":"saltstack_setup","template_kind_id":null,"template_kind_name":null},{"id":49,"name":"UserData default","template_kind_id":9,"template_kind_name":"user_data"},{"id":50,"name":"WAIK default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux"},{"id":51,"name":"XenServer default answerfile","template_kind_id":6,"template_kind_name":"provision"},{"id":52,"name":"XenServer default finish","template_kind_id":7,"template_kind_name":"finish"},{"id":53,"name":"XenServer default PXELinux","template_kind_id":2,"template_kind_name":"PXELinux"}],"domains":[],"realms":[],"environments":[],"hostgroups":[],"locations":[],"hosts_count":0,"parameters":[],"default_content_view_id":1,"library_id":1}
2018-10-26 16:37:53 - nailgun.client - DEBUG - Making HTTP POST request to https://server-host/katello/api/v2/organizations/1/sync_plans with options {'auth': ('admin', 'changeme'), 'verify': False, 'headers': {'content-type': 'application/json'}}, no params and data {"enabled": false, "interval": "hourly", "name": "POsdBWRUZf", "sync_date": "2284-04-28 16:54:50", "organization_id": 1}.
2018-10-26 16:37:55 - nailgun.client - DEBUG - Received HTTP 200 response:   {"id":9,"organization_id":1,"name":"POsdBWRUZf","description":null,"interval":"hourly","next_sync":null,"created_at":"2018-10-26 13:37:55 UTC","updated_at":"2018-10-26 13:37:55 UTC","enabled":false,"products":[],"permissions":{"view_sync_plans":true,"edit_sync_plans":true,"destroy_sync_plans":true},"sync_date":"2284/04/28 16:54:50 +0000"}

2018-10-26 16:37:55 - nailgun.client - DEBUG - Making HTTP POST request to https://server-host/katello/api/v2/products with options {'auth': ('admin', 'changeme'), 'verify': False, 'headers': {'content-type': 'application/json'}}, no params and data {"name": "kfvePWflla", "organization_id": 1}.
2018-10-26 16:37:58 - nailgun.client - DEBUG - Received HTTP 200 response:   {"redhat":false,"id":221,"cp_id":"382614305246","name":"kfvePWflla","label":"kfvePWflla","description":null,"provider_id":1,"sync_plan_id":null,"sync_summary":{},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":null,"last_sync":null,"last_sync_words":null,"organization_id":1,"organization":{"name":"Default Organization","label":"Default_Organization","id":1},"sync_plan":null,"repository_count":0,"created_at":"2018-10-26 13:37:56 UTC","updated_at":"2018-10-26 13:37:56 UTC","product_content":[],"available_content":[],"repositories":[],"provider":{"name":"Anonymous"},"sync_status":{"id":null,"product_id":null,"progress":null,"sync_id":null,"state":null,"raw_state":null,"start_time":null,"finish_time":null,"duration":null,"display_size":null,"size":null,"is_running":null,"error_details":null},"permissions":{"view_products":true,"edit_products":true,"destroy_products":true,"sync_products":true},"published_content_view_ids":[],"active_task_count":0}

2018-10-26 16:37:58 - nailgun.client - DEBUG - Making HTTP POST request to https://server-host/katello/api/v2/repositories with options {'auth': ('admin', 'changeme'), 'verify': False, 'headers': {'content-type': 'application/json'}}, no params and data {"content_type": "yum", "name": "MNBTnDbQRv", "url": "http://inecas.fedorapeople.org/fakerepos/zoo3/", "product_id": 221}.
2018-10-26 16:38:02 - nailgun.client - DEBUG - Received HTTP 200 response:   {"content_type":"yum","docker_upstream_name":null,"mirror_on_sync":true,"verify_ssl_on_sync":true,"unprotected":true,"full_path":"http://server-host/pulp/repos/Default_Organization/Library/custom/kfvePWflla/MNBTnDbQRv/","checksum_type":null,"container_repository_name":null,"download_policy":"on_demand","url":"http://inecas.fedorapeople.org/fakerepos/zoo3/","relative_path":"Default_Organization/Library/custom/kfvePWflla/MNBTnDbQRv","gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"content_view_version_id":1,"library_instance_id":null,"product_type":"custom","promoted":false,"ostree_branches":[],"upstream_username":null,"ostree_upstream_sync_policy":null,"ostree_upstream_sync_depth":null,"deb_releases":null,"deb_components":null,"deb_architectures":null,"ignore_global_proxy":false,"ignorable_content":null,"organization":{"name":"Default Organization","label":"Default_Organization","id":1},"created_at":"2018-10-26 13:37:59 UTC","updated_at":"2018-10-26 13:38:01 UTC","arch":"noarch","content_id":"1540561080393","backend_identifier":"5b090b9f-a9a4-4a4d-a2cc-e481044498a5","content_label":null,"major":null,"minor":null,"id":133,"name":"MNBTnDbQRv","label":"MNBTnDbQRv","product":{"id":221,"cp_id":"382614305246","name":"kfvePWflla","orphaned":false,"sync_plan":["name","description","sync_date","interval","next_sync"]},"last_sync":null,"content_counts":{"ostree_branch":0,"docker_manifest":0,"docker_manifest_list":0,"docker_tag":0,"rpm":0,"srpm":0,"package":0,"package_group":0,"erratum":0,"puppet_module":0,"file":0,"deb":0},"last_sync_words":null,"environment":{"id":1},"permissions":{"deletable":true},"upstream_password_exists":false,"upstream_auth_exists":false}

2018-10-26 16:38:02 - nailgun.client - DEBUG - Making HTTP PUT request to https://server-host/katello/api/v2/organizations/1/sync_plans/9/add_products with options {'auth': ('admin', 'changeme'), 'verify': False, 'headers': {'content-type': 'application/json'}}, no params and data {"product_ids": [221]}.
2018-10-26 16:38:04 - nailgun.client - DEBUG - Received HTTP 200 response:   {"id":9,"organization_id":1,"name":"POsdBWRUZf","description":null,"interval":"hourly","next_sync":null,"created_at":"2018-10-26 13:37:55 UTC","updated_at":"2018-10-26 13:37:55 UTC","enabled":false,"products":[{"id":221,"cp_id":"382614305246","name":"kfvePWflla","label":"kfvePWflla","description":null,"sync_state":null,"last_sync":null,"last_sync_words":null,"repository_count":1}],"permissions":{"view_sync_plans":true,"edit_sync_plans":true,"destroy_sync_plans":true},"sync_date":"2284/04/28 16:54:50 +0000"}

2018-10-26 16:38:04 - nailgun.client - DEBUG - Making HTTP POST request to https://server-host/katello/api/v2/products/221/sync with options {'auth': ('admin', 'changeme'), 'verify': False, 'headers': {'content-type': 'application/json'}}, no params and no data.
2018-10-26 16:38:05 - nailgun.client - DEBUG - Received HTTP 202 response:   {"id":"7f37dcc5-cced-4f45-97d5-ac63cf51f645","label":"Actions::BulkAction","pending":true,"action":"Bulk action","username":"admin","started_at":"2018-10-26 13:38:05 UTC","ended_at":null,"state":"planned","result":"pending","progress":0.0,"input":{"action_class":"Actions::Katello::Repository::Sync","target_ids":[133],"target_class":"Katello::Repository","args":[],"current_user_id":4},"output":{},"humanized":{"action":"Bulk action","input":null,"output":null,"errors":[]},"cli_example":null}

2018-10-26 16:38:05 - nailgun.client - DEBUG - Making HTTP GET request to https://server-host/foreman_tasks/api/tasks/7f37dcc5-cced-4f45-97d5-ac63cf51f645 with options {'auth': ('admin', 'changeme'), 'verify': False, 'headers': {'content-type': 'application/json'}}, no params and no data.
2018-10-26 16:38:06 - nailgun.client - DEBUG - Received HTTP 200 response: {"id":"7f37dcc5-cced-4f45-97d5-ac63cf51f645","label":"Actions::BulkAction","pending":true,"action":"Bulk action","username":"admin","started_at":"2018-10-26 13:38:05 UTC","ended_at":null,"state":"running","result":"pending","progress":0.0,"input":{"action_class":"Actions::Katello::Repository::Sync","target_ids":[133],"target_class":"Katello::Repository","args":[],"current_user_id":4},"output":{},"humanized":{"action":"Synchronize","input":["synchronize",["repository",{"text":"repository 'MNBTnDbQRv'","link":null}],["product",{"text":"product 'kfvePWflla'","link":"/products/221/"}],["organization",{"text":"organization 'Default Organization'","link":"/organizations/1/edit"}],"..."],"output":null,"errors":[]},"cli_example":null}
2018-10-26 16:38:11 - nailgun.client - DEBUG - Making HTTP GET request to https://server-host/foreman_tasks/api/tasks/7f37dcc5-cced-4f45-97d5-ac63cf51f645 with options {'auth': ('admin', 'changeme'), 'verify': False, 'headers': {'content-type': 'application/json'}}, no params and no data.
2018-10-26 16:38:12 - nailgun.client - DEBUG - Received HTTP 200 response: {"id":"7f37dcc5-cced-4f45-97d5-ac63cf51f645","label":"Actions::BulkAction","pending":true,"action":"Bulk action","username":"admin","started_at":"2018-10-26 13:38:05 UTC","ended_at":null,"state":"running","result":"pending","progress":0.0,"input":{"action_class":"Actions::Katello::Repository::Sync","target_ids":[133],"target_class":"Katello::Repository","args":[],"current_user_id":4},"output":{"planned_count":1,"cancelled_count":0,"total_count":1,"failed_count":0,"pending_count":1,"success_count":0},"humanized":{"action":"Synchronize","input":["synchronize",["repository",{"text":"repository 'MNBTnDbQRv'","link":null}],["product",{"text":"product 'kfvePWflla'","link":"/products/221/"}],["organization",{"text":"organization 'Default Organization'","link":"/organizations/1/edit"}],"..."],"output":"1 task(s), 0 success, 0 fail","errors":[]},"cli_example":null}
2018-10-26 16:38:17 - nailgun.client - DEBUG - Making HTTP GET request to https://server-host/foreman_tasks/api/tasks/7f37dcc5-cced-4f45-97d5-ac63cf51f645 with options {'auth': ('admin', 'changeme'), 'verify': False, 'headers': {'content-type': 'application/json'}}, no params and no data.
2018-10-26 16:38:18 - nailgun.client - DEBUG - Received HTTP 200 response: {"id":"7f37dcc5-cced-4f45-97d5-ac63cf51f645","label":"Actions::BulkAction","pending":true,"action":"Bulk action","username":"admin","started_at":"2018-10-26 13:38:05 UTC","ended_at":null,"state":"running","result":"pending","progress":0.0,"input":{"action_class":"Actions::Katello::Repository::Sync","target_ids":[133],"target_class":"Katello::Repository","args":[],"current_user_id":4},"output":{"planned_count":1,"cancelled_count":0,"total_count":1,"failed_count":0,"pending_count":1,"success_count":0},"humanized":{"action":"Synchronize","input":["synchronize",["repository",{"text":"repository 'MNBTnDbQRv'","link":null}],["product",{"text":"product 'kfvePWflla'","link":"/products/221/"}],["organization",{"text":"organization 'Default Organization'","link":"/organizations/1/edit"}],"..."],"output":"1 task(s), 0 success, 0 fail","errors":[]},"cli_example":null}
2018-10-26 16:38:23 - nailgun.client - DEBUG - Making HTTP GET request to https://server-host/foreman_tasks/api/tasks/7f37dcc5-cced-4f45-97d5-ac63cf51f645 with options {'auth': ('admin', 'changeme'), 'verify': False, 'headers': {'content-type': 'application/json'}}, no params and no data.
2018-10-26 16:38:24 - nailgun.client - DEBUG - Received HTTP 200 response: {"id":"7f37dcc5-cced-4f45-97d5-ac63cf51f645","label":"Actions::BulkAction","pending":false,"action":"Synchronize synchronize; repository 'MNBTnDbQRv'; product 'kfvePWflla'; organization 'Default Organization'; ...","username":"admin","started_at":"2018-10-26 13:38:05 UTC","ended_at":"2018-10-26 13:38:20 UTC","state":"stopped","result":"success","progress":1.0,"input":{"action_class":"Actions::Katello::Repository::Sync","target_ids":[133],"target_class":"Katello::Repository","args":[],"current_user_id":4},"output":{"planned_count":1,"cancelled_count":0,"total_count":1,"failed_count":0,"pending_count":0,"success_count":1},"humanized":{"action":"Synchronize","input":["synchronize",["repository",{"text":"repository 'MNBTnDbQRv'","link":null}],["product",{"text":"product 'kfvePWflla'","link":"/products/221/"}],["organization",{"text":"organization 'Default Organization'","link":"/organizations/1/edit"}],"..."],"output":"1 task(s), 1 success, 0 fail","errors":[]},"cli_example":null}
2018-10-26 16:38:24 - nailgun.client - DEBUG - Making HTTP GET request to https://server-host/katello/api/v2/products/221 with options {'auth': ('admin', 'changeme'), 'verify': False, 'headers': {'content-type': 'application/json'}}, no params and no data.
2018-10-26 16:38:25 - nailgun.client - DEBUG - Received HTTP 200 response:   {"redhat":false,"id":221,"cp_id":"382614305246","name":"kfvePWflla","label":"kfvePWflla","description":null,"provider_id":1,"sync_plan_id":9,"sync_summary":{"success":1},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing Complete.","last_sync":"2018-10-26 13:38:05 UTC","last_sync_words":"less than a minute","organization_id":1,"organization":{"name":"Default Organization","label":"Default_Organization","id":1},"sync_plan":{"id":9,"name":"POsdBWRUZf","description":null,"sync_date":"2284-04-28 16:54:50 UTC","interval":"hourly","next_sync":null},"repository_count":1,"created_at":"2018-10-26 13:37:56 UTC","updated_at":"2018-10-26 13:38:03 UTC","product_content":[{"enabled":true,"product_id":221,"content":{"name":"MNBTnDbQRv","label":"Default_Organization_kfvePWflla_MNBTnDbQRv","vendor":"Custom","content_url":"/custom/kfvePWflla/MNBTnDbQRv","gpg_url":null,"id":"1540561080393","type":"yum","gpgUrl":null,"contentUrl":"/custom/kfvePWflla/MNBTnDbQRv"}}],"available_content":[{"enabled":true,"product_id":221,"content":{"name":"MNBTnDbQRv","label":"Default_Organization_kfvePWflla_MNBTnDbQRv","vendor":"Custom","content_url":"/custom/kfvePWflla/MNBTnDbQRv","gpg_url":null,"id":"1540561080393","type":"yum","gpgUrl":null,"contentUrl":"/custom/kfvePWflla/MNBTnDbQRv"}}],"repositories":[{"name":"MNBTnDbQRv","id":133}],"provider":{"name":"Anonymous"},"sync_status":{"id":133,"product_id":221,"progress":{"progress":100.0},"sync_id":"942a64d2-f241-4806-bfbc-aec0ae78c217","state":"Syncing Complete.","raw_state":"stopped","start_time":"less than a minute ago","finish_time":"less than a minute ago","duration":"less than a minute","display_size":"No new packages.","size":"No new packages.","is_running":false,"error_details":"#<ActiveModel::Errors:0x00007fe8c63668a0>"},"permissions":{"view_products":true,"edit_products":true,"destroy_products":true,"sync_products":true},"published_content_view_ids":[],"active_task_count":0}

2018-10-26 16:38:25 - nailgun.client - DEBUG - Making HTTP DELETE request to https://server-host/katello/api/v2/organizations/1/sync_plans/9 with options {'auth': ('admin', 'changeme'), 'verify': False, 'headers': {'content-type': 'application/json'}}, no params and no data.
2018-10-26 16:38:28 - nailgun.client - DEBUG - Received HTTP 200 response:   {"id":9,"organization_id":1,"name":"POsdBWRUZf","description":null,"interval":"hourly","next_sync":null,"created_at":"2018-10-26 13:37:55 UTC","updated_at":"2018-10-26 13:37:55 UTC","enabled":false,"products":[{"id":221,"cp_id":"382614305246","name":"kfvePWflla","label":"kfvePWflla","description":null,"sync_state":"Syncing Complete.","last_sync":"2018-10-26 13:38:05 UTC","last_sync_words":"less than a minute","repository_count":1}],"permissions":{"view_sync_plans":true,"edit_sync_plans":true,"destroy_sync_plans":true},"sync_date":"2284/04/28 16:54:50 +0000"}

2018-10-26 16:38:28 - nailgun.client - DEBUG - Making HTTP GET request to https://server-host/katello/api/v2/products/221 with options {'auth': ('admin', 'changeme'), 'verify': False, 'headers': {'content-type': 'application/json'}}, no params and no data.
2018-10-26 16:38:29 - nailgun.client - DEBUG - Received HTTP 200 response:   {"redhat":false,"id":221,"cp_id":"382614305246","name":"kfvePWflla","label":"kfvePWflla","description":null,"provider_id":1,"sync_plan_id":null,"sync_summary":{"success":1},"gpg_key_id":null,"ssl_ca_cert_id":null,"ssl_client_cert_id":null,"ssl_client_key_id":null,"sync_state":"Syncing Complete.","last_sync":"2018-10-26 13:38:05 UTC","last_sync_words":"less than a minute","organization_id":1,"organization":{"name":"Default Organization","label":"Default_Organization","id":1},"sync_plan":null,"repository_count":1,"created_at":"2018-10-26 13:37:56 UTC","updated_at":"2018-10-26 13:38:27 UTC","product_content":[{"enabled":true,"product_id":221,"content":{"name":"MNBTnDbQRv","label":"Default_Organization_kfvePWflla_MNBTnDbQRv","vendor":"Custom","content_url":"/custom/kfvePWflla/MNBTnDbQRv","gpg_url":null,"id":"1540561080393","type":"yum","gpgUrl":null,"contentUrl":"/custom/kfvePWflla/MNBTnDbQRv"}}],"available_content":[{"enabled":true,"product_id":221,"content":{"name":"MNBTnDbQRv","label":"Default_Organization_kfvePWflla_MNBTnDbQRv","vendor":"Custom","content_url":"/custom/kfvePWflla/MNBTnDbQRv","gpg_url":null,"id":"1540561080393","type":"yum","gpgUrl":null,"contentUrl":"/custom/kfvePWflla/MNBTnDbQRv"}}],"repositories":[{"name":"MNBTnDbQRv","id":133}],"provider":{"name":"Anonymous"},"sync_status":{"id":133,"product_id":221,"progress":{"progress":100.0},"sync_id":"942a64d2-f241-4806-bfbc-aec0ae78c217","state":"Syncing Complete.","raw_state":"stopped","start_time":"less than a minute ago","finish_time":"less than a minute ago","duration":"less than a minute","display_size":"No new packages.","size":"No new packages.","is_running":false,"error_details":"#<ActiveModel::Errors:0x00007fe8c6ee7350>"},"permissions":{"view_products":true,"edit_products":true,"destroy_products":true,"sync_products":true},"published_content_view_ids":[],"active_task_count":0}

2018-10-26 16:38:29 - nailgun.client - DEBUG - Making HTTP GET request to https://server-host/katello/api/v2/organizations/1/sync_plans/9 with options {'auth': ('admin', 'changeme'), 'verify': False, 'headers': {'content-type': 'application/json'}}, no params and no data.
2018-10-26 16:38:30 - nailgun.client - WARNING - Received HTTP 404 response: {"displayMessage":"Couldn't find sync plan '9' in organization '1'","errors":["Couldn't find sync plan '9' in organization '1'"]}
PASSED2018-10-26 16:38:30 - robottelo - DEBUG - Finished Test: tests/foreman/draft/test_sync.py/test_product_sync_plan


========================== 1 passed in 39.57 seconds ===========================
Process finished with exit code 0

```
</details>