### PR TITLE
Use content credentials katello API instead of old gpg_keys

### DIFF
--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -109,6 +109,7 @@ class InitTestCase(TestCase):
                 entities.ConfigTemplate,
                 entities.ProvisioningTemplate,
                 # entities.ContentUpload,  # see below
+                entities.ContentCredential,
                 entities.ContentView,
                 entities.ContentViewVersion,
                 entities.DiscoveredHost,
@@ -1498,6 +1499,7 @@ class UpdateTestCase(TestCase):
         entities_ = (
             entities.AbstractComputeResource(self.cfg),
             entities.Architecture(self.cfg),
+            entities.ContentCredential(self.cfg),
             entities.ComputeProfile(self.cfg),
             entities.ConfigGroup(self.cfg),
             entities.DiscoveryRule(self.cfg),


### PR DESCRIPTION
This change will allow us to support SSL certificate management with
foreman_ansible_modules