### PR TITLE
CVV have lifecycle environments, not puppet envs

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -1941,7 +1941,7 @@ class ContentViewVersion(
     def __init__(self, server_config=None, **kwargs):
         self._fields = {
             'content_view': entity_fields.OneToOneField(ContentView),
-            'environment': entity_fields.OneToManyField(Environment),
+            'environment': entity_fields.OneToManyField(LifecycleEnvironment),
             'major': entity_fields.IntegerField(),
             'minor': entity_fields.IntegerField(),
             'package_count': entity_fields.IntegerField(),


### PR DESCRIPTION
To test:

```py
>>> cvv=ContentViewVersion(id=11).read()
>>> cvv.environment
[nailgun.entities.LifecycleEnvironment(id=1), nailgun.entities.LifecycleEnvironment(id=2), nailgun.entities.LifecycleEnvironment(id=3)]
>>> cvv.environment[0].read()
nailgun.entities.LifecycleEnvironment(description=None, label=u'Library', prior=None, organization=nailgun.entities.Organization(id=1), id=1, name=u'Library')
```