### PR TITLE
Add FAM tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ __pycache__/
 # Coverage information
 /.coverage
 /htmlcov/
+
+# FAM tests
+/foreman-ansible-modules/

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ python:
     - 3.6
 install:
     - pip install -r requirements.txt -r requirements-dev.txt --no-cache-dir
+addons:
+  apt:
+    packages:
+    - rpm
 script:
     - make lint
     - make test-coverage
@@ -12,6 +16,7 @@ script:
     - make docs-clean
     - make package
     - make package-clean
+    - make test-fam
 after_success:
     coveralls
 notifications:

--- a/Makefile
+++ b/Makefile
@@ -48,4 +48,10 @@ package-clean:
 publish: package
 	twine upload dist/*
 
+test-fam:
+	git clone https://github.com/theforeman/foreman-ansible-modules.git
+	pip install -r foreman-ansible-modules/requirements-dev.txt
+	$(MAKE) -C foreman-ansible-modules test/test_playbooks/server_vars.yml
+	$(MAKE) -C foreman-ansible-modules test
+
 .PHONY: help docs-html docs-clean lint test test-coverage package package-clean publish


### PR DESCRIPTION
This commit makes use of pre-recorded tests that FAM uses, this has a couple of benefits:
- Increase test coverage, using real-world recorded API interactions between nailgun and server. Unit tests only take us so far.
- pre-recorded means they are fast, no need to build and server, ect..
- Using the pre-recorded tests in FAM means Nailgun doesn't need to record its own.