### PR TITLE
lower the chunk size for content uploads to 2MB

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -1733,7 +1733,7 @@ class ContentUpload(
 
         try:
             offset = 0
-            content_chunk_size = 4 * 1024 * 1024
+            content_chunk_size = 2 * 1024 * 1024
 
             with open(filepath, 'rb') as contentfile:
                 chunk = contentfile.read(content_chunk_size)


### PR DESCRIPTION
Pulp/Django limit the upload size to about 2.5MB, so let's play safe and
use 2MB here.

(cherry picked from commit a3778dc3ba7308c0cfed8b3b6a0d7ee13f6f69cc)