### PR TITLE
Add MTU support to subnets

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -6397,6 +6397,7 @@ class Subnet(
             'network': entity_fields.IPAddressField(required=True),
             'to': entity_fields.IPAddressField(),
             'vlanid': entity_fields.StringField(),
+            'mtu': entity_fields.IntegerField(min_val=68, max_val=4294967295),
         }
         if _get_version(server_config) >= Version('6.1'):
             self._fields.update({


### PR DESCRIPTION
As MTU support for subnet has landed in [foreman 1.18](https://theforeman.org/manuals/1.18/index.html#Releasenotesfor1.18) and this version is included in [Satellite 6.4 (login required)](https://access.redhat.com/articles/1343683), this add MTU attribute in subnets for Satellite >= 6.4 and is needed by [theforeman/foreman-ansible-modules
#203](https://github.com/theforeman/foreman-ansible-modules/pull/203)