### PR TITLE
Added 6.5 workaround for Host Collection create

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2939,6 +2939,19 @@ class HostCollection(
             payload['system_uuids'] = payload.pop('system_ids')
         return payload
 
+    @signals.emit(sender=signals.SENDER_CLASS, post_result_name='entity')
+    def create(self, create_missing=None):
+        """Manually fetch a complete set of attributes for this entity.
+
+        For more information, see `Bugzilla #1654383
+        <https://bugzilla.redhat.com/show_bug.cgi?id=1654383>`_.
+
+        """
+        return HostCollection(
+            self._server_config,
+            id=self.create_json(create_missing)['id'],
+        ).read()
+
     def update_payload(self, fields=None):
         """Rename ``system_ids`` to ``system_uuids``."""
         payload = super(HostCollection, self).update_payload(fields)

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -580,6 +580,7 @@ class CreateTestCase(TestCase):
             entities.DockerComputeResource(self.cfg),
             entities.Domain(self.cfg),
             entities.Host(self.cfg),
+            entities.HostCollection(self.cfg),
             entities.HostGroup(self.cfg),
             entities.Location(self.cfg),
             entities.Media(self.cfg),


### PR DESCRIPTION
Test results:
```python
In [1]: hc = entities.HostCollection(organization=3, host=[2]).create()
2018-11-28 18:18:43 - nailgun.client - DEBUG - Making HTTP POST request to https://example.com/katello/api/v2/host_collections with options {'auth': ('admin', 'some_password'), 'verify': False, 'headers': {'content-type': 'application/json'}}, no params and data {"name": "ytdGyDgHTrIc", "host_ids": [2], "organization_id": 3}.
2018-11-28 18:18:44 - nailgun.client - DEBUG - Received HTTP 200 response:   {"name":"ytdGyDgHTrIc","organization_id":3,"max_hosts":null,"description":null,"total_hosts":1,"unlimited_hosts":true,"created_at":"2018-11-28 16:18:44 UTC","updated_at":"2018-11-28 16:18:44 UTC","id":10,"permissions":{"deletable":true,"editable":true}}

2018-11-28 18:18:44 - nailgun.client - DEBUG - Making HTTP GET request to https://example.com/katello/api/v2/host_collections/10 with options {'auth': ('admin', 'some_password'), 'verify': False, 'headers': {'content-type': 'application/json'}}, no params and no data.
2018-11-28 18:18:44 - nailgun.client - DEBUG - Received HTTP 200 response:   {"host_ids":[2],"name":"ytdGyDgHTrIc","organization_id":3,"max_hosts":null,"description":null,"total_hosts":1,"unlimited_hosts":true,"created_at":"2018-11-28 16:18:44 UTC","updated_at":"2018-11-28 16:18:44 UTC","id":10,"permissions":{"deletable":true,"editable":true}}


In [2]: hc.host
Out[2]: [nailgun.entities.Host(id=2)]
```