### PR TITLE
Add registry name fields to Lifecycle Environment

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -4062,6 +4062,8 @@ class LifecycleEnvironment(
                 required=True,
             ),
             'prior': entity_fields.OneToOneField(LifecycleEnvironment),
+            'registry_name_pattern': entity_fields.StringField(),
+            'registry_unauthenticated_pull': entity_fields.BooleanField(),
         }
         self._meta = {
             'api_path': 'katello/api/v2/environments',


### PR DESCRIPTION
Lifecycle Environment entity gained two fields in future Satellite 6.5 release.

To test:
```
entities.LifecycleEnvironment(id=1).read()
2018-11-29 13:37:05 - nailgun.client - DEBUG - Making HTTP GET request to https://sat-6-5-qa-rhel7.mzalewsk.example.com/katello/api/v2/environments/1 with options {'auth': ('admin', 'changeme'), 'verify': False, 'headers': {'content-type': 'application/json'}}, no params and no data.
2018-11-29 13:37:06 - nailgun.client - DEBUG - Received HTTP 200 response:   {"library":true,"registry_name_pattern":"<%= organization.label %>-<%= lifecycle_environment.label %>-<%= content_view.label %>-<%= product.name %>-<%= repository.label %>","registry_unauthenticated_pull":false,"id":1,"name":"Library","label":"Library","description":null,"organization_id":1,"organization":{"name":"Default Organization","label":"Default_Organization","id":1},"created_at":"2018-11-18 10:15:25 UTC","updated_at":"2018-11-23 15:06:33 UTC","prior":null,"successor":null,"counts":{"content_hosts":0,"content_views":1,"packages":0,"puppet_modules":0,"module_streams":0,"errata":{"security":null,"bugfix":null,"enhancement":null,"total":null},"yum_repositories":0,"docker_repositories":1,"ostree_repositories":0,"products":1},"permissions":{"create_lifecycle_environments":true,"view_lifecycle_environments":true,"edit_lifecycle_environments":true,"destroy_lifecycle_environments":false,"promote_or_remove_content_views_to_environments":true}}

nailgun.entities.LifecycleEnvironment(description=None, label='Library', name='Library', organization=nailgun.entities.Organization(id=1), prior=None, registry_name_pattern='<%= organization.label %>-<%= lifecycle_environment.label %>-<%= content_view.label %>-<%= product.name %>-<%= repository.label %>', registry_unauthenticated_pull=False, id=1)
```