### PR TITLE
added foreman_tasks_recurring_logic_id in sync plan entity

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -6687,6 +6687,7 @@ class SyncPlan(
             ),
             'product': entity_fields.OneToManyField(Product),
             'sync_date': entity_fields.DateTimeField(required=True),
+            'foreman_tasks_recurring_logic': entity_fields.OneToOneField(RecurringLogic)
         }
         super(SyncPlan, self).__init__(server_config, **kwargs)
         self._meta = {


### PR DESCRIPTION
**Description:** 
This is a new field was added in  sync plan for Satellite 6.5 feature while migrating sync plan from Pulp to Katello 

**How to use?**
```
In [10]: org = entities.Organization(id=1).read()

In [11]: sync_plan = entities.SyncPlan(organization=org, name='ddsd').search()

In [12]: sync_plan[0].foreman_tasks_recurring_logic.id
Out[12]: 2
```
**Objective** 

This will help to resolve https://github.com/SatelliteQE/robottelo/issues/6511 issue 