### PR TITLE
Fix search of Product added in Syncplan asks for organization

### DIFF
--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1469,6 +1469,60 @@ class ReadTestCase(TestCase):
         self.assertIn('root_pass', read.call_args[0][2])
 
 
+class SearchTestCase(TestCase):
+    """Tests for
+    :meth:`nailgun.entity_mixins.EntitySearchMixin.search`.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Set a server configuration at ``cls.cfg``."""
+        cls.cfg = config.ServerConfig('http://example.com')
+
+    def test_product_with_sync_plan(self):
+        """Call :meth:`nailgun.entities.Product.search` for a product with sync
+        plan assigned.
+
+        Ensure that the sync plan entity was correctly fetched.
+
+        """
+        with mock.patch.object(EntitySearchMixin, 'search_json') as search_json:
+            # Synplan set
+            search_json.return_value = {
+                'results': [
+                    {'id': 2,
+                     'name': 'test_product',
+                     'organization': {
+                         'id': 1,
+                         'label': 'Default_Organization',
+                         'name': 'Default Organization'},
+                     'organization_id': 1,
+                     'sync_plan': {
+                         'id': 1,
+                         'interval': 'hourly',
+                         'name': 'sync1'},
+                     'sync_plan_id': 1}]
+            }
+            result = entities.Product(self.cfg, organization=1).search()
+            self.assertIsNotNone(result[0].sync_plan)
+            self.assertEqual(result[0].sync_plan.id, 1)
+            # Synplan not set
+            search_json.return_value = {
+                'results': [
+                    {'id': 3,
+                     'name': 'test_product2',
+                     'organization': {
+                         'id': 1,
+                         'label': 'Default_Organization',
+                         'name': 'Default Organization'},
+                     'organization_id': 1,
+                     'sync_plan': None,
+                     'sync_plan_id': None}]
+            }
+            result = entities.Product(self.cfg, organization=1).search()
+            self.assertIsNone(result[0].sync_plan)
+
+
 class SearchNormalizeTestCase(TestCase):
     """Tests for
     :meth:`nailgun.entity_mixins.EntitySearchMixin.search_normalize`.


### PR DESCRIPTION
Fixes https://github.com/SatelliteQE/satellite6-upgrade/issues/260 issue

This fixes the Product entity search was breaking because it was not able to read the sync plan without organization.

The issue was observed due to bug - https://bugzilla.redhat.com/show_bug.cgi?id=1237283

Results post Fix:
```
In [14]: entities.Product(name='Red Hat Software Collections (for RHEL Server)', organization=org).search()
Out[14]: [nailgun.entities.Product(description=None, gpg_key=None, label='Red_Hat_Software_Collections__for_RHEL_Server_', name='Red Hat Software Collections (for RHEL Server)', organization=nailgun.entities.Organization(id=1), id=2, sync_plan=nailgun.entities.SyncPlan(id=1, organization=nailgun.entities.Organization(id=1)))]

In [16]: prod = entities.Product(name='Red Hat Software Collections (for RHEL Server)', organization=org).search()[0]

In [17]: prod.sync_plan
Out[17]: nailgun.entities.SyncPlan(id=1, organization=nailgun.entities.Organization(id=1))
```