### PR TITLE
Add docker_tags_whitelist field to Repository entity

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -5679,6 +5679,7 @@ class Repository(
             'docker_upstream_name': entity_fields.StringField(
                 default='busybox'
             ),
+            'docker_tags_whitelist': entity_fields.ListField(),
             'download_policy': entity_fields.StringField(
                 choices=('background', 'immediate', 'on_demand'),
                 default='immediate',


### PR DESCRIPTION
Repository entity gained new field in future Satellite 6.5 release.

To test:
```
>>> entities.Repository(content_type='docker', docker_upstream_name='alpine', name='test_docker_whitelist', docker_tags_whitelist=['latest'], product=entities.Product(organization=1).create(), url='https://registry-1.docker.io').create()
nailgun.entities.Repository(backend_identifier='cf5c7b27-6cd5-45e4-8624-5d2ade624994', checksum_type=None, content_counts={'ostree_branch': 0, 'docker_manifest': 0, 'docker_manifest_list': 0, 'docker_tag': 0, 'rpm': 0, 'srpm': 0, 'package': 0, 'package_group': 0, 'erratum': 0, 'puppet_module': 0, 'file': 0, 'deb': 0, 'module_stream': 0}, content_type='docker', container_repository_name='default_organization-qksddiiya-test_docker_whitelist', docker_upstream_name='alpine', docker_tags_whitelist=['latest'], download_policy=None, full_path='sat-6-5-qa-rhel7.mzalewsk.example.com:5000/default_organization-qksddiiya-test_docker_whitelist', gpg_key=None, label='test_docker_whitelist', last_sync=None, mirror_on_sync=True, name='test_docker_whitelist', product=nailgun.entities.Product(id=18), unprotected=True, url='https://registry-1.docker.io', upstream_username=None, verify_ssl_on_sync=True, id=18)
>>> repo = entities.Repository(id=18).read()
>>> repo.docker_tags_whitelist
['latest']
>>> repo.docker_tags_whitelist = ['nanoserver']
>>> repo.update()
nailgun.entities.Repository(backend_identifier='cf5c7b27-6cd5-45e4-8624-5d2ade624994', checksum_type=None, content_counts={'ostree_branch': 0, 'docker_manifest': 0, 'docker_manifest_list': 0, 'docker_tag': 0, 'rpm': 0, 'srpm': 0, 'package': 0, 'package_group': 0, 'erratum': 0, 'puppet_module': 0, 'file': 0, 'deb': 0, 'module_stream': 0}, content_type='docker', container_repository_name='default_organization-qksddiiya-test_docker_whitelist', docker_upstream_name='alpine', docker_tags_whitelist=['nanoserver'], download_policy=None, full_path='sat-6-5-qa-rhel7.mzalewsk.example.com:5000/default_organization-qksddiiya-test_docker_whitelist', gpg_key=None, label='test_docker_whitelist', last_sync=None, mirror_on_sync=True, name='test_docker_whitelist', product=nailgun.entities.Product(id=18), unprotected=True, url='https://registry-1.docker.io', upstream_username=None, verify_ssl_on_sync=True, id=18)
```