### PR TITLE
Use content credentials katello API instead of old gpg_keys (#554)

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -1619,6 +1619,41 @@ class DockerRegistryContainer(AbstractDockerContainer):
         super(DockerRegistryContainer, self).__init__(server_config, **kwargs)
 
 
+class ContentCredential(
+        Entity,
+        EntityCreateMixin,
+        EntityDeleteMixin,
+        EntityReadMixin,
+        EntitySearchMixin,
+        EntityUpdateMixin):
+    """A representation of a Content Credential entity."""
+
+    def __init__(self, server_config=None, **kwargs):
+        self._fields = {
+            'content': entity_fields.StringField(required=True),
+            'name': entity_fields.StringField(
+                required=True,
+                str_type='alpha',
+                length=(6, 12),
+                unique=True
+            ),
+            'organization': entity_fields.OneToOneField(
+                Organization,
+                required=True,
+            ),
+            'content_type': entity_fields.StringField(
+                choices=('cert', 'gpg_key'),
+                default='gpg_key',
+                required=True,
+            ),
+        }
+        self._meta = {
+            'api_path': 'katello/api/v2/content_credentials',
+            'server_modes': ('sat'),
+        }
+        super(ContentCredential, self).__init__(server_config, **kwargs)
+
+
 class ContentUpload(
         Entity,
         EntityCreateMixin,
@@ -2644,33 +2679,10 @@ class ForemanTask(Entity, EntityReadMixin, EntitySearchMixin):
         return _handle_response(response, self._server_config, synchronous)
 
 
-class GPGKey(
-        Entity,
-        EntityCreateMixin,
-        EntityDeleteMixin,
-        EntityReadMixin,
-        EntitySearchMixin,
-        EntityUpdateMixin):
+class GPGKey(ContentCredential):
     """A representation of a GPG Key entity."""
 
     def __init__(self, server_config=None, **kwargs):
-        self._fields = {
-            'content': entity_fields.StringField(required=True),
-            'name': entity_fields.StringField(
-                required=True,
-                str_type='alpha',
-                length=(6, 12),
-                unique=True
-            ),
-            'organization': entity_fields.OneToOneField(
-                Organization,
-                required=True,
-            ),
-        }
-        self._meta = {
-            'api_path': 'katello/api/v2/gpg_keys',
-            'server_modes': ('sat'),
-        }
         super(GPGKey, self).__init__(server_config, **kwargs)
 
 
@@ -4743,7 +4755,7 @@ class Product(
     def __init__(self, server_config=None, **kwargs):
         self._fields = {
             'description': entity_fields.StringField(),
-            'gpg_key': entity_fields.OneToOneField(GPGKey),
+            'gpg_key': entity_fields.OneToOneField(ContentCredential),
             'label': entity_fields.StringField(),
             'name': entity_fields.StringField(
                 required=True,
@@ -5281,7 +5293,7 @@ class Repository(
                 default='immediate',
             ),
             'full_path': entity_fields.StringField(),
-            'gpg_key': entity_fields.OneToOneField(GPGKey),
+            'gpg_key': entity_fields.OneToOneField(ContentCredential),
             'label': entity_fields.StringField(),
             'last_sync': entity_fields.OneToOneField(ForemanTask),
             'mirror_on_sync': entity_fields.BooleanField(),

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -109,6 +109,7 @@ class InitTestCase(TestCase):
                 entities.ConfigTemplate,
                 entities.ProvisioningTemplate,
                 # entities.ContentUpload,  # see below
+                entities.ContentCredential,
                 entities.ContentView,
                 entities.ContentViewVersion,
                 entities.DiscoveredHost,
@@ -1574,6 +1575,7 @@ class UpdateTestCase(TestCase):
         entities_ = (
             entities.AbstractComputeResource(self.cfg),
             entities.Architecture(self.cfg),
+            entities.ContentCredential(self.cfg),
             entities.ComputeProfile(self.cfg),
             entities.ConfigGroup(self.cfg),
             entities.DiscoveryRule(self.cfg),


### PR DESCRIPTION
This change will allow us to support SSL certificate management with
foreman_ansible_modules

------

Cherry-pick from https://github.com/SatelliteQE/nailgun/pull/554