### PR TITLE
Added org and loc for authsource entity

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -534,6 +534,8 @@ class AuthSourceLDAP(
             'attr_lastname': entity_fields.StringField(),
             'attr_login': entity_fields.StringField(),
             'attr_mail': entity_fields.EmailField(),
+            'location': entity_fields.OneToManyField(Location),
+            'organization': entity_fields.OneToManyField(Organization),
         }
         self._meta = {
             'api_path': 'api/v2/auth_source_ldaps',


### PR DESCRIPTION
 ```
auth = AuthSourceLDAP(server_config, onthefly_register=True, `name='test4',server_type='free_ipa',port='389',account='admin',account_password='changeme',base_dn='dc=example,dc=com',host='192.168.101.1', attr_login='login_ad',attr_lastname='surname',attr_firstname='firstname',attr_mail='mail', organization=[org],location=[loc]).create()
```

```
>>> auth.read()
nailgun.entities.AuthSourceLDAP(account='admin', attr_photo=None, base_dn='dc=example,dc=com', groups_base=None, host='192.168.101.1', name='test4', onthefly_register=True, port=389, server_type='free_ipa', tls=False, attr_firstname='firstname', attr_lastname='surname', attr_login='login_ad', attr_mail='mail', location=[nailgun.entities.Location(id=10)], organization=[nailgun.entities.Organization(id=11)], id=13)
```