### PR TITLE
Add Job Invocation entity

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -1396,6 +1396,77 @@ class TemplateInput(
                                                ignore=ignore, params=params)
 
 
+class JobInvocation(
+        Entity,
+        EntityReadMixin,
+        EntitySearchMixin):
+    """A representation of a Job invocation entity."""
+    def __init__(self, server_config=None, **kwargs):
+        self._fields = {
+            'description': entity_fields.StringField(),
+            'dynflow_task': entity_fields.OneToOneField(ForemanTask),
+            'failed': entity_fields.IntegerField(),
+            'job_category': entity_fields.StringField(),
+            'pending': entity_fields.IntegerField(),
+            'start_at': entity_fields.DateTimeField(),
+            'status': entity_fields.IntegerField(),
+            'status_label': entity_fields.StringField(),
+            'succeeded': entity_fields.IntegerField(),
+            'task': entity_fields.OneToOneField(ForemanTask),
+            'targeting': entity_fields.DictField(),
+            'targeting_id': entity_fields.IntegerField(),
+            'template_invocations': entity_fields.ListField(),
+            'total': entity_fields.IntegerField(),
+        }
+        self._meta = {
+            'api_path': 'api/job_invocations',
+            'server_modes': ('sat')}
+        super(JobInvocation, self).__init__(server_config, **kwargs)
+
+    def run(self, synchronous=True, **kwargs):
+        """Helper to run existing job template
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+            'data' supports next fields:
+
+                required:
+                    job_template_id/feature,
+                    targeting_type,
+                    search_query/bookmark_id,
+                    inputs
+                optional:
+                    description_format,
+                    concurrency_control
+                    scheduling,
+                    ssh,
+                    recurrence,
+                    execution_timeout_interval
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+        """
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
+        if 'data' in kwargs:
+            if 'job_template_id' not in kwargs['data'] and 'feature' not in kwargs['data']:
+                raise KeyError('Provide either job_template_id or feature value')
+            if 'search_query' not in kwargs['data'] and 'bookmark_id' not in kwargs['data']:
+                raise KeyError('Provide either search_query or bookmark_id value')
+            for param_name in ['targeting_type', 'inputs']:
+                if param_name not in kwargs['data']:
+                    raise KeyError('Provide {} value'.format(param_name))
+            kwargs['data'] = {u'job_invocation': kwargs['data']}
+        response = client.post(self.path('base'), **kwargs)
+        response.raise_for_status()
+        if synchronous is True:
+            return ForemanTask(
+                server_config=self._server_config, id=response.json()['task']['id']).poll()
+        return response.json()
+
+
 class JobTemplate(
     Entity,
     EntityCreateMixin,


### PR DESCRIPTION
```
entities.JobInvocation().run(synchronous=False, data={
    'job_template_id': 117,
    'inputs': {'command': "ls"},
    'targeting_type': 'static_query',
    'search_query': "name = {0}".format('***'),
})
{'id': 16, 'description': 'Run ls', 'job_category': 'Commands', 'targeting_id': 16, 'status': 3, 'start_at': '2018-12-20 12:50:03 UTC', 'status_label': 'running', 'dynflow_task': {'id': '6fdb8f93-a521-4717-b458-f701e66c0215', 'state': 'planned'}, 'succeeded': 'N/A', 'failed': 'N/A', 'pending': 'N/A', 'total': 1, 'targeting': {'bookmark_id': None, 'search_query': 'name = ***', 'targeting_type': 'static_query', 'user_id': 4, 'hosts': [{'name': '***', 'id': 1}]}, 'task': {'id': '6fdb8f93-a521-4717-b458-f701e66c0215', 'state': 'planned'}, 'template_invocations': []}
```