### PR TITLE
Make ComputeProfile searchable

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -765,6 +765,7 @@ class ComputeProfile(
         EntityCreateMixin,
         EntityDeleteMixin,
         EntityReadMixin,
+        EntitySearchMixin,
         EntityUpdateMixin):
     """A representation of a Compute Profile entity."""
 


### PR DESCRIPTION
Hoping to be able to remove https://github.com/theforeman/foreman-ansible-modules/blob/master/module_utils/ansible_nailgun_cement.py#L200

Its been in FAM for 1 year now, https://github.com/theforeman/foreman-ansible-modules/blob/master/module_utils/ansible_nailgun_cement.py#L468