### PR TITLE
Backport support for composite content views to 6.3 branch (from PR #589)

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -38,6 +38,7 @@ from nailgun.entity_mixins import (
     EntitySearchMixin,
     EntityUpdateMixin,
     _poll_task,
+    _payload,
     to_json_serializable as to_json
 )
 
@@ -1750,11 +1751,13 @@ class ContentViewVersion(
     def __init__(self, server_config=None, **kwargs):
         self._fields = {
             'content_view': entity_fields.OneToOneField(ContentView),
-            'environment': entity_fields.OneToManyField(Environment),
+            'description': entity_fields.StringField(),
+            'environment': entity_fields.OneToManyField(LifecycleEnvironment),
             'major': entity_fields.IntegerField(),
             'minor': entity_fields.IntegerField(),
             'package_count': entity_fields.IntegerField(),
             'puppet_module': entity_fields.OneToManyField(PuppetModule),
+            'repository': entity_fields.OneToManyField(Repository),
             'version': entity_fields.StringField(),
         }
         self._meta = {
@@ -2046,6 +2049,7 @@ class ContentView(
             'component': entity_fields.OneToManyField(ContentViewVersion),
             'composite': entity_fields.BooleanField(),
             'content_host_count': entity_fields.IntegerField(),
+            'content_view_component': entity_fields.OneToManyField(ContentViewComponent),
             'description': entity_fields.StringField(),
             'environment': entity_fields.OneToManyField(LifecycleEnvironment),
             'label': entity_fields.StringField(unique=True),
@@ -2077,13 +2081,64 @@ class ContentView(
         For more information, see `Bugzilla #1237257
         <https://bugzilla.redhat.com/show_bug.cgi?id=1237257>`_.
 
+        Add content_view_component to the response if needed, as
+        :meth:`nailgun.entity_mixins.EntityReadMixin.read` can't initialize
+        content_view_component.
         """
+        if attrs is None:
+            attrs = self.read_json()
         if _get_version(self._server_config) < Version('6.1'):
-            if attrs is None:
-                attrs = self.read_json()
             org = _get_org(self._server_config, attrs['organization']['label'])
             attrs['organization'] = org.get_values()
-        return super(ContentView, self).read(entity, attrs, ignore, params)
+
+        if ignore is None:
+            ignore = set()
+        ignore.add('content_view_component')
+        result = super(ContentView, self).read(entity, attrs, ignore, params)
+        if 'content_view_components' in attrs and attrs['content_view_components']:
+            result.content_view_component = [
+                ContentViewComponent(
+                    self._server_config,
+                    composite_content_view=result.id,
+                    id=content_view_component['id'],
+                )
+                for content_view_component in attrs['content_view_components']
+            ]
+        return result
+
+    def search(self, fields=None, query=None, filters=None):
+        """Search for entities.
+
+        :param fields: A set naming which fields should be used when generating
+            a search query. If ``None``, all values on the entity are used. If
+            an empty set, no values are used.
+        :param query: A dict containing a raw search query. This is melded in
+            to the generated search query like so:  ``{generated:
+            query}.update({manual: query})``.
+        :param filters: A dict. Used to filter search results locally.
+        :return: A list of entities, all of type ``type(self)``.
+        """
+        results = self.search_json(fields, query)['results']
+        results = self.search_normalize(results)
+        entities = []
+        for result in results:
+            content_view_components = result.get('content_view_component')
+            if content_view_components is not None:
+                del result['content_view_component']
+            entity = type(self)(self._server_config, **result)
+            if content_view_components:
+                entity.content_view_component = [
+                    ContentViewComponent(
+                        self._server_config,
+                        composite_content_view=result['id'],
+                        id=cvc_id,
+                    )
+                    for cvc_id in content_view_components
+                ]
+            entities.append(entity)
+        if filters is not None:
+            entities = self.search_filter(entities, filters)
+        return entities
 
     def path(self, which=None):
         """Extend ``nailgun.entity_mixins.Entity.path``.
@@ -2193,6 +2248,108 @@ class ContentView(
             '{0}/environments/{1}'.format(self.path(), environment_id),
             **self._server_config.get_client_kwargs()
         )
+        return _handle_response(response, self._server_config, synchronous)
+
+
+class ContentViewComponent(
+        Entity,
+        EntityReadMixin,
+        EntityUpdateMixin):
+    """A representation of a Content View Components entity."""
+
+    def __init__(self, server_config=None, **kwargs):
+        _check_for_value('composite_content_view', kwargs)
+        self._fields = {
+            'composite_content_view': entity_fields.OneToOneField(ContentView),
+            'content_view': entity_fields.OneToOneField(ContentView),
+            'content_view_version': entity_fields.OneToOneField(ContentViewVersion),
+            'latest': entity_fields.BooleanField(),
+        }
+        super(ContentViewComponent, self).__init__(server_config, **kwargs)
+        self._meta = {
+            'api_path': '{0}/content_view_components'.format(self.composite_content_view.path()),
+        }
+
+    def read(self, entity=None, attrs=None, ignore=None, params=None):
+        """
+        Add composite_content_view to the response if needed, as
+        :meth:`nailgun.entity_mixins.EntityReadMixin.read` can't initialize
+        composite_content_view.
+        """
+        if attrs is None:
+            attrs = self.read_json()
+        if ignore is None:
+            ignore = set()
+        if entity is None:
+            entity = type(self)(
+                self._server_config,
+                composite_content_view=self.composite_content_view,
+            )
+
+        ignore.add('composite_content_view')
+        return super(ContentViewComponent, self).read(entity, attrs, ignore, params)
+
+    def path(self, which=None):
+        """Extend ``nailgun.entity_mixins.Entity.path``.
+        The format of the returned path depends on the value of ``which``:
+
+        add
+            /content_view_components/add
+        remove
+            /content_view_components/remove
+
+        Otherwise, call ``super``.
+        """
+        if which in (
+                'add',
+                'remove'):
+            return '{0}/{1}'.format(
+                super(ContentViewComponent, self).path(which='base'),
+                which
+            )
+
+        return super(ContentViewComponent, self).path(which)
+
+    def add(self, synchronous=True, **kwargs):
+        """Add provided Content View Component.
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+        """
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        if 'data' not in kwargs:
+            # data is required
+            kwargs['data'] = dict()
+        if 'component_ids' not in kwargs['data']:
+            kwargs['data']['components'] = [_payload(self.get_fields(), self.get_values())]
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.put(self.path('add'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous)
+
+    def remove(self, synchronous=True, **kwargs):
+        """remove provided Content View Component.
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+        """
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        if 'data' not in kwargs:
+            # data is required
+            kwargs['data'] = dict()
+        if 'data' in kwargs and 'component_ids' not in kwargs['data']:
+            kwargs['data']['component_ids'] = [self.id]
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.put(self.path('remove'), **kwargs)
         return _handle_response(response, self._server_config, synchronous)
 
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -179,6 +179,7 @@ class InitTestCase(TestCase):
                 {'email': 'nobody@example.com', 'url': 'http://example.com'},
             ),
             (entities.ContentUpload, {'repository': 1}),
+            (entities.ContentViewComponent, {'composite_content_view': 1}),
             (entities.ContentViewFilterRule, {'content_view_filter': 1}),
             (entities.ContentViewPuppetModule, {'content_view': 1}),
             (entities.HostPackage, {'host': 1}),
@@ -223,6 +224,7 @@ class InitTestCase(TestCase):
 
         """
         for entity in (
+                entities.ContentViewComponent,
                 entities.ContentViewFilterRule,
                 entities.ContentViewPuppetModule,
                 entities.HostPackage,
@@ -1038,6 +1040,7 @@ class ReadTestCase(TestCase):
                     self.cfg,
                     content_view_filter=2,
                 ),
+                entities.ContentViewComponent(self.cfg, composite_content_view=2, content_view=1),
                 entities.ContentViewPuppetModule(self.cfg, content_view=2),
                 entities.Interface(self.cfg, host=2),
                 entities.Image(self.cfg, compute_resource=1),
@@ -1078,6 +1081,7 @@ class ReadTestCase(TestCase):
                 # entities.HostGroup,  # see HostGroupTestCase.test_read
                 # entities.Product,  # See Product.test_read
                 # entities.UserGroup,  # see test_attrs_arg_v2
+                entities.ContentView,
                 entities.Domain,
                 entities.Filter,
                 entities.Host,
@@ -2409,6 +2413,206 @@ class HostTestCase(TestCase):
         self.assertEqual(client_request.call_args[1], kwargs)
         self.assertEqual(handlr.call_count, 1)
         self.assertEqual(handlr.return_value, response)
+
+
+class ContentViewTestCase(TestCase):
+    """Tests for :class:`nailgun.entities.ContentView`."""
+    def setUp(self):
+        self.server_config = config.ServerConfig('http://example.com')
+        self.cv = entities.ContentView(
+            self.server_config,
+            id=gen_integer(min_value=1),
+        )
+        self.single_entity = {
+            "auto_publish": True,
+            "composite": True,
+            "components": [],
+            "content_host_count": 0,
+            "content_view_components": [{
+                "composite_content_view": {
+                    "id": 11,
+                    "label": "My_CVC",
+                    "name": "My CVC",
+                },
+                "content_view": {
+                    "id": 10,
+                    "label": "My_CV",
+                    "name": "My CV",
+                },
+                "content_view_version": {
+                    "content_view": {
+                        "id": 10,
+                        "label": "My_CV",
+                        "name": "My CV"
+                    },
+                    "content_view_id": 10,
+                    "environments": [
+                        {
+                            "id": 1,
+                        }
+                    ],
+                    "id": 21,
+                    "name": "My_CV 2.0",
+                    "version": "6.0"
+                },
+                "id": 4,
+                "latest": True,
+
+            }],
+            "description": None,
+            "environments": [{
+                "id": 1,
+                "name": "Library",
+                "label": "Library",
+            }],
+            "id": 5,
+            "label": "my_CV",
+            "last_published": '2018-11-23 11:51:30 UTC',
+            "name": "my CV",
+            "next_version": "3.0",
+            "organization_id": 1,
+            "puppet_modules": [{
+                "name": "katello-katello",
+                "id": 1,
+            }],
+            "repositories": [{
+                "name": "my_tst_repo",
+                "id": 3,
+            }],
+            "versions": [{
+                "id": 4,
+                "version": "2.0",
+                "environment_ids": [1],
+            }],
+        }
+
+    def test_read(self):
+        """Check that helper method is sane.
+        """
+        with mock.patch.object(self.cv, 'read_json', return_value=self.single_entity) as handlr:
+            response = self.cv.read()
+        self.assertEqual(handlr.call_count, 1)
+        self.assertEqual(type(response), entities.ContentView)
+        self.assertEqual(type(response.content_view_component[0]),
+                         entities.ContentViewComponent)
+
+    def test_search(self):
+        """Check that helper method is sane.
+        """
+        return_dict = {
+            'results': [self.single_entity],
+        }
+        with mock.patch.object(self.cv, 'search_json', return_value=return_dict) as handlr:
+            response = self.cv.search()
+        self.assertEqual(handlr.call_count, 1)
+        self.assertEqual(type(response[0]), entities.ContentView)
+        self.assertEqual(type(response[0].content_view_component[0]),
+                         entities.ContentViewComponent)
+
+
+class ContentViewComponentTestCase(TestCase):
+    """Tests for :class:`nailgun.entities.ContentViewComponent`."""
+
+    def setUp(self):
+        """Set a server configuration at ``self.cfg``."""
+
+        self.server_config = config.ServerConfig('http://example.com')
+        self.ccv = entities.ContentView(
+            self.server_config,
+            composite=True,
+            id=gen_integer(min_value=1),
+        )
+        self.cv = entities.ContentView(
+            self.server_config,
+            id=gen_integer(min_value=1),
+        )
+        self.cvc = entities.ContentViewComponent(
+            self.server_config,
+            composite_content_view=self.ccv,
+            content_view=self.cv,
+            latest=True,
+            id=gen_integer(min_value=1),
+        )
+        self.common_return_value = {
+            'composite_content_view': {
+                'label': 'mv_ccv',
+                'id': 11,
+            },
+            'content_view': {
+                'label': 'test',
+                'id': 10,
+            },
+            'content_view_version': {
+                'content_view_id': 10,
+                'content_view': {
+                    'label': 'test',
+                    'id': 10,
+                },
+                'repositories': [{
+                    'label': 'my_repo',
+                    'id': 19,
+                }],
+                'environments': [{
+                    'label': 'Library',
+                    'id': 1,
+                }],
+                'id': 21,
+            },
+            'id': 2,
+            'latest': True
+        }
+
+        self.read_json_pacther = mock.patch.object(self.cvc, 'read_json')
+
+    def test_path(self):
+        for which in ['add', 'remove']:
+            path = self.cvc.path(which=which)
+            self.assertIn('{}/content_view_components/{}'.format(
+                self.cvc.composite_content_view.id,
+                which), path)
+            self.assertRegex(path, which + '$')
+
+    def test_add(self):
+        """Check that helper method is sane.
+            Assert that:
+            * Method has a correct signature.
+            * Method calls `client.*` once.
+            * Method calls `entities._handle_response` once.
+        """
+        self.assertEqual(
+            inspect.getargspec(self.cvc.add),
+            (['self', 'synchronous'], None, 'kwargs', (True,))
+        )
+        return_dict = {
+            'results': [self.common_return_value]
+        }
+        with mock.patch.object(entities, '_handle_response', return_value=return_dict) as handlr:
+            with mock.patch.object(client, 'put') as client_request:
+                self.cvc.add()
+        self.assertEqual(client_request.call_count, 1)
+        self.assertEqual(len(client_request.call_args[0]), 1)
+        self.assertEqual(handlr.call_count, 1)
+
+    def test_remove(self):
+        """Check that helper method is sane.
+            Assert that:
+            * Method has a correct signature.
+            * Method calls `client.*` once.
+            * Method calls `entities._handle_response` once.
+        """
+        self.assertEqual(
+            inspect.getargspec(self.cvc.remove),
+            (['self', 'synchronous'], None, 'kwargs', (True,))
+        )
+        return_dict = {
+            'results': self.common_return_value
+        }
+        with mock.patch.object(entities, '_handle_response', return_value=return_dict) as handlr:
+            with mock.patch.object(client, 'put') as client_request:
+                self.cvc.remove()
+        self.assertEqual(client_request.call_count, 1)
+        self.assertEqual(len(client_request.call_args[0]), 1)
+        self.assertEqual(handlr.call_count, 1)
 
 
 class PuppetClassTestCase(TestCase):


### PR DESCRIPTION
The code applied to the 6.4 branch with PR 589 can be applied to 6.3 almost unchanged.

At my company we are still on Satellite 6.3, so if CCV support for 6.3 can be added upstream, it would save us from maintaining our own private fork.