### PR TITLE
[Cherry-pick 6.4.z] Add Job Invocation entity

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -7214,3 +7214,74 @@ class User(
         """
         self.update_json(fields)
         return self.read()
+
+
+class JobInvocation(
+        Entity,
+        EntityReadMixin,
+        EntitySearchMixin):
+    """A representation of a Job invocation entity. """
+    def __init__(self, server_config=None, **kwargs):
+        self._fields = {
+            'description': entity_fields.StringField(),
+            'dynflow_task': entity_fields.OneToOneField(ForemanTask),
+            'failed': entity_fields.IntegerField(),
+            'job_category': entity_fields.StringField(),
+            'pending': entity_fields.IntegerField(),
+            'start_at': entity_fields.DateTimeField(),
+            'status': entity_fields.IntegerField(),
+            'status_label': entity_fields.StringField(),
+            'succeeded': entity_fields.IntegerField(),
+            'task': entity_fields.OneToOneField(ForemanTask),
+            'targeting': entity_fields.DictField(),
+            'targeting_id': entity_fields.IntegerField(),
+            'template_invocations': entity_fields.ListField(),
+            'total': entity_fields.IntegerField(),
+        }
+        self._meta = {
+            'api_path': 'api/job_invocations',
+            'server_modes': ('sat')}
+        super(JobInvocation, self).__init__(server_config, **kwargs)
+
+    def run(self, synchronous=True, **kwargs):
+        """Helper to run existing job template
+
+        :param synchronous: What should happen if the server returns an HTTP
+         202 (accepted) status code? Wait for the task to complete if
+         ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+         'data' supports next fields:
+
+             required:
+                    job_template_id/feature,
+                    targeting_type,
+                    search_query/bookmark_id,
+                    inputs
+             optional:
+                    description_format,
+                    concurrency_control
+                    scheduling,
+                    ssh,
+                    recurrence,
+                    execution_timeout_interval
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+        """
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
+        if 'data' in kwargs:
+            if 'job_template_id' not in kwargs['data'] and 'feature' not in kwargs['data']:
+                raise KeyError('Provide either job_template_id or feature value')
+            if 'search_query' not in kwargs['data'] and 'bookmark_id' not in kwargs['data']:
+                raise KeyError('Provide either search_query or bookmark_id value')
+            for param_name in ['targeting_type', 'inputs']:
+                if param_name not in kwargs['data']:
+                    raise KeyError('Provide {} value'.format(param_name))
+            kwargs['data'] = {u'job_invocation': kwargs['data']}
+        response = client.post(self.path('base'), **kwargs)
+        response.raise_for_status()
+        if synchronous is True:
+            return ForemanTask(
+                server_config=self._server_config, id=response.json()['task']['id']).poll()
+        return response.json()

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -130,6 +130,7 @@ class InitTestCase(TestCase):
                 entities.HostCollectionErrata,
                 entities.HostCollectionPackage,
                 entities.HostGroup,
+                entities.JobInvocation,
                 entities.LibvirtComputeResource,
                 entities.LifecycleEnvironment,
                 entities.Location,
@@ -3509,3 +3510,50 @@ class JsonSerializableTestCase(TestCase):
             entities.ForemanTask, **kwargs)
         kwargs['started_at'] = '2016-11-20 01:02:03'
         self.assertDictEqual(kwargs, entities.to_json_serializable(task))
+
+
+class JobInvocationTestCase(TestCase):
+    """Tests for :class:`nailgun.entities.JobInvocation`."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.cfg = config.ServerConfig('http://example.com')
+
+    def test_required_param(self):
+        """Check required parameters"""
+        data_list = [
+            {'inputs': 'ls', 'search_query': 'foo'},
+            {'feature': 'foo', 'inputs': 'ls'},
+            {'job_template_id': 1, 'search_query': 'foo'},
+            {'feature': 'foo', 'bookmark_id': 1, 'inputs': 'ls'},
+            {'feature': 'foo', 'bookmark_id': 1, 'targeting_type': 'foo'},
+        ]
+        for data in data_list:
+            with self.assertRaises(KeyError):
+                entities.JobInvocation(self.cfg).run(data=data)
+
+    def test_non_sync_run(self):
+        """Run job asynchronously with valid parameters and check that correct
+        post request is sent
+        """
+        with mock.patch.object(client, 'post') as post:
+            entities.JobInvocation(self.cfg).run(synchronous=False, data={
+                'job_template_id': 1,
+                'search_query': 'foo',
+                'inputs': 'ls',
+                'targeting_type': 'foo'
+            })
+        self.assertEqual(post.call_count, 1)
+        self.assertEqual(len(post.call_args[0]), 1)
+
+    def test_sync_run(self):
+        """Check that sync run will result in ForemanTask poll"""
+        with mock.patch.object(entities, '_poll_task') as poll_task:
+            with mock.patch.object(client, 'post'):
+                entities.JobInvocation(self.cfg).run(synchronous=True, data={
+                    'job_template_id': 1,
+                    'search_query': 'foo',
+                    'inputs': 'ls',
+                    'targeting_type': 'foo'
+                })
+        self.assertEqual(poll_task.call_count, 1)


### PR DESCRIPTION
- Cherry pick of #596 
- Same API does exists with Satellite6.4
- Test results:
```
>>> entities.JobInvocation().run(synchronous=False, data={'job_template_id': 89, 'inputs': {'command': "ls"},'targeting_type': 'static_query', 'search_query': "name = 'test'"})
{'id': 12, 'description': 'Run ls', 'job_category': 'Commands', 'targeting_id': 12, 'status': 3, 'start_at': '2019-01-29 05:17:17 UTC', 'status_label': 'running', 'dynflow_task': {'id': 'c42f3ee2-e1e4-4520-9ba8-49bc1de92b66', 'state': 'planned'}, 'succeeded': 'N/A', 'failed': 'N/A', 'pending': 'N/A', 'total': 0, 'targeting': {'bookmark_id': None, 'search_query': "name = 'test'", 'targeting_type': 'static_query', 'user_id': 3, 'hosts': []}, 'task': {'id': 'c42f3ee2-e1e4-4520-9ba8-49bc1de92b66', 'state': 'planned'}, 'template_invocations': []}


>>>  entities.JobInvocation(id=12).read()
nailgun.entities.JobInvocation(description='Run ls', dynflow_task=nailgun.entities.ForemanTask(id='c42f3ee2-e1e4-4520-9ba8-49bc1de92b66'), failed=0, job_category='Commands', pending=0, start_at='2019-01-29 05:17:17 UTC', status=0, status_label='succeeded', succeeded=0, task=nailgun.entities.ForemanTask(id='c42f3ee2-e1e4-4520-9ba8-49bc1de92b66'), targeting={'bookmark_id': None, 'search_query': "name = 'test'", 'targeting_type': 'static_query', 'user_id': 3, 'hosts': []}, targeting_id=12, template_invocations=[], total=0, id=12)

>>>  entities.JobInvocation().search(query={'search': 'description="Run ls"'})
[nailgun.entities.JobInvocation(description='Run ls', dynflow_task=nailgun.entities.ForemanTask(id='c42f3ee2-e1e4-4520-9ba8-49bc1de92b66'), failed=0, job_category='Commands', pending=0, start_at='2019-01-29 05:17:17 UTC', status=0, status_label='succeeded', succeeded=0, targeting_id=12, total=0, id=12)]
```