### PR TITLE
Add Job Invocation entity

### DIFF
--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -128,6 +128,7 @@ class InitTestCase(TestCase):
                 entities.HostCollectionErrata,
                 entities.HostCollectionPackage,
                 entities.HostGroup,
+                entities.JobInvocation,
                 entities.LibvirtComputeResource,
                 entities.LifecycleEnvironment,
                 entities.Location,
@@ -3296,3 +3297,50 @@ class JsonSerializableTestCase(TestCase):
             entities.ForemanTask, **kwargs)
         kwargs['started_at'] = '2016-11-20 01:02:03'
         self.assertDictEqual(kwargs, entities.to_json_serializable(task))
+
+
+class JobInvocationTestCase(TestCase):
+    """Tests for :class:`nailgun.entities.JobInvocation`."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.cfg = config.ServerConfig('http://example.com')
+
+    def test_required_param(self):
+        """Check required parameters"""
+        data_list = [
+            {'inputs': 'ls', 'search_query': 'foo'},
+            {'feature': 'foo', 'inputs': 'ls'},
+            {'job_template_id': 1, 'search_query': 'foo'},
+            {'feature': 'foo', 'bookmark_id': 1, 'inputs': 'ls'},
+            {'feature': 'foo', 'bookmark_id': 1, 'targeting_type': 'foo'},
+        ]
+        for data in data_list:
+            with self.assertRaises(KeyError):
+                entities.JobInvocation(self.cfg).run(data=data)
+
+    def test_non_sync_run(self):
+        """Run job asynchronously with valid parameters and check that correct
+        post request is sent
+        """
+        with mock.patch.object(client, 'post') as post:
+            entities.JobInvocation(self.cfg).run(synchronous=False, data={
+                'job_template_id': 1,
+                'search_query': 'foo',
+                'inputs': 'ls',
+                'targeting_type': 'foo'
+            })
+        self.assertEqual(post.call_count, 1)
+        self.assertEqual(len(post.call_args[0]), 1)
+
+    def test_sync_run(self):
+        """Check that sync run will result in ForemanTask poll"""
+        with mock.patch.object(entities, '_poll_task') as poll_task:
+            with mock.patch.object(client, 'post'):
+                entities.JobInvocation(self.cfg).run(synchronous=True, data={
+                    'job_template_id': 1,
+                    'search_query': 'foo',
+                    'inputs': 'ls',
+                    'targeting_type': 'foo'
+                })
+        self.assertEqual(poll_task.call_count, 1)


### PR DESCRIPTION
- Same API does exists with Satellite6.3
- Test results:
```
>>> entities.JobInvocation().run(synchronous=False, data={'job_template_id': 110, 'inputs': {'command': "ls"},'targeting_type': 'static_query', 'search_query': "name = 'test'"})
{'id': 20, 'description': 'Run ls', 'job_category': 'Commands', 'targeting_id': 20, 'status': 3, 'start_at': '2019-01-29 05:13:23 UTC', 'status_label': 'running', 'dynflow_task': {'id': 'd8a38fca-48bf-4c11-93eb-c7e18191cdec', 'state': 'planned'}, 'succeeded': 'N/A', 'failed': 'N/A', 'pending': 'N/A', 'total': 'N/A', 'targeting': {'bookmark_id': None, 'search_query': "name = 'test'", 'targeting_type': 'static_query', 'user_id': 5, 'hosts': []}, 'task': {'id': 'd8a38fca-48bf-4c11-93eb-c7e18191cdec', 'state': 'planned'}, 'template_invocations': []}

>>> entities.JobInvocation(id=20).read()
nailgun.entities.JobInvocation(description='Run ls', dynflow_task=nailgun.entities.ForemanTask(id='d8a38fca-48bf-4c11-93eb-c7e18191cdec'), failed=0, job_category='Commands', pending=0, start_at='2019-01-29 05:13:23 UTC', status=0, status_label='succeeded', succeeded=0, task=nailgun.entities.ForemanTask(id='d8a38fca-48bf-4c11-93eb-c7e18191cdec'), targeting={'bookmark_id': None, 'search_query': "name = 'test'", 'targeting_type': 'static_query', 'user_id': 5, 'hosts': []}, targeting_id=20, template_invocations=[], total=0, id=20)

>>> entities.JobInvocation().search(query={'search': 'description="Run ls"'})
[nailgun.entities.JobInvocation(description='Run ls', dynflow_task=nailgun.entities.ForemanTask(id='d8a38fca-48bf-4c11-93eb-c7e18191cdec'), failed=0, job_category='Commands', pending=0, start_at='2019-01-29 05:13:23 UTC', status=0, status_label='succeeded', succeeded=0, targeting_id=20, total=0, id=20), nailgun.entities.JobInvocation(description='Run ls', dynflow_task=nailgun.entities.ForemanTask(id='d0726ce7-0755-494c-b1cd-4e31636d1e93'), failed=0, job_category='Commands', pending=0, start_at='2019-01-29 05:12:15 UTC', status=0, status_label='succeeded', succeeded=0, targeting_id=19, total=0, id=19), nailgun.entities.JobInvocation(description='Run ls', dynflow_task=nailgun.entities.ForemanTask(id='9303900e-887d-409a-9bae-4930ebd75216'), failed=0, job_category='Commands', pending=0, start_at='2019-01-28 13:59:05 UTC', status=0, status_label='succeeded', succeeded=0, targeting_id=18, total=0, id=18)]
```