### PR TITLE
Made UserGroup entity searchable

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -7413,6 +7413,7 @@ class UserGroup(
         EntityCreateMixin,
         EntityDeleteMixin,
         EntityReadMixin,
+        EntitySearchMixin,
         EntityUpdateMixin):
     """A representation of a User Group entity."""
 


### PR DESCRIPTION
```python
In [5]: entities.UserGroup().search()

Out[5]:
[nailgun.entities.UserGroup(admin=False, name='test_group1', id=1),
 nailgun.entities.UserGroup(admin=False, name='test_group2', id=2)]

In [6]: entities.UserGroup().search(query={'search': 'name=test_group1'})

Out[6]: [nailgun.entities.UserGroup(admin=False, name='test_group1', id=1)]
```