### PR TITLE
Add datacenter and quota for ovirt CR

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -1256,6 +1256,8 @@ class OVirtComputeResource(AbstractComputeResource):
             'password': entity_fields.StringField(),
             'user': entity_fields.StringField(),
             'use_v4': entity_fields.BooleanField(),
+            'datacenter': entity_fields.StringField(),
+            'ovirt_quota': entity_fields.StringField(),
         }
         super(OVirtComputeResource, self).__init__(server_config, **kwargs)
         self._fields['provider'].default = 'Ovirt'


### PR DESCRIPTION
Add fields:
* datacenter
* ovirt_quota

```
>>> from nailgun import entity_mixins, entity_fields, entities
>>> from nailgun.config import ServerConfig
>>> from nailgun.entities import Entity, AbstractComputeResource, OVirtComputeResource, ComputeProfile, ComputeAttribute, Location, Organization, Domain
>>> cr = AbstractComputeResource(id=2).read()
>>> cr
nailgun.entities.OVirtComputeResource(description='', location=[], name='ovirt-cr01', organization=[nailgun.entities.Organization(id=1)], provider='Ovirt', provider_friendly_name='oVirt', url='https://ovirt.example.com/ovirt-engine/api', user='bagasse@example.com', use_v4=True, datacenter='c1479626-99a2-44eb-8401-14b5630f417f', ovirt_quota='502a76bb-a3fe-42f1-aed6-2a7c892a6786', id=2)
>>>
```