### PR TITLE
add compute_attributes, interface_attributes and build_status_label fields to Host entity

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -3657,8 +3657,10 @@ class Host(  # pylint:disable=too-many-instance-attributes,R0904
             'all_parameters': entity_fields.ListField(),
             'architecture': entity_fields.OneToOneField(Architecture),
             'build': entity_fields.BooleanField(),
+            'build_status_label': entity_fields.StringField(),
             'capabilities': entity_fields.StringField(),
             'comment': entity_fields.StringField(),
+            'compute_attributes': entity_fields.DictField(),
             'compute_profile': entity_fields.OneToOneField(ComputeProfile),
             'compute_resource': entity_fields.OneToOneField(
                 AbstractComputeResource),
@@ -3670,6 +3672,7 @@ class Host(  # pylint:disable=too-many-instance-attributes,R0904
             'host_parameters_attributes': entity_fields.ListField(),
             'image': entity_fields.OneToOneField(Image),
             'interface': entity_fields.OneToManyField(Interface),
+            'interfaces_attributes': entity_fields.ListField(),
             'ip': entity_fields.StringField(),
             'location': entity_fields.OneToOneField(Location, required=True),
             'mac': entity_fields.MACAddressField(),
@@ -4070,6 +4073,8 @@ class Host(  # pylint:disable=too-many-instance-attributes,R0904
             ignore.add('host_parameters_attributes')
         if 'content_facet_attributes' not in attrs:
             ignore.add('content_facet_attributes')
+        ignore.add('compute_attributes')
+        ignore.add('interfaces_attributes')
         ignore.add('root_pass')
         # Image entity requires compute_resource_id to initialize as it is
         # part of its path. The thing is that entity_mixins.read() initializes


### PR DESCRIPTION
Implemented additional fields for `Host` entity. This unlocks the possibility of using nailgun for true compute-resource-based provisioning 

for the `build_status_label`:

```bash
# host in build mode:
In [8]: h = entities.Host(id=53).read()
2019-02-12 01:21:29 - nailgun.client - DEBUG - Making HTTP GET request to https://sat-6-5-qa-rhel7.localhost.example.com/api/v2/hosts/53 with options {'auth': ('admin', 'changeme'), 'verify': False, 'headers': {'content-type': 'application/json'}}, no params and no data.
2019-02-12 01:21:30 - nailgun.client - DEBUG - Received HTTP 200 response: {"ip":"192.168.100.124","ip6":null,"environment_id":31,"environment_name":"KT_JHiqyw_OHOssaCw_WvsPhv_112","last_report":null,"mac":"52:54:00:bb:51:8d","realm_id":null,"realm_name":null,"sp_mac":null,"sp_ip":null,"sp_name":null,"domain_id":1,"domain_name":"localhost.example.com","architecture_id":1,"architecture_name":"x86_64","operatingsystem_id":1,"operatingsystem_name":"RedHat 7.6","subnet_id":47,"subnet_name":"kLLHkkMtfG","subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":99,"ptable_name":"Kickstart default","medium_id":null,"medium_name":null,"pxe_loader":"PXELinux BIOS","build":true,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":52,"owner_id":57,"owner_name":"4VkqaC8PqM","owner_type":"User","enabled":true,"managed":true,"use_image":null,"image_file":"","uuid":"36862047-c197-4f22-a423-34c837938b33","compute_resource_id":54,"compute_resource_name":"pYVjUufcih","compute_profile_id":null,"compute_profile_name":null,"capabilities":["build","image","new_volume"],"provision_method":"build","certname":"cindy-cheshire.localhost.example.com","image_id":null,"image_name":null,"created_at":"2019-02-11 20:03:34 UTC","updated_at":"2019-02-11 20:03:34 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","organization_id":153,"organization_name":"JHiqyw","location_id":154,"location_name":"pAhCIHaFWK","puppet_status":0,"model_name":null,"build_status":1,"build_status_label":"Pending installation","name":"cindy-cheshire.localhost.example.com","id":53,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"openscap_proxy_id":null,"openscap_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"openscap_proxy":null,"token":"ab88a025-b3b2-47b7-91c6-96ff77dae3df","hostgroup_name":"RPcfZGtAgS","hostgroup_title":"RPcfZGtAgS","parameters":[{"priority":70,"created_at":"2019-02-11 20:03:34 UTC","updated_at":"2019-02-11 20:03:34 UTC","id":6,"name":"kt_activation_keys","value":"MWFYoVIZbQ"}],"all_parameters":[{"priority":70,"created_at":"2019-02-11 20:03:34 UTC","updated_at":"2019-02-11 20:03:34 UTC","id":6,"name":"kt_activation_keys","value":"MWFYoVIZbQ"},{"priority":0,"created_at":"2019-01-31 19:44:47 UTC","updated_at":"2019-01-31 19:44:47 UTC","id":2,"name":"enable-puppet5","value":"true"},{"priority":0,"created_at":"2019-01-31 19:44:47 UTC","updated_at":"2019-01-31 19:44:47 UTC","id":1,"name":"enable-epel","value":"false"}],"content_facet_attributes":{"id":9,"uuid":null,"content_view_id":112,"content_view_name":"WvsPhv","lifecycle_environment_id":113,"lifecycle_environment_name":"OHOssaCw","content_source_id":1,"content_source_name":"sat-6-5-qa-rhel7.localhost.example.com","kickstart_repository_id":167,"kickstart_repository_name":"167","errata_counts":{"security":0,"bugfix":0,"enhancement":0,"total":0},"applicable_package_count":0,"upgradable_package_count":0,"applicable_module_stream_count":0,"upgradable_module_stream_count":0,"content_view":{"id":112,"name":"WvsPhv"},"lifecycle_environment":{"id":113,"name":"OHOssaCw"},"content_source":{"id":1,"name":"sat-6-5-qa-rhel7.localhost.example.com","url":"https://sat-6-5-qa-rhel7.localhost.example.com:9090"},"kickstart_repository":{"id":167,"name":"Red Hat Enterprise Linux 7 Server Kickstart x86_64 7.6"},"content_view_version":"1.0","content_view_version_id":117,"content_view_default?":false,"lifecycle_environment_library?":false,"katello_agent_installed":false},"host_collections":[],"interfaces":[{"subnet_id":47,"subnet_name":"kLLHkkMtfG","subnet6_id":null,"subnet6_name":null,"domain_id":1,"domain_name":"localhost.example.com","created_at":"2019-02-11 20:03:34 UTC","updated_at":"2019-02-11 20:03:34 UTC","managed":true,"identifier":null,"id":61,"name":"cindy-cheshire.localhost.example.com","ip":"192.168.100.124","ip6":null,"mac":"52:54:00:bb:51:8d","mtu":1500,"fqdn":"cindy-cheshire.localhost.example.com","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"facts":{},"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"puppetrun_hosts":true,"play_roles_on_host":true,"view_discovered_hosts":true,"submit_discovered_hosts":true,"auto_provision_discovered_hosts":true,"provision_discovered_hosts":true,"edit_discovered_hosts":true,"destroy_discovered_hosts":true}}

In [9]: h.build_status_label
Out[9]: 'Pending installation'

# the build_status_label is a read-only attribute and setting it has no effect
In [10]: h = entities.Host(build_status_label="foo").create()
2019-02-12 01:22:36 - nailgun.client - DEBUG - Making HTTP POST request to https://sat-6-5-qa-rhel7.localhost.example.com/api/v2/locations with options {'auth': ('admin', 'changeme'), 'verify': False, 'headers': {'content-type': 'application/json'}}, no params and data {"location": {"name": "PgDjrSnv"}}
...
domain_id":10,"domain_name":"sbq3o6swiz","architecture_id":10,"architecture_name":"iYUuhS","operatingsystem_id":51,"operatingsystem_name":"nRjDpXEq 408","subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"sp_subnet_id":null,"ptable_id":153,"ptable_name":"otJIDRghcupLNAZXEiAsWhbontfn","medium_id":17,"medium_name":"aUXfytcb","pxe_loader":null,"build":false,"comment":null,"disk":null,"installed_at":null,"model_id":null,"hostgroup_id":null,"owner_id":4,"owner_name":"Admin User","owner_type":"User","enabled":true,"managed":true,"use_image":null,"image_file":"","uuid":null,"compute_resource_id":null,"compute_resource_name":null,"compute_profile_id":null,"compute_profile_name":null,"capabilities":["build"],"provision_method":"build","certname":"epfhdra.sbq3o6swiz","image_id":null,"image_name":null,"created_at":"2019-02-12 00:22:41 UTC","updated_at":"2019-02-12 00:22:41 UTC","last_compile":null,"global_status":0,"global_status_label":"OK","organization_id":164,"organization_name":"ucHRCH","location_id":163,"location_name":"PgDjrSnv","puppet_status":0,"model_name":null,"build_status":0,"build_status_label":"Installed","name":"epfhdra.sbq3o6swiz","id":60,"puppet_proxy_id":null,"puppet_proxy_name":null,"puppet_ca_proxy_id":null,"puppet_ca_proxy_name":null,"openscap_proxy_id":null,"openscap_proxy_name":null,"puppet_proxy":null,"puppet_ca_proxy":null,"openscap_proxy":null,"hostgroup_name":null,"hostgroup_title":null,"parameters":[],"all_parameters":[{"priority":0,"created_at":"2019-01-31 19:44:47 UTC","updated_at":"2019-01-31 19:44:47 UTC","id":2,"name":"enable-puppet5","value":"true"},{"priority":0,"created_at":"2019-01-31 19:44:47 UTC","updated_at":"2019-01-31 19:44:47 UTC","id":1,"name":"enable-epel","value":"false"}],"host_collections":[],"interfaces":[{"subnet_id":null,"subnet_name":null,"subnet6_id":null,"subnet6_name":null,"domain_id":10,"domain_name":"sbq3o6swiz","created_at":"2019-02-12 00:22:41 UTC","updated_at":"2019-02-12 00:22:41 UTC","managed":true,"identifier":null,"id":68,"name":"epfhdra.sbq3o6swiz","ip":null,"ip6":null,"mac":"96:30:16:88:e9:f5","mtu":null,"fqdn":"epfhdra.sbq3o6swiz","primary":true,"provision":true,"type":"interface","virtual":false}],"puppetclasses":[],"config_groups":[],"all_puppetclasses":[],"permissions":{"view_hosts":true,"create_hosts":true,"edit_hosts":true,"destroy_hosts":true,"build_hosts":true,"power_hosts":true,"console_hosts":true,"ipmi_boot_hosts":true,"puppetrun_hosts":true,"play_roles_on_host":true,"view_discovered_hosts":true,"submit_discovered_hosts":true,"auto_provision_discovered_hosts":true,"provision_discovered_hosts":true,"edit_discovered_hosts":true,"destroy_discovered_hosts":true}}
In [11]: h.build_status_label
Out[11]: 'Installed'

# host with build=False
In [12]: h = entities.Host().create()
...
2019-02-12 01:32:24 - nailgun.client - DEBUG - Making HTTP POST request to https://sat-6-5-qa-rhel7.localhost.example.com/api/v2/hosts with options {'auth': ('admin', 'changeme'), 'verify': False, 'headers': {'content-type': 'application/json'}}, no params and data {"host": {"name": "oriveis", "mac": "2e:4f:f0:e3:39:51", "root_pass": "rpmJntAPhecpSxGycRsmswXnIh", "architecture_id": 11, "domain_id": 11, "environment_id": 40, "location_id": 165, "medium_id": 18, "operatingsystem_id": 52, "organization_id": 166, "ptable_id": 154}}.
...
In [13]: h.build_status_label
Out[13]: 'Installed'
```

here are the `compute_attributes` and `interfaces_attributes` in live action:
https://github.com/rplevka/robottelo/blob/e2e-api/tests/foreman/endtoend/test_api_endtoend.py#L1455-L1470

and the relevant output from the test (pretty-printed):
```
2019-02-07 22:46:52 - nailgun.client - DEBUG - Making HTTP POST request to https://sat-6-5-qa-rhel7.localhost.example.com/api/v2/hosts with options {'auth': ('admin', 'changeme'), 'verify': False, 'headers': {'content-type': 'application/json'}}, no params and data
{  
  "host":{  
    "mac":"a4:53:6f:0c:f3:d6",
    "interfaces_attributes":[  
      {  
        "compute_attributes":{  
          "network":"provision",
          "type":"network",
          "provision":true,
          "managed":true
        }
      }
    ],
    "compute_attributes":{  
      "start":"1",
      "volumes_attributes":{  
        "0":{  
          "poolname":"default",
          "capacity":"20G",
          "format_type":"raw"
        }
      }
    },
    "build":true,
    "content_facet_attributes":{  
      "kickstart_repository_id":153,
      "content_source_id":1,
      "content_view_id":69,
      "lifecycle_environment_id":70,
      "name":"ktl-yigweNFvdV"
    },
    "host_parameters_attributes":[  
      {  
        "name":"kt_activation_keys",
        "value":"GVIlRJGSNA"
      }
    ],
    "root_pass":"changeme",
    "architecture_id":1,
    "compute_resource_id":31,
    "domain_id":1,
    "environment_id":1,
    "hostgroup_id":32,
    "location_id":73,
    "operatingsystem_id":1,
    "organization_id":72,
    "ptable_id":99,
    "subnet_id":23
  }
}
.
2019-02-07 22:46:57 - nailgun.client - DEBUG - Received HTTP 201 response: 

{  
  "ip":"192.168.100.90",
  "ip6":null,
  "environment_id":21,
  "environment_name":"KT_eCVpFHWgs_DMmXGuo_zecPRlV_69",
  "last_report":null,
  "mac":"52:54:00:33:d4:b2",
  "realm_id":null,
  "realm_name":null,
  "sp_mac":null,
  "sp_ip":null,
  "sp_name":null,
  "domain_id":1,
  "domain_name":"foo.bar",
  "architecture_id":1,
  "architecture_name":"x86_64",
  "operatingsystem_id":1,
  "operatingsystem_name":"RedHat 7.6",
  "subnet_id":23,
  "subnet_name":"fbuuiKpYVO",
  "subnet6_id":null,
  "subnet6_name":null,
  "sp_subnet_id":null,
  "ptable_id":99,
  "ptable_name":"Kickstart default",
  "medium_id":null,
  "medium_name":null,
  "pxe_loader":"PXELinux BIOS",
  "build":true,
  "comment":null,
  "disk":null,
  "installed_at":null,
  "model_id":null,
  "hostgroup_id":32,
  "owner_id":4,
  "owner_name":"Admin User",
  "owner_type":"User",
  "enabled":true,
  "managed":true,
  "use_image":null,
  "image_file":"",
  "uuid":"59c1a85d-45fe-44fe-93fb-708570e8183b",
  "compute_resource_id":31,
  "compute_resource_name":"KZkLAGOrGa",
  "compute_profile_id":null,
  "compute_profile_name":null,
  "capabilities":[  
    "build",
    "image",
    "new_volume"
  ],
  "provision_method":"build",
  "certname":"sadie-pennix.foo.bar",
  "image_id":null,
  "image_name":null,
  "created_at":"2019-02-07 21:46:57 UTC",
  "updated_at":"2019-02-07 21:46:57 UTC",
  "last_compile":null,
  "global_status":0,
  "global_status_label":"OK",
  "organization_id":72,
  "organization_name":"eCVpFHWgs",
  "location_id":73,
  "location_name":"YOUEAa",
  "puppet_status":0,
  "model_name":null,
  "build_status":1,
  "build_status_label":"Pending installation",
  "name":"sadie-pennix.foo.bar",
  "id":32,
  "puppet_proxy_id":null,
  "puppet_proxy_name":null,
  "puppet_ca_proxy_id":null,
  "puppet_ca_proxy_name":null,
  "openscap_proxy_id":null,
  "openscap_proxy_name":null,
  "puppet_proxy":null,
  "puppet_ca_proxy":null,
  "openscap_proxy":null,
  "token":"796d4e26-7662-4514-9f1f-25ac4ec7bd50",
  "hostgroup_name":"qFVmoYrBvj",
  "hostgroup_title":"qFVmoYrBvj",
  "parameters":[  
    {  
      "priority":70,
      "created_at":"2019-02-07 21:46:57 UTC",
      "updated_at":"2019-02-07 21:46:57 UTC",
      "id":5,
      "name":"kt_activation_keys",
      "value":"GVIlRJGSNA"
    }
  ],
  "all_parameters":[  
    {  
      "priority":70,
      "created_at":"2019-02-07 21:46:57 UTC",
      "updated_at":"2019-02-07 21:46:57 UTC",
      "id":5,
      "name":"kt_activation_keys",
      "value":"GVIlRJGSNA"
    },
    {  
      "priority":0,
      "created_at":"2019-01-31 19:44:47 UTC",
      "updated_at":"2019-01-31 19:44:47 UTC",
      "id":2,
      "name":"enable-puppet5",
      "value":"true"
    },
    {  
      "priority":0,
      "created_at":"2019-01-31 19:44:47 UTC",
      "updated_at":"2019-01-31 19:44:47 UTC",
      "id":1,
      "name":"enable-epel",
      "value":"false"
    }
  ],
  "content_facet_attributes":{  
    "id":8,
    "uuid":null,
    "content_view_id":69,
    "content_view_name":"zecPRlV",
    "lifecycle_environment_id":70,
    "lifecycle_environment_name":"DMmXGuo",
    "content_source_id":1,
    "content_source_name":"sat-6-5-qa-rhel7.localhost.example.com",
    "kickstart_repository_id":153,
    "kickstart_repository_name":"153",
    "errata_counts":{  
      "security":0,
      "bugfix":0,
      "enhancement":0,
      "total":0
    },
    "applicable_package_count":0,
    "upgradable_package_count":0,
    "applicable_module_stream_count":0,
    "upgradable_module_stream_count":0,
    "content_view":{  
      "id":69,
      "name":"zecPRlV"
    },
    "lifecycle_environment":{  
      "id":70,
      "name":"DMmXGuo"
    },
    "content_source":{  
      "id":1,
      "name":"sat-6-5-qa-rhel7.localhost.example.com",
      "url":"https://sat-6-5-qa-rhel7.localhost.example.com:9090"
    },
    "kickstart_repository":{  
      "id":153,
      "name":"Red Hat Enterprise Linux 7 Server Kickstart x86_64 7.6"
    },
    "content_view_version":"1.0",
    "content_view_version_id":74,
    "content_view_default?":false,
    "lifecycle_environment_library?":false,
    "katello_agent_installed":false
  },
  "host_collections":[  

  ],
  "interfaces":[  
    {  
      "subnet_id":23,
      "subnet_name":"fbuuiKpYVO",
      "subnet6_id":null,
      "subnet6_name":null,
      "domain_id":1,
      "domain_name":"foo.bar",
      "created_at":"2019-02-07 21:46:57 UTC",
      "updated_at":"2019-02-07 21:46:57 UTC",
      "managed":true,
      "identifier":null,
      "id":40,
      "name":"sadie-pennix.foo.bar",
      "ip":"192.168.100.90",
      "ip6":null,
      "mac":"52:54:00:33:d4:b2",
      "mtu":1500,
      "fqdn":"sadie-pennix.foo.bar",
      "primary":true,
      "provision":true,
      "type":"interface",
      "virtual":false
    }
  ],
  "puppetclasses":[  

  ],
  "config_groups":[  

  ],
  "all_puppetclasses":[  

  ],
  "facts":{  

  },
  "permissions":{  
    "view_hosts":true,
    "create_hosts":true,
    "edit_hosts":true,
    "destroy_hosts":true,
    "build_hosts":true,
    "power_hosts":true,
    "console_hosts":true,
    "ipmi_boot_hosts":true,
    "puppetrun_hosts":true,
    "play_roles_on_host":true,
    "view_discovered_hosts":true,
    "submit_discovered_hosts":true,
    "auto_provision_discovered_hosts":true,
    "provision_discovered_hosts":true,
    "edit_discovered_hosts":true,
    "destroy_discovered_hosts":true
  }
}
```
