### PR TITLE
Fixes build_status_label, not always returned

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -4085,6 +4085,7 @@ class Host(  # pylint:disable=too-many-instance-attributes,R0904
         ignore.add('image')
         # host id is required for interface initialization
         ignore.add('interface')
+        ignore.add('build_status_label')
         result = super(Host, self).read(entity, attrs, ignore, params)
         if attrs.get('image_id'):
             result.image = Image(
@@ -4103,6 +4104,8 @@ class Host(  # pylint:disable=too-many-instance-attributes,R0904
                 )
                 for interface in attrs['interfaces']
             ]
+        if 'build_status_label' in attrs:
+            result.build_status_label = attrs['build_status_label']
         return result
 
     @signals.emit(sender=signals.SENDER_CLASS, post_result_name='entity')


### PR DESCRIPTION
closes https://github.com/SatelliteQE/nailgun/issues/617

Think  we have to keep it simple and rely only only server response , if return initialize
out put of a test when not returned , and was failing in automation
```
(robottelo) dlezz@dlezz:~/projects/robottelo-fork$ pytest -v tests/foreman/ui_airgun/test_hostcollection.py::test_positive_install_package_group 
============================================ test session starts =============================================
platform linux -- Python 3.6.6, pytest-4.0.2, py-1.5.4, pluggy-0.8.0 -- /home/dlezz/.pyenv/versions/robottelo/bin/python3.6
cachedir: .pytest_cache
shared_function enabled - ON - scope: ffff - storage: redis
rootdir: /home/dlezz/projects/robottelo-fork, inifile:
plugins: xdist-1.26.0, timeout-1.3.3, services-1.3.1, mock-1.10.0, forked-0.2, cov-2.6.1
collecting ... 2019-03-18 11:39:18 - conftest - DEBUG - BZ deselect is disabled in settings

collected 1 item                                                                                             

tests/foreman/ui_airgun/test_hostcollection.py::test_positive_install_package_group PASSED             [100%]

========================================= 1 passed in 702.52 seconds =========================================
```
other output when return 

```
In[2]: from robottelo.config import settings
In[3]: settings.configure()
In[4]: from nailgun import entities
In[5]: org = entities.Organization(id=3).read()
In[6]: host = entities.Host(organization=org).create()
In[7]: host.build_status_label
Out[7]: 'Installed'
In[8]: host.name
Out[8]: 'wbgisvl.12cyed89rv'
In[9]: host = host.read()
In[10]: host.build_status_label
Out[10]: 'Installed'
```
