### PR TITLE
Make it possible to set timeout when pooling publish task

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2697,7 +2697,7 @@ class ContentView(
             )
         return super(ContentView, self).path(which)
 
-    def publish(self, synchronous=True, **kwargs):
+    def publish(self, synchronous=True, timeout=None, **kwargs):
         """Helper for publishing an existing content view.
 
         :param synchronous: What should happen if the server returns an HTTP
@@ -2714,7 +2714,8 @@ class ContentView(
             kwargs['data']['id'] = self.id  # pylint:disable=no-member
         kwargs.update(self._server_config.get_client_kwargs())
         response = client.post(self.path('publish'), **kwargs)
-        return _handle_response(response, self._server_config, synchronous)
+        return _handle_response(response, self._server_config, synchronous=synchronous,
+                                timeout=timeout)
 
     def available_puppet_modules(self, synchronous=True, **kwargs):
         """Get puppet modules available to be added to the content view.

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -2332,10 +2332,16 @@ class GenericTestCase(TestCase):
         """
         for method, request in self.methods_requests:
             with self.subTest((method, request)):
-                self.assertEqual(
-                    inspect.getargspec(method),
-                    (['self', 'synchronous'], None, 'kwargs', (True,))
-                )
+                if ' ContentView.publish ' in str(method):
+                    self.assertEqual(
+                        inspect.getargspec(method),
+                        (['self', 'synchronous', 'timeout'], None, 'kwargs', (True, None))
+                    )
+                else:
+                    self.assertEqual(
+                        inspect.getargspec(method),
+                        (['self', 'synchronous'], None, 'kwargs', (True,))
+                    )
                 kwargs = {'kwarg': gen_integer()}
                 with mock.patch.object(entities, '_handle_response') as handlr:
                     with mock.patch.object(client, request) as client_request:


### PR DESCRIPTION
I need this in my test as in my case Publish task takes more than 10 minutes (`timeout=300` is default).