### PR TITLE
Added support for rebuild_config in hostgroup

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -3548,6 +3548,8 @@ class HostGroup(
             /api/hostgroups/:hostgroup_id/clone
         puppetclass_ids
             /api/hostgroups/:hostgroup_id/puppetclass_ids
+        rebuild_config
+            /api/hostgroups/:hostgroup_id/rebuild_config
         smart_class_parameters
             /api/hostgroups/:hostgroup_id/smart_class_parameters
         smart_class_variables
@@ -3559,6 +3561,7 @@ class HostGroup(
         if which in (
                 'clone',
                 'puppetclass_ids',
+                'rebuild_config',
                 'smart_class_parameters',
                 'smart_variables'
         ):
@@ -3663,6 +3666,22 @@ class HostGroup(
         kwargs = kwargs.copy()
         kwargs.update(self._server_config.get_client_kwargs())
         response = client.post(self.path('clone'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous)
+
+    def rebuild_config(self, synchronous=True, **kwargs):
+        """Helper to 'Rebuild orchestration config' of an existing host group
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+        """
+        kwargs = kwargs.copy()
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.put(self.path('rebuild_config'), **kwargs)
         return _handle_response(response, self._server_config, synchronous)
 
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -413,6 +413,7 @@ class PathTestCase(TestCase):
                 (entities.ContentView, 'publish'),
                 (entities.ContentViewVersion, 'promote'),
                 (entities.ForemanTask, 'self'),
+                (entities.HostGroup, 'rebuild_config'),
                 (entities.Organization, 'products'),
                 (entities.Organization, 'self'),
                 (entities.Organization, 'subscriptions'),

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -3186,7 +3186,7 @@ class HostGroupTestCase(TestCase):
 
     def test_rebuild_config(self):
         """"Test for :meth:`nailgun.entities.HostGroup.rebuild_config`
-                Assert that the method is called one with correct argumets
+        Assert that the method is called one with correct arguments
         """
         entity = self.entity
         entity.id = 1

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -3184,6 +3184,29 @@ class HostGroupTestCase(TestCase):
         self.assertEqual(handler.call_count, 1)
         self.assertEqual(handler.return_value, response)
 
+    def test_rebuild_config(self):
+        """"Test for :meth:`nailgun.entities.HostGroup.rebuild_config`
+                Assert that the method is called one with correct argumets
+        """
+        entity = self.entity
+        entity.id = 1
+        self.assertEqual(
+            inspect.getargspec(entity.rebuild_config),
+            (['self', 'synchronous'], None, 'kwargs', (True,))
+        )
+        kwargs = {
+            'kwarg': gen_integer(),
+            'data': {'only': 'TFTP'}
+        }
+        with mock.patch.object(entities, '_handle_response') as handler:
+            with mock.patch.object(client, 'put') as put:
+                response = entity.rebuild_config(**kwargs)
+        self.assertEqual(put.call_count, 1)
+        self.assertEqual(len(put.call_args[0]), 1)
+        self.assertEqual(put.call_args[1], kwargs)
+        self.assertEqual(handler.call_count, 1)
+        self.assertEqual(handler.return_value, response)
+
 
 class HostTestCase(TestCase):
     """Tests for :class:`nailgun.entities.Host`."""

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -351,6 +351,7 @@ class PathTestCase(TestCase):
                 (entities.Host, 'smart_variables'),
                 (entities.HostGroup, 'clone'),
                 (entities.HostGroup, 'puppetclass_ids'),
+                (entities.HostGroup, 'rebuild_config'),
                 (entities.HostGroup, 'smart_class_parameters'),
                 (entities.HostGroup, 'smart_variables'),
                 (entities.Organization, 'download_debug_certificate'),


### PR DESCRIPTION
- Added support for rebuild_config in hostgroup
- test result:
```
(Pdb) dir(hostgroup)
['__class__', '__delattr__', '__dict__', '__dir__', '__doc__', '__eq__', '__format__', '__ge__', '__getattribute__', '__gt__', '__hash__', '__init__', '__init_subclass__', '__le__', '__lt__', '__module__', '__ne__', '__new__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__', '__sizeof__', '__str__', '__subclasshook__', '__weakref__', '_fields', '_meta', '_server_config', 'add_puppetclass', 'architecture', 'clone', 'compare', 'content_source', 'content_view', 'create', 'create_json', 'create_missing', 'create_payload', 'create_raw', 'delete', 'delete_puppetclass', 'delete_raw', 'domain', 'environment', 'get_fields', 'get_values', 'id', 'lifecycle_environment', 'list_scparams', 'list_smart_variables', 'location', 'medium', 'name', 'operatingsystem', 'organization', 'parent', 'path', 'ptable', 'puppet_ca_proxy', 'puppet_proxy', 'read', 'read_json', 'read_raw', 'realm', 'rebuild_config', 'search', 'search_filter', 'search_json', 'search_normalize', 'search_payload', 'search_raw', 'subnet', 'to_json', 'to_json_dict', 'update', 'update_json', 'update_payload', 'update_raw']
(Pdb) 

(Pdb) hostgroup.rebuild_config(data={'only': 'DNS'})
{'message': 'Configuration successfully rebuilt.'}
(Pdb) hostgroup.rebuild_config(data={'only': 'TFTP'})
{'message': 'Configuration successfully rebuilt.'}
(Pdb) 
```