### PR TITLE
uuid for ContentViewPuppetModule now deprecated

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2521,7 +2521,6 @@ class ContentViewPuppetModule(
                 unique=True
 
             ),
-            'uuid': entity_fields.StringField(unique=True),
         }
         super(ContentViewPuppetModule, self).__init__(server_config, **kwargs)
         self._meta = {


### PR DESCRIPTION
deprecated in this commit: https://github.com/Katello/katello/pull/8135/files

Robottelo api tests for classparameters are affected by this, example test result after change:

```
pytest tests/foreman/api/test_classparameters.py -k test_negative_enable_avoid_duplicates_checkbox================================================================= test session starts ==================================================================
platform linux -- Python 3.7.3, pytest-4.0.2, py-1.7.0, pluggy-0.12.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/pondrejk/Documents/robottelo, inifile:
plugins: cov-2.7.1, mock-1.10.4, forked-0.2, services-1.3.1, xdist-1.29.0
collecting ... 2019-06-19 13:08:01 - conftest - DEBUG - BZ deselect is disabled in settings

collected 49 items / 48 deselected                                                                                                                     

tests/foreman/api/test_classparameters.py .                                                                                                      [100%]


================================================= 1 passed, 48 deselected, 1 warnings in 78.29 seconds =================================================
```