### PR TITLE
authSourceLDAP Search support

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -552,7 +552,8 @@ class AuthSourceLDAP(
         EntityCreateMixin,
         EntityDeleteMixin,
         EntityReadMixin,
-        EntityUpdateMixin):
+        EntityUpdateMixin,
+        EntitySearchMixin):
     """A representation of a AuthSourceLDAP entity."""
 
     def __init__(self, server_config=None, **kwargs):


### PR DESCRIPTION
$subject

Results:
----------------

```
In [2]: entities.AuthSourceLDAP().search(query={'search': 'name=31JSNDAxSE'})
Out[2]: [nailgun.entities.AuthSourceLDAP(account='foobar', attr_photo='', base_dn='cn=Users,dc=hidden,dc=hidden,dc=hidden,dc=hidden,dc=redhat,dc=com', groups_base='cn=foobargroup,dc=hidden,dc=hidden,dc=hidden,dc=hidden,dc=redhat,dc=com', host='some_ip', name='31JSNDAxSE', onthefly_register=False, port=000, server_type='active_directory', tls=False, attr_firstname='givenName', attr_lastname='sn', attr_login='same', attr_mail='mail', location=[nailgun.entities.Location(id=2), nailgun.entities.Location(id=37)], organization=[nailgun.entities.Organization(id=1), nailgun.entities.Organization(id=36)], id=15)]
```