### PR TITLE
Add support to kubevirt for virt-who-config

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -7960,7 +7960,7 @@ class VirtWhoConfig(
         deploy_script
             /foreman_virt_who_configure/api/v2/configs/:id/deploy_script
 
-        Organizations/configs
+        configs
             /foreman_virt_who_configure/api/v2/organizations/:organization_id/configs
 
         ``super`` is called otherwise.
@@ -7969,11 +7969,11 @@ class VirtWhoConfig(
         if which and which in ('deploy_script'):
             return '{0}/{1}'.format(
                 super(VirtWhoConfig, self).path(which='self'), which)
-        if which and which in ('Organizations/configs'):
+        if which and which in ('configs'):
             return '{0}/{1}/{2}/{3}'.format(
                 self._server_config.url,
                 'foreman_virt_who_configure/api/v2/organizations',
-                self.organization.id,
+                self.read().id,
                 which
             )
         return super(VirtWhoConfig, self).path(which)
@@ -8019,7 +8019,7 @@ class VirtWhoConfig(
         ignore.add('hypervisor_password')
         return super(VirtWhoConfig, self).read(entity, attrs, ignore, params)
 
-    def read_per_organization(self, synchronous=True, **kwargs):
+    def get_organization_configs(self, synchronous=True, **kwargs):
         """
         Unusually, the ``/foreman_virt_who_configure/api/v2/organizations/
         :organization_id/configs`` path is totally unsupported.
@@ -8035,5 +8035,5 @@ class VirtWhoConfig(
         """
         kwargs = kwargs.copy()
         kwargs.update(self._server_config.get_client_kwargs())
-        response = client.get(self.path('Organizations/configs'), **kwargs)
+        response = client.get(self.path('configs'), **kwargs)
         return _handle_response(response, self._server_config, synchronous)

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -7944,7 +7944,8 @@ class VirtWhoConfig(
             'proxy': entity_fields.StringField(),
             'satellite_url': entity_fields.StringField(required=True),
             'whitelist': entity_fields.StringField(),
-            'organization': entity_fields.OneToOneField(Organization)
+            'organization_id': entity_fields.IntegerField(),
+            'status': entity_fields.StringField()
         }
         self._meta = {
             'api_path': 'foreman_virt_who_configure/api/v2/configs',
@@ -7973,7 +7974,7 @@ class VirtWhoConfig(
             return '{0}/{1}/{2}/{3}'.format(
                 self._server_config.url,
                 'foreman_virt_who_configure/api/v2/organizations',
-                self.read().organization.id,
+                self.read().organization_id,
                 which
             )
         return super(VirtWhoConfig, self).path(which)

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -7934,11 +7934,11 @@ class VirtWhoConfig(
             'hypervisor_password': entity_fields.StringField(),
             'hypervisor_server': entity_fields.StringField(required=True),
             'hypervisor_type': entity_fields.StringField(
-                choices=['esx', 'rhevm', 'hyperv', 'xen', 'libvirt'],
+                choices=['esx', 'rhevm', 'hyperv', 'xen', 'libvirt', 'kubevirt'],
                 default='libvirt', required=True),
             'hypervisor_username': entity_fields.StringField(required=True),
             'interval': entity_fields.IntegerField(
-                choices=[60, 120, 240, 480, 720], default=120, required=True),
+                choices=[60, 120, 240, 480, 720, 1440, 2880, 4320], default=120, required=True),
             'name': entity_fields.StringField(required=True),
             'no_proxy': entity_fields.StringField(),
             'proxy': entity_fields.StringField(),
@@ -7960,12 +7960,22 @@ class VirtWhoConfig(
         deploy_script
             /foreman_virt_who_configure/api/v2/configs/:id/deploy_script
 
+        Organizations/configs
+            /foreman_virt_who_configure/api/v2/organizations/:organization_id/configs
+
         ``super`` is called otherwise.
 
         """
         if which and which in ('deploy_script'):
             return '{0}/{1}'.format(
                 super(VirtWhoConfig, self).path(which='self'), which)
+        if which and which in ('Organizations/configs'):
+            return '{0}/{1}/{2}/{3}'.format(
+                self._server_config.url,
+                'foreman_virt_who_configure/api/v2/organizations',
+                self.organization.id,
+                which
+            )
         return super(VirtWhoConfig, self).path(which)
 
     def create_payload(self):
@@ -8008,3 +8018,23 @@ class VirtWhoConfig(
             ignore = set()
         ignore.add('hypervisor_password')
         return super(VirtWhoConfig, self).read(entity, attrs, ignore, params)
+
+    def read_per_organization(self, synchronous=True, **kwargs):
+        """
+        Unusually, the
+        ``/foreman_virt_who_configure/api/v2/organizations/:organization_id/configs``
+        path is totally unsupported.
+
+        Support to List of virt-who configurations per organization
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+        """
+        kwargs = kwargs.copy()
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.get(self.path('Organizations/configs'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous)

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -8021,11 +8021,10 @@ class VirtWhoConfig(
 
     def read_per_organization(self, synchronous=True, **kwargs):
         """
-        Unusually, the
-        ``/foreman_virt_who_configure/api/v2/organizations/:organization_id/configs``
-        path is totally unsupported.
+        Unusually, the ``/foreman_virt_who_configure/api/v2/organizations/
+        :organization_id/configs`` path is totally unsupported.
+        Support to List of virt-who configurations per organization.
 
-        Support to List of virt-who configurations per organization
         :param synchronous: What should happen if the server returns an HTTP
             202 (accepted) status code? Wait for the task to complete if
             ``True``. Immediately return the server's response otherwise.

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -7973,7 +7973,7 @@ class VirtWhoConfig(
             return '{0}/{1}/{2}/{3}'.format(
                 self._server_config.url,
                 'foreman_virt_who_configure/api/v2/organizations',
-                self.read().id,
+                self.read().organization.id,
                 which
             )
         return super(VirtWhoConfig, self).path(which)

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -4117,6 +4117,7 @@ class VirtWhoConfigTestCase(TestCase):
         self.assertDictEqual(expected_dict,
                              vh.update_payload(['name', 'hypervisor_username']))
 
+
 class JobInvocationTestCase(TestCase):
     """Tests for :class:`nailgun.entities.JobInvocation`."""
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -427,7 +427,8 @@ class PathTestCase(TestCase):
                 (entities.Repository, 'upload_content'),
                 (entities.RHCIDeployment, 'deploy'),
                 (entities.SmartProxy, 'refresh'),
-                (entities.VirtWhoConfig, 'deploy_script')
+                (entities.VirtWhoConfig, 'deploy_script'),
+                (entities.VirtWhoConfig, 'configs')
         ):
             with self.subTest((entity, which)):
                 with self.assertRaises(NoSuchPathError):

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -4055,7 +4055,7 @@ class VirtWhoConfigTestCase(TestCase):
     def test_create(self):
         org = entities.Organization(self.cfg, name='vhorg', id=2)
         vh = entities.VirtWhoConfig(server_config=self.cfg, name='vhtest1',
-                                    organization=org,
+                                    organization_id=org.id,
                                     filtering_mode=1,
                                     whitelist='*.example.com',
                                     proxy='proxy.example.com',
@@ -4091,7 +4091,7 @@ class VirtWhoConfigTestCase(TestCase):
     def test_update(self):
         org = entities.Organization(self.cfg, name='vhorg', id=2)
         vh = entities.VirtWhoConfig(server_config=self.cfg, name='vhtest1',
-                                    organization=org,
+                                    organization_id=org.id,
                                     filtering_mode=1,
                                     whitelist='*.example.com',
                                     proxy='proxy.example.com',
@@ -4116,7 +4116,6 @@ class VirtWhoConfigTestCase(TestCase):
         }
         self.assertDictEqual(expected_dict,
                              vh.update_payload(['name', 'hypervisor_username']))
-
 
 class JobInvocationTestCase(TestCase):
     """Tests for :class:`nailgun.entities.JobInvocation`."""

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -4117,6 +4117,35 @@ class VirtWhoConfigTestCase(TestCase):
         self.assertDictEqual(expected_dict,
                              vh.update_payload(['name', 'hypervisor_username']))
 
+    def test_methods(self):
+        """Check that get_organization_configs helper method is sane.
+
+        This method is just like
+        :meth:`tests.test_entities.GenericTestCase.test_generic`, but with a
+        slightly different set of mocks. Test the following:
+
+        * :meth:`nailgun.entities.VirtWhoConfig.get_organization_configs`
+
+        """
+        cfg = config.ServerConfig('http://example.com')
+        generic = {'server_config': cfg, 'id': 1}
+        method = entities.VirtWhoConfig(**generic).get_organization_configs
+        request = 'get'
+        with self.subTest((method, request)):
+            self.assertEqual(
+                inspect.getargspec(method),
+                (['self', 'synchronous'], None, 'kwargs', (True,))
+            )
+            kwargs = {'kwarg': gen_integer()}
+            with mock.patch.object(entities, '_handle_response') as handlr:
+                with mock.patch.object(client, request) as client_request:
+                    response = method(**kwargs)
+            self.assertEqual(client_request.call_count, 2)
+            self.assertEqual(len(client_request.call_args[0]), 1)
+            self.assertEqual(client_request.call_args[1], kwargs)
+            self.assertEqual(handlr.call_count, 1)
+            self.assertEqual(handlr.return_value, response)
+
 
 class JobInvocationTestCase(TestCase):
     """Tests for :class:`nailgun.entities.JobInvocation`."""


### PR DESCRIPTION
1. Add support to kubevirt for virt-who-config
2. Add support to Interval for Satellite New features. (support to chose 1440,2880,4320)
3. Add support to Get List of virt-who configurations per organization