### PR TITLE
Add host_parents options for virt-who entity

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -7743,6 +7743,8 @@ class VirtWhoConfig(
         self._fields = {
             'blacklist': entity_fields.StringField(),
             'debug': entity_fields.BooleanField(),
+            'exclude_host_parents': entity_fields.StringField(),
+            'filter_host_parents': entity_fields.StringField(),
             'filtering_mode': entity_fields.IntegerField(
                 choices=[0, 1, 2], default=0, required=True),
             'hypervisor_id': entity_fields.StringField(
@@ -7758,11 +7760,11 @@ class VirtWhoConfig(
                 choices=[60, 120, 240, 480, 720, 1440, 2880, 4320], default=120, required=True),
             'name': entity_fields.StringField(required=True),
             'no_proxy': entity_fields.StringField(),
+            'organization_id': entity_fields.IntegerField(),
             'proxy': entity_fields.StringField(),
             'satellite_url': entity_fields.StringField(required=True),
+            'status': entity_fields.StringField(),
             'whitelist': entity_fields.StringField(),
-            'organization_id': entity_fields.IntegerField(),
-            'status': entity_fields.StringField()
         }
         self._meta = {
             'api_path': 'foreman_virt_who_configure/api/v2/configs',

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -7751,17 +7751,18 @@ class VirtWhoConfig(
             'hypervisor_password': entity_fields.StringField(),
             'hypervisor_server': entity_fields.StringField(required=True),
             'hypervisor_type': entity_fields.StringField(
-                choices=['esx', 'rhevm', 'hyperv', 'xen', 'libvirt'],
+                choices=['esx', 'rhevm', 'hyperv', 'xen', 'libvirt', 'kubevirt'],
                 default='libvirt', required=True),
             'hypervisor_username': entity_fields.StringField(required=True),
             'interval': entity_fields.IntegerField(
-                choices=[60, 120, 240, 480, 720], default=120, required=True),
+                choices=[60, 120, 240, 480, 720, 1440, 2880, 4320], default=120, required=True),
             'name': entity_fields.StringField(required=True),
             'no_proxy': entity_fields.StringField(),
             'proxy': entity_fields.StringField(),
             'satellite_url': entity_fields.StringField(required=True),
             'whitelist': entity_fields.StringField(),
-            'organization': entity_fields.OneToOneField(Organization)
+            'organization_id': entity_fields.IntegerField(),
+            'status': entity_fields.StringField()
         }
         self._meta = {
             'api_path': 'foreman_virt_who_configure/api/v2/configs',
@@ -7777,12 +7778,22 @@ class VirtWhoConfig(
         deploy_script
             /foreman_virt_who_configure/api/v2/configs/:id/deploy_script
 
+        configs
+            /foreman_virt_who_configure/api/v2/organizations/:organization_id/configs
+
         ``super`` is called otherwise.
 
         """
         if which and which in ('deploy_script'):
             return '{0}/{1}'.format(
                 super(VirtWhoConfig, self).path(which='self'), which)
+        if which and which in ('configs'):
+            return '{0}/{1}/{2}/{3}'.format(
+                self._server_config.url,
+                'foreman_virt_who_configure/api/v2/organizations',
+                self.read().organization_id,
+                which
+            )
         return super(VirtWhoConfig, self).path(which)
 
     def create_payload(self):
@@ -7825,3 +7836,22 @@ class VirtWhoConfig(
             ignore = set()
         ignore.add('hypervisor_password')
         return super(VirtWhoConfig, self).read(entity, attrs, ignore, params)
+
+    def get_organization_configs(self, synchronous=True, **kwargs):
+        """
+        Unusually, the ``/foreman_virt_who_configure/api/v2/organizations/
+        :organization_id/configs`` path is totally unsupported.
+        Support to List of virt-who configurations per organization.
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+        """
+        kwargs = kwargs.copy()
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.get(self.path('configs'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous)

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -422,7 +422,8 @@ class PathTestCase(TestCase):
                 (entities.Repository, 'upload_content'),
                 (entities.RHCIDeployment, 'deploy'),
                 (entities.SmartProxy, 'refresh'),
-                (entities.VirtWhoConfig, 'deploy_script')
+                (entities.VirtWhoConfig, 'deploy_script'),
+                (entities.VirtWhoConfig, 'configs')
         ):
             with self.subTest((entity, which)):
                 with self.assertRaises(NoSuchPathError):
@@ -3924,7 +3925,7 @@ class VirtWhoConfigTestCase(TestCase):
     def test_create(self):
         org = entities.Organization(self.cfg, name='vhorg', id=2)
         vh = entities.VirtWhoConfig(server_config=self.cfg, name='vhtest1',
-                                    organization=org,
+                                    organization_id=org.id,
                                     filtering_mode=1,
                                     whitelist='*.example.com',
                                     proxy='proxy.example.com',
@@ -3960,7 +3961,7 @@ class VirtWhoConfigTestCase(TestCase):
     def test_update(self):
         org = entities.Organization(self.cfg, name='vhorg', id=2)
         vh = entities.VirtWhoConfig(server_config=self.cfg, name='vhtest1',
-                                    organization=org,
+                                    organization_id=org.id,
                                     filtering_mode=1,
                                     whitelist='*.example.com',
                                     proxy='proxy.example.com',
@@ -3985,6 +3986,35 @@ class VirtWhoConfigTestCase(TestCase):
         }
         self.assertDictEqual(expected_dict,
                              vh.update_payload(['name', 'hypervisor_username']))
+
+    def test_methods(self):
+        """Check that get_organization_configs helper method is sane.
+
+        This method is just like
+        :meth:`tests.test_entities.GenericTestCase.test_generic`, but with a
+        slightly different set of mocks. Test the following:
+
+        * :meth:`nailgun.entities.VirtWhoConfig.get_organization_configs`
+
+        """
+        cfg = config.ServerConfig('http://example.com')
+        generic = {'server_config': cfg, 'id': 1}
+        method = entities.VirtWhoConfig(**generic).get_organization_configs
+        request = 'get'
+        with self.subTest((method, request)):
+            self.assertEqual(
+                inspect.getargspec(method),
+                (['self', 'synchronous'], None, 'kwargs', (True,))
+            )
+            kwargs = {'kwarg': gen_integer()}
+            with mock.patch.object(entities, '_handle_response') as handlr:
+                with mock.patch.object(client, request) as client_request:
+                    response = method(**kwargs)
+            self.assertEqual(client_request.call_count, 2)
+            self.assertEqual(len(client_request.call_args[0]), 1)
+            self.assertEqual(client_request.call_args[1], kwargs)
+            self.assertEqual(handlr.call_count, 1)
+            self.assertEqual(handlr.return_value, response)
 
 
 class JobInvocationTestCase(TestCase):


### PR DESCRIPTION
Cherry-pick #660 #650 to stable-branch 
#660 :
1.Add filter_host_parents and exclude_host_parents options
2.Sort the fields by alphabetically.

#650 :
1.Add support to kubevirt for virt-who-config
2.Add support to Interval for Satellite New features. (support to chose 1440,2880,4320)
3.Add support to Get List of virt-who configurations per organization