### PR TITLE
add description field to Subnet entity

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -7146,6 +7146,7 @@ class Subnet(
                 default=u'DHCP',
             ),
             'cidr': entity_fields.IntegerField(),
+            'description': entity_fields.StringField(),
             'dhcp': entity_fields.OneToOneField(SmartProxy),
             # When reading a subnet, no discovery information is
             # returned by the server. See Bugzilla #1217146.


### PR DESCRIPTION
```
(Pdb++) sn = entities.Subnet(id=4).read()
2019-10-10 11:38:16 - nailgun.client - DEBUG - Making HTTP GET request to https://192.168.121.209/api/v2/subnets/4 with options {'auth': ('admin', 'changeme'), 'verify': False, 'headers': {'content-type': 'application/json'}}, no params and no data.
2019-10-10 11:38:16 - nailgun.client - DEBUG - Received HTTP 200 response: {"network":"7350:325a:3baa:fd41:2224:1288:5c5:5855","network_type":"IPv6","cidr":24,"mask":"ffff:ff00::","priority":null,"vlanid":null,"mtu":1600,"gateway":"","dns_primary":"","dns_secondary":"","from":"","to":"","created_at":"2019-10-10 09:32:44 UTC","updated_at":"2019-10-10 09:32:44 UTC","ipam":"EUI-64","boot_mode":"DHCP","id":4,"name":"ToQeuQkixB","description":"4NFGKQnBsv","network_address":"7350:325a:3baa:fd41:2224:1288:5c5:5855/24","dhcp_id":null,"dhcp_name":null,"tftp_id":null,"tftp_name":null,"httpboot_id":null,"httpboot_name":null,"dns_id":null,"template_id":null,"template_name":null,"discovery_id":null,"discovery_name":null,"dhcp":null,"tftp":null,"httpboot":null,"dns":null,"template":null,"discovery":null,"domains":[],"interfaces":[],"parameters":[],"locations":[{"id":8,"name":"hmGIftO","title":"hmGIftO","description":null}],"organizations":[{"id":7,"name":"GiBLWTFb","title":"GiBLWTFb","description":null}]}
(Pdb++) sn.description
'4NFGKQnBsv'
```