### PR TITLE
Don't try to iterate over null

### DIFF
--- a/nailgun/entity_mixins.py
+++ b/nailgun/entity_mixins.py
@@ -204,6 +204,9 @@ def _payload(fields, values):
                         return _payload(obj.get_fields(), obj.get_values())
                     return obj
 
+                if values[field_name] is None:
+                    continue
+
                 values[field_name] = [
                     parse(obj) for obj in values[field_name]]
     return values


### PR DESCRIPTION
If property is ListField and current value is null (which is common for fields that never got any value assigned), leave it as is and don't try to iterate over it.

Introduced as fix for long-running failures in docker repositories (see https://github.com/SatelliteQE/robottelo/issues/7540):
```
$ pytest -v tests/foreman/api/test_docker.py::DockerRepositoryTestCase::test_positive_update_url tests/foreman/api/test_docker.py::DockerRepositoryTestCase::test_positive_update_upstream_name tests/foreman/api/test_docker.py::DockerRepositoryTestCase::test_positive_update_name
===================================================================================== test session starts =====================================================================================

tests/foreman/api/test_docker.py::DockerRepositoryTestCase::test_positive_update_url PASSED                                                                                             [ 33%]
tests/foreman/api/test_docker.py::DockerRepositoryTestCase::test_positive_update_upstream_name PASSED                                                                                   [ 66%]
tests/foreman/api/test_docker.py::DockerRepositoryTestCase::test_positive_update_name PASSED                                                                                            [100%]

================================================================================== 3 passed in 43.97 seconds ==================================================================================
```

This also somewhat fixes #607 , i.e. you can assign None to ListField, update and Nailgun won't crash. From what I've seen, you will get empty list in response.