### PR TITLE
[cherry-pick] Don't try to iterate over null

### DIFF
--- a/nailgun/entity_mixins.py
+++ b/nailgun/entity_mixins.py
@@ -204,6 +204,9 @@ def _payload(fields, values):
                         return _payload(obj.get_fields(), obj.get_values())
                     return obj
 
+                if values[field_name] is None:
+                    continue
+
                 values[field_name] = [
                     parse(obj) for obj in values[field_name]]
     return values


### PR DESCRIPTION
This is cherry-pick of #686 into stable-satellite.

If property is ListField and current value is null (which is common for fields that never got any value assigned), leave it as is and don't try to iterate over it.