### PR TITLE
Drop py2 support, specify py 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: python
 python:
-    - 2.7
     - 3.6
 install:
     - pip install -r requirements.txt -r requirements-dev.txt --no-cache-dir

--- a/docs/create_organization_nailgun.py
+++ b/docs/create_organization_nailgun.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
 """Create an organization, print out its attributes and delete it.
 
 Use NailGun to accomplish this task.

--- a/docs/create_organization_nailgun_v2.py
+++ b/docs/create_organization_nailgun_v2.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
 """Create an organization, print out its attributes and delete it."""
 from pprint import pprint
 

--- a/docs/create_organization_plain.py
+++ b/docs/create_organization_plain.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
 """Create an organization, print out its attributes and delete it.
 
 Use Requests and standard library modules to accomplish this task.

--- a/docs/create_user_nailgun.py
+++ b/docs/create_user_nailgun.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
 """Create an identical user account on a pair of satellites."""
 from __future__ import print_function
 

--- a/docs/create_user_plain.py
+++ b/docs/create_user_plain.py
@@ -1,11 +1,10 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
 """Create an identical user account on a pair of satellites.
 
 If you'd like to test out this script, you can quickly set up an environment
 like so::
 
-    virtualenv env
+    python3 -m venv env
     source env/bin/activate
     pip install requests
     ./create_user_plain.py  # copy this script to the current directory

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -7,14 +7,14 @@ from simple to more advanced.
 You can run any of the scripts presented in this document. This is the set-up
 procedure for scripts that use NailGun::
 
-    virtualenv env
+    python3 -m venv env
     source env/bin/activate
     pip install nailgun
     ./some_script.py  # some script of your choice
 
 This is the set-up procedure for scripts that do not use NailGun::
 
-    virtualenv env
+    python3 -m venv env
     source env/bin/activate
     pip install requests
     ./some_script.py  # some script of your choice

--- a/nailgun/__init__.py
+++ b/nailgun/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """The root of the NailGun namespace.
 
 NailGun's modules are organized in to a tree of dependencies, where each module

--- a/nailgun/client.py
+++ b/nailgun/client.py
@@ -114,10 +114,7 @@ def _log_response(response):
     :return: Nothing is returned.
 
     """
-    message = u'Received HTTP {0} response: {1}'.format(
-        response.status_code,
-        response.text
-    )
+    message = f'Received HTTP {response.status_code} response: {response.text}'
     if response.status_code >= 400:  # pragma: no cover
         logger.warning(message)
     else:

--- a/nailgun/entity_mixins.py
+++ b/nailgun/entity_mixins.py
@@ -7,7 +7,6 @@ import time
 from collections import Iterable
 from datetime import date
 from datetime import datetime
-from sys import version_info
 from urllib.parse import urljoin
 
 from fauxfactory import gen_choice

--- a/release.sh
+++ b/release.sh
@@ -36,21 +36,19 @@ echo "${NEW_VERSION}" > VERSION
 # Generate the package
 make package-clean package
 
-# Sanity check NailGun packages on both Python 2 and Python 3
-for python in python{2,3}; do
-    venv="$(mktemp --directory)"
-    virtualenv -p "${python}" "${venv}"
-    set +u
-    source "${venv}/bin/activate"
-    set -u
-    for dist in dist/*; do
-        pip install --quiet "${dist}"
-        python -c "import nailgun" 1>/dev/null
-        pip uninstall --quiet --yes nailgun
-    done
-    deactivate
-    rm -rf "${venv}"
+# Sanity check NailGun packages
+venv="$(mktemp --directory)"
+python3 -m virtualenv "${venv}"
+set +u
+source "${venv}/bin/activate"
+set -u
+for dist in dist/*; do
+    pip install --quiet "${dist}"
+    python -c "import nailgun" 1>/dev/null
+    pip uninstall --quiet --yes nailgun
 done
+deactivate
+rm -rf "${venv}"
 
 # Get the changes from last release and commit
 git add VERSION

--- a/release.sh
+++ b/release.sh
@@ -38,7 +38,7 @@ make package-clean package
 
 # Sanity check NailGun packages
 venv="$(mktemp --directory)"
-python3 -m virtualenv "${venv}"
+python3 -m venv "${venv}"
 set +u
 source "${venv}/bin/activate"
 set -u

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """A setuptools-based script for installing NailGun.
 
 For more information, see:
@@ -7,8 +7,6 @@ For more information, see:
 * https://docs.python.org/distutils/sourcedist.html
 
 """
-import sys
-
 from setuptools import find_packages
 from setuptools import setup
 

--- a/setup.py
+++ b/setup.py
@@ -26,16 +26,9 @@ REQUIREMENTS = [
     'packaging',
     'pyxdg',
     'requests>=2.7',
-    'blinker_herald'
+    'blinker_herald',
+    'fauxfactory'
 ]
-
-
-if sys.version_info >= (3, 0):
-    REQUIREMENTS.append('fauxfactory')
-else:
-    # Fauxfactory 3.0+ dropped support for Python 2.x
-    REQUIREMENTS.append('fauxfactory<3.0')
-
 
 setup(
     name='nailgun',
@@ -50,11 +43,8 @@ setup(
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
-        ('License :: OSI Approved :: GNU General Public License v3 or later '
-         '(GPLv3+)'),
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
+        'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
+        'Programming Language :: Python :: 3.6',
     ],
     packages=find_packages(exclude=['docs', 'tests']),
     install_requires=REQUIREMENTS,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,17 +1,12 @@
-# -*- coding: utf-8 -*-
 """Unit tests for :mod:`nailgun.client`."""
 import inspect
-from sys import version_info
+from unittest import TestCase
 
 import mock
 import requests
 from fauxfactory import gen_alpha
 
 from nailgun import client
-if version_info < (3, 4):
-    from unittest2 import TestCase
-else:
-    from unittest import TestCase
 
 
 class ContentTypeIsJsonTestCase(TestCase):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,7 @@
 """Unit tests for :mod:`nailgun.config`."""
+import builtins
 import json
-from sys import version_info
+from unittest import TestCase
 
 from mock import call
 from mock import mock_open
@@ -11,17 +12,6 @@ from nailgun.config import _get_config_file_path
 from nailgun.config import BaseServerConfig
 from nailgun.config import ConfigFileError
 from nailgun.config import ServerConfig
-if version_info.major == 2:
-    # The `__builtins__` module (note the "s") also provides the `open`
-    # function. However, that module is an implementation detail for CPython 2,
-    # so it should not be relied on.
-    import __builtin__ as builtins
-else:
-    import builtins
-if version_info < (3, 4):
-    from unittest2 import TestCase
-else:
-    from unittest import TestCase
 
 
 FILE_PATH = '/tmp/bogus.json'

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -304,7 +304,7 @@ class PathTestCase(TestCase):
             with self.subTest((entity, path)):
                 self.assertIn(path, entity(self.cfg).path())
                 self.assertIn(
-                    '{}/{}'.format(path, self.id_),
+                    f'{path}/{self.id_}',
                     entity(self.cfg, id=self.id_).path()
                 )
         # Deprecated entities
@@ -314,7 +314,7 @@ class PathTestCase(TestCase):
             with self.subTest((entity, path)):
                 self.assertIn(path, entity(self.cfg_610).path())
                 self.assertIn(
-                    '{}/{}'.format(path, self.id_),
+                    f'{path}/{self.id_}',
                     entity(self.cfg_610, id=self.id_).path()
                 )
 
@@ -381,7 +381,7 @@ class PathTestCase(TestCase):
         ):
             with self.subTest((entity, which)):
                 path = entity(self.cfg, id=self.id_).path(which=which)
-                self.assertIn('{}/{}'.format(self.id_, which), path)
+                self.assertIn(f'{self.id_}/{which}', path)
                 self.assertRegex(path, which + '$')
 
     def test_noid_and_which(self):
@@ -469,7 +469,7 @@ class PathTestCase(TestCase):
                 id=1,
             ).path(which)
             self.assertIn('compliance/arf_reports/1/' + which, path)
-            self.assertRegex(path, '{}$'.format(which))
+            self.assertRegex(path, f'{which}$')
 
     def test_os_default_template(self):
         """ Test ``nailgun.entities.OSDefaultTemplate.path``
@@ -504,7 +504,7 @@ class PathTestCase(TestCase):
                 usergroup=1,
             ).path(which)
             self.assertIn('usergroups/1/external_usergroups/2/' + which, path)
-            self.assertRegex(path, '{}$'.format(which))
+            self.assertRegex(path, f'{which}$')
 
     def test_repository_set(self):
         """Test :meth:`nailgun.entities.RepositorySet.path`.
@@ -528,7 +528,7 @@ class PathTestCase(TestCase):
                 product=1,
             ).path(which)
             self.assertIn('/repository_sets/2/' + which, path)
-            self.assertRegex(path, '{}$'.format(which))
+            self.assertRegex(path, f'{which}$')
 
     def test_snapshot(self):
         """Test :meth:`nailgun.entities.Snapshot.path`.
@@ -550,7 +550,7 @@ class PathTestCase(TestCase):
             host=1,
         ).path(which)
         self.assertIn('hosts/1/snapshots/snapshot-2/' + which, path)
-        self.assertRegex(path, '{}$'.format(which))
+        self.assertRegex(path, f'{which}$')
 
     def test_sync_plan(self):
         """Test :meth:`nailgun.entities.SyncPlan.path`.
@@ -573,7 +573,7 @@ class PathTestCase(TestCase):
                 organization=1,
             ).path(which)
             self.assertIn('organizations/1/sync_plans/2/' + which, path)
-            self.assertRegex(path, '{}$'.format(which))
+            self.assertRegex(path, f'{which}$')
 
     def test_system(self):
         """Test :meth:`nailgun.entities.System.path`.
@@ -594,12 +594,12 @@ class PathTestCase(TestCase):
 
         system = entities.System(self.cfg_610, uuid=self.id_)
         for path in (system.path(), system.path('self')):
-            self.assertIn('/systems/{}'.format(self.id_), path)
-            self.assertRegex(path, '{}$'.format(self.id_))
+            self.assertIn(f'/systems/{self.id_}', path)
+            self.assertRegex(path, f'{self.id_}$')
 
         path = system.path('subscriptions')
-        self.assertIn('/systems/{}/subscriptions'.format(self.id_), path)
-        self.assertRegex(path, '{}$'.format('subscriptions'))
+        self.assertIn('/systems/{self.id_}/subscriptions', path)
+        self.assertRegex(path, 'subscriptions$')
 
     def test_subscription(self):
         """Test :meth:`nailgun.entities.Subscription.path`.
@@ -621,13 +621,10 @@ class PathTestCase(TestCase):
             with self.subTest(which):
                 path = sub.path(which)
                 self.assertIn(
-                    'organizations/{}/subscriptions/{}'.format(
-                        sub.organization.id,
-                        which,
-                    ),
+                    f'organizations/{sub.organization.id}/subscriptions/{which}',
                     path
                 )
-                self.assertRegex(path, '{}$'.format(which))
+                self.assertRegex(path, '{which}$')
 
     def test_capsule(self):
         """Test :meth:`nailgun.entities.Capsule.path`.
@@ -644,14 +641,12 @@ class PathTestCase(TestCase):
                 'content_sync'):
             with self.subTest(which):
                 path = capsule.path(which)
+                which_parts = which.split("_", 1)
                 self.assertIn(
-                    'capsules/{}/content/{}'.format(
-                        capsule.id,
-                        which.split('_', 1)[1],
-                    ),
+                    f'capsules/{capsule.id}/content/{which_parts[1]}',
                     path
                 )
-                self.assertRegex(path, '{}/{}$'.format(*which.split('_', 1)))
+                self.assertRegex(path, f'{which_parts[0]}/{which_parts[1]}$')
 
     def test_hostsubscription(self):
         """Test :meth:`nailgun.entities.HostSubscription.path`.
@@ -667,13 +662,10 @@ class PathTestCase(TestCase):
             with self.subTest(which):
                 path = sub.path(which)
                 self.assertIn(
-                    'hosts/{}/subscriptions/{}'.format(
-                        sub.host.id,
-                        which,
-                    ),
+                    f'hosts/{sub.host.id}/subscriptions/{which}',
                     path
                 )
-                self.assertRegex(path, '{}$'.format(which))
+                self.assertRegex(path, f'{which}$')
 
 
 class CreateTestCase(TestCase):
@@ -2418,12 +2410,12 @@ class FileTestCase(TestCase):
         """Check json serialisation on nested entities"""
         file_kwargs = {
             'id': 1,
-            'name': u'test_file.txt',
-            'path': u'test_file.txt',
-            'uuid': u'3a013738-e5b8-43b2-81f5-3732b6e42776',
+            'name': 'test_file.txt',
+            'path': 'test_file.txt',
+            'uuid': '3a013738-e5b8-43b2-81f5-3732b6e42776',
             'checksum': (
-                u'16c946e116072838b213f622298b74baa75c52c8fee50a6230b4680e3c1'
-                u'36fb1'
+                '16c946e116072838b213f622298b74baa75c52c8fee50a6230b4680e3c1'
+                '36fb1'
             ),
         }
         cfg = config.ServerConfig(
@@ -2492,7 +2484,7 @@ class ConfigTemplateTestCase(TestCase):
             template_kind=8,
             template_combinations=template_combinations)
         expected_dct = {
-            u'config_template': {
+            'config_template': {
                 'name': 'cfg', 'snippet': False, 'template': 'cat',
                 'template_kind_id': 8, 'template_combinations_attributes': [
                     {'environment_id': 1, 'hostgroup_id': 1},
@@ -2507,7 +2499,7 @@ class ConfigTemplateTestCase(TestCase):
             hostgroup=hostgroup,
             environment=env3)
         cfg_template.template_combinations.append(combination3)
-        attrs = expected_dct[u'config_template']
+        attrs = expected_dct['config_template']
         attrs['template_combinations_attributes'].append(
             {'environment_id': 3, 'hostgroup_id': 2}
         )
@@ -2787,9 +2779,10 @@ class ContentViewComponentTestCase(TestCase):
     def test_path(self):
         for which in ['add', 'remove']:
             path = self.cvc.path(which=which)
-            self.assertIn('{}/content_view_components/{}'.format(
-                self.cvc.composite_content_view.id,
-                which), path)
+            self.assertIn(
+                f'{self.cvc.composite_content_view.id}/content_view_components/{which}',
+                path
+            )
             self.assertRegex(path, which + '$')
 
     def test_add(self):
@@ -2856,14 +2849,14 @@ class ReportTemplateTestCase(TestCase):
             default=False,
             template='cat')
         expected_dct = {
-            u'report_template': {
+            'report_template': {
                 'name': 'cfg', 'default': False, 'template': 'cat',
             }
         }
         self.assertEqual(expected_dct, report_template.create_payload())
         # Testing update
         report_template.template = 'dog'
-        expected_dct[u'report_template']['template'] = 'dog'
+        expected_dct['report_template']['template'] = 'dog'
         self.assertEqual(expected_dct, report_template.update_payload())
 
     def test_generate(self):
@@ -2905,7 +2898,7 @@ class ProvisioningTemplateTestCase(TestCase):
             template_kind=8,
             template_combinations=template_combinations)
         expected_dct = {
-            u'provisioning_template': {
+            'provisioning_template': {
                 'name': 'cfg', 'snippet': False, 'template': 'cat',
                 'template_kind_id': 8, 'template_combinations_attributes': [
                     {'environment_id': 1, 'hostgroup_id': 1},
@@ -2920,7 +2913,7 @@ class ProvisioningTemplateTestCase(TestCase):
             hostgroup=hostgroup,
             environment=env3)
         cfg_template.template_combinations.append(combination3)
-        attrs = expected_dct[u'provisioning_template']
+        attrs = expected_dct['provisioning_template']
         attrs['template_combinations_attributes'].append(
             {'environment_id': 3, 'hostgroup_id': 2}
         )
@@ -3639,20 +3632,20 @@ class PackageTestCase(TestCase):
     def test_to_json(self):
         """Check json serialisation on nested entities"""
         package_kwargs = {
-            'nvrea': u'sclo-git25-1.0-2.el7.x86_64',
+            'nvrea': 'sclo-git25-1.0-2.el7.x86_64',
             'checksum': (
-                u'751e639a0b8add0adc0c5cf0bf77693b3197b17533037ce2e7b9daa6188'
-                u'98b99'
+                '751e639a0b8add0adc0c5cf0bf77693b3197b17533037ce2e7b9daa6188'
+                '98b99'
             ),
-            'summary': u'Package that installs sclo-git25',
-            'filename': u'sclo-git25-1.0-2.el7.x86_64.rpm',
-            'epoch': u'0', 'version': u'1.0',
-            'nvra': u'sclo-git25-1.0-2.el7.x86_64',
-            'release': u'2.el7',
-            'sourcerpm': u'sclo-git25-1.0-2.el7.src.rpm',
-            'arch': u'x86_64',
+            'summary': 'Package that installs sclo-git25',
+            'filename': 'sclo-git25-1.0-2.el7.x86_64.rpm',
+            'epoch': '0', 'version': '1.0',
+            'nvra': 'sclo-git25-1.0-2.el7.x86_64',
+            'release': '2.el7',
+            'sourcerpm': 'sclo-git25-1.0-2.el7.src.rpm',
+            'arch': 'x86_64',
             'id': 64529,
-            'name': u'sclo-git25'
+            'name': 'sclo-git25'
         }
         cfg = config.ServerConfig(
             url='https://foo.bar', verify=False,
@@ -3961,20 +3954,20 @@ class JsonSerializableTestCase(TestCase):
     def test_entities(self):
         """Testing nested entities serialization"""
         package_kwargs = {
-            'nvrea': u'sclo-git25-1.0-2.el7.x86_64',
+            'nvrea': 'sclo-git25-1.0-2.el7.x86_64',
             'checksum': (
-                u'751e639a0b8add0adc0c5cf0bf77693b3197b17533037ce2e7b9daa6188'
-                u'98b99'
+                '751e639a0b8add0adc0c5cf0bf77693b3197b17533037ce2e7b9daa6188'
+                '98b99'
             ),
-            'summary': u'Package that installs sclo-git25',
-            'filename': u'sclo-git25-1.0-2.el7.x86_64.rpm',
-            'epoch': u'0', 'version': u'1.0',
-            'nvra': u'sclo-git25-1.0-2.el7.x86_64',
-            'release': u'2.el7',
-            'sourcerpm': u'sclo-git25-1.0-2.el7.src.rpm',
-            'arch': u'x86_64',
+            'summary': 'Package that installs sclo-git25',
+            'filename': 'sclo-git25-1.0-2.el7.x86_64.rpm',
+            'epoch': '0', 'version': '1.0',
+            'nvra': 'sclo-git25-1.0-2.el7.x86_64',
+            'release': '2.el7',
+            'sourcerpm': 'sclo-git25-1.0-2.el7.src.rpm',
+            'arch': 'x86_64',
             'id': 64529,
-            'name': u'sclo-git25'
+            'name': 'sclo-git25'
         }
 
         repo_kwargs = {'id': 3, 'content_type': 'file'}
@@ -4067,7 +4060,7 @@ class VirtWhoConfigTestCase(TestCase):
     @classmethod
     def setUpClass(cls):
         cls.server = 'sat.example.com'
-        cls.cfg = config.ServerConfig('http://{}/'.format(cls.server))
+        cls.cfg = config.ServerConfig(f'http://{cls.server}/')
 
     def test_create(self):
         org = entities.Organization(self.cfg, name='vhorg', id=2)

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 """Tests for :mod:`nailgun.entities`."""
 import inspect
 import json

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -381,7 +381,7 @@ class PathTestCase(TestCase):
             with self.subTest((entity, which)):
                 path = entity(self.cfg, id=self.id_).path(which=which)
                 self.assertIn(f'{self.id_}/{which}', path)
-                self.assertRegex(path, which + '$')
+                self.assertRegex(path, fr'{which}$')
 
     def test_noid_and_which(self):
         """Execute ``entity().path(which=…)``."""
@@ -407,7 +407,7 @@ class PathTestCase(TestCase):
             with self.subTest((entity, which)):
                 path = entity(self.cfg).path(which)
                 self.assertIn(which, path)
-                self.assertRegex(path, which + '$')
+                self.assertRegex(path, fr'{which}$')
 
     def test_no_such_path_error(self):
         """Trigger :class:`nailgun.entity_mixins.NoSuchPathError` exceptions.
@@ -468,7 +468,7 @@ class PathTestCase(TestCase):
                 id=1,
             ).path(which)
             self.assertIn('compliance/arf_reports/1/' + which, path)
-            self.assertRegex(path, f'{which}$')
+            self.assertRegex(path, fr'{which}$')
 
     def test_os_default_template(self):
         """ Test ``nailgun.entities.OSDefaultTemplate.path``
@@ -503,7 +503,7 @@ class PathTestCase(TestCase):
                 usergroup=1,
             ).path(which)
             self.assertIn('usergroups/1/external_usergroups/2/' + which, path)
-            self.assertRegex(path, f'{which}$')
+            self.assertRegex(path, fr'{which}$')
 
     def test_repository_set(self):
         """Test :meth:`nailgun.entities.RepositorySet.path`.
@@ -527,7 +527,7 @@ class PathTestCase(TestCase):
                 product=1,
             ).path(which)
             self.assertIn('/repository_sets/2/' + which, path)
-            self.assertRegex(path, f'{which}$')
+            self.assertRegex(path, fr'{which}$')
 
     def test_snapshot(self):
         """Test :meth:`nailgun.entities.Snapshot.path`.
@@ -549,7 +549,7 @@ class PathTestCase(TestCase):
             host=1,
         ).path(which)
         self.assertIn('hosts/1/snapshots/snapshot-2/' + which, path)
-        self.assertRegex(path, f'{which}$')
+        self.assertRegex(path, fr'{which}$')
 
     def test_sync_plan(self):
         """Test :meth:`nailgun.entities.SyncPlan.path`.
@@ -572,7 +572,7 @@ class PathTestCase(TestCase):
                 organization=1,
             ).path(which)
             self.assertIn('organizations/1/sync_plans/2/' + which, path)
-            self.assertRegex(path, f'{which}$')
+            self.assertRegex(path, fr'{which}$')
 
     def test_system(self):
         """Test :meth:`nailgun.entities.System.path`.
@@ -589,16 +589,16 @@ class PathTestCase(TestCase):
         system = entities.System(self.cfg_610)
         for path in (system.path(), system.path('base')):
             self.assertIn('/systems', path)
-            self.assertRegex(path, 'systems$')
+            self.assertRegex(path, r'systems$')
 
         system = entities.System(self.cfg_610, uuid=self.id_)
         for path in (system.path(), system.path('self')):
             self.assertIn(f'/systems/{self.id_}', path)
-            self.assertRegex(path, f'{self.id_}$')
+            self.assertRegex(path, fr'{self.id_}$')
 
         path = system.path('subscriptions')
-        self.assertIn('/systems/{self.id_}/subscriptions', path)
-        self.assertRegex(path, 'subscriptions$')
+        self.assertIn(f'/systems/{self.id_}/subscriptions', path)
+        self.assertRegex(path, r'subscriptions$')
 
     def test_subscription(self):
         """Test :meth:`nailgun.entities.Subscription.path`.
@@ -623,7 +623,7 @@ class PathTestCase(TestCase):
                     f'organizations/{sub.organization.id}/subscriptions/{which}',
                     path
                 )
-                self.assertRegex(path, '{which}$')
+                self.assertRegex(path, fr'{which}$')
 
     def test_capsule(self):
         """Test :meth:`nailgun.entities.Capsule.path`.
@@ -645,7 +645,7 @@ class PathTestCase(TestCase):
                     f'capsules/{capsule.id}/content/{which_parts[1]}',
                     path
                 )
-                self.assertRegex(path, f'{which_parts[0]}/{which_parts[1]}$')
+                self.assertRegex(path, fr'{which_parts[0]}/{which_parts[1]}$')
 
     def test_hostsubscription(self):
         """Test :meth:`nailgun.entities.HostSubscription.path`.
@@ -664,7 +664,7 @@ class PathTestCase(TestCase):
                     f'hosts/{sub.host.id}/subscriptions/{which}',
                     path
                 )
-                self.assertRegex(path, f'{which}$')
+                self.assertRegex(path, fr'{which}$')
 
 
 class CreateTestCase(TestCase):
@@ -2782,7 +2782,7 @@ class ContentViewComponentTestCase(TestCase):
                 f'{self.cvc.composite_content_view.id}/content_view_components/{which}',
                 path
             )
-            self.assertRegex(path, which + '$')
+            self.assertRegex(path, fr'{which}$')
 
     def test_add(self):
         """Check that helper method is sane.

--- a/tests/test_entity_fields.py
+++ b/tests/test_entity_fields.py
@@ -1,21 +1,13 @@
-# -*- coding: utf-8 -*-
 """Unit tests for :mod:`nailgun.entity_fields`."""
 import datetime
 import socket
 from random import randint
-from sys import version_info
+from unittest import TestCase
+from urllib.parse import urlparse
 
 from fauxfactory.constants import VALID_NETMASKS
 
 from nailgun import entity_fields
-if version_info.major == 2:
-    from urlparse import urlparse
-else:
-    from urllib.parse import urlparse
-if version_info < (3, 4):
-    from unittest2 import TestCase
-else:
-    from unittest import TestCase
 
 
 # It is OK that this class has no public methods. It just needs to exist for
@@ -70,7 +62,7 @@ class GenValueTestCase(TestCase):
 
         """
         email = entity_fields.EmailField().gen_value()
-        self.assertIsInstance(email, type(u''))
+        self.assertIsInstance(email, type(''))
         self.assertIn('@', email)
 
     def test_float_field(self):
@@ -87,7 +79,7 @@ class GenValueTestCase(TestCase):
         try:
             socket.inet_aton(addr)
         except socket.error as err:
-            self.fail('({0}) {1}'.format(addr, err))
+            self.fail(f'({addr}) {err}')
 
     def test_mac_address_field(self):
         """Test :meth:`nailgun.entity_fields.MACAddressField.gen_value`.
@@ -147,7 +139,7 @@ class StringFieldTestCase(TestCase):
     def test_str_is_returned(self):
         """Ensure a unicode string at least 1 char long is returned."""
         string = entity_fields.StringField().gen_value()
-        self.assertIsInstance(string, type(u''))
+        self.assertIsInstance(string, type(''))
         self.assertGreater(len(string), 0)
 
     def test_length_arg(self):

--- a/tests/test_entity_fields.py
+++ b/tests/test_entity_fields.py
@@ -94,7 +94,7 @@ class GenValueTestCase(TestCase):
         """
         self.assertRegex(
             entity_fields.MACAddressField().gen_value().upper(),
-            '^([0-9A-F]{2}[:]){5}[0-9A-F]{2}$'
+            r'^([0-9A-F]{2}[:]){5}[0-9A-F]{2}$'
         )
 
     def test_dict_field(self):

--- a/tests/test_entity_mixins.py
+++ b/tests/test_entity_mixins.py
@@ -1,9 +1,6 @@
-# -*- coding: utf-8 -*-
 """Tests for :mod:`nailgun.entity_mixins`."""
-# Python 3.3 and later includes module `ipaddress` in the standard library. If
-# NailGun ever moves past Python 2.x, that module should be used instead of
-# `socket`.
-from sys import version_info
+import http.client as http_client
+from unittest import TestCase
 
 import mock
 from fauxfactory import gen_integer
@@ -17,14 +14,6 @@ from nailgun.entity_fields import ListField
 from nailgun.entity_fields import OneToManyField
 from nailgun.entity_fields import OneToOneField
 from nailgun.entity_fields import StringField
-if version_info.major == 2:
-    import httplib as http_client
-else:
-    import http.client as http_client
-if version_info < (3, 4):
-    from unittest2 import TestCase
-else:
-    from unittest import TestCase
 # The size of this module is a direct reflection of the size of module
 # `nailgun.entity_mixins`. It would be good to split that module up, then split
 # this module up similarly.
@@ -359,10 +348,8 @@ class EntityTestCase(TestCase):
     def test_path(self):
         """Test :meth:`nailgun.entity_mixins.Entity.path`."""
         # e.g. 'https://sat.example.com/katello/api/v2'
-        path = '{0}/{1}'.format(
-            self.cfg.url,
-            SampleEntity(self.cfg)._meta['api_path']
-        )
+        api_path = SampleEntity(self.cfg)._meta["api_path"]
+        path = f'{self.cfg.url}/{api_path}'
 
         # Call `path()` on an entity with no ID.
         self.assertEqual(SampleEntity(self.cfg).path(), path)
@@ -528,10 +515,7 @@ class EntityTestCase(TestCase):
 
         """
         entity = SampleEntityTwo(self.cfg, id=gen_integer())
-        target = (
-            'tests.test_entity_mixins.SampleEntityTwo(id={0})'
-            .format(entity.id)
-        )
+        target = f'tests.test_entity_mixins.SampleEntityTwo(id={entity.id})'
         self.assertEqual(repr(entity), target)
         # create default config if it does not exist
         try:
@@ -552,9 +536,7 @@ class EntityTestCase(TestCase):
         entity_id = gen_integer()
         target = (
             'tests.test_entity_mixins.SampleEntityTwo('
-            'one_to_many=[tests.test_entity_mixins.SampleEntity(id={0})]'
-            ')'
-            .format(entity_id)
+            f'one_to_many=[tests.test_entity_mixins.SampleEntity(id={entity_id})])'
         )
         entity = SampleEntityTwo(
             self.cfg,


### PR DESCRIPTION
Update setup.py/travis supported python versions.

Make some updates in regard to py3.6 support including f-strings, and no `u''` string specs.

NOTE: At the moment this includes the commits from #700, they will be re-based out.