### PR TITLE
Remove `config_template` in Organization and Location entities

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -4873,6 +4873,7 @@ class Location(
         if ignore is None:
             ignore = set()
         ignore.add('realm')
+        ignore.add('config_template')
         return super(Location, self).read(entity, attrs, ignore, params)
 
     def update(self, fields=None):
@@ -5247,6 +5248,7 @@ class Organization(
         if ignore is None:
             ignore = set()
         ignore.add('realm')
+        ignore.add('config_template')
         return super(Organization, self).read(entity, attrs, ignore, params)
 
     def update(self, fields=None):

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -4818,7 +4818,6 @@ class Location(
         self._fields = {
             'compute_resource': entity_fields.OneToManyField(
                 AbstractComputeResource),
-            'config_template': entity_fields.OneToManyField(ConfigTemplate),
             'description': entity_fields.StringField(),
             'domain': entity_fields.OneToManyField(Domain),
             'environment': entity_fields.OneToManyField(Environment),
@@ -4873,7 +4872,6 @@ class Location(
         if ignore is None:
             ignore = set()
         ignore.add('realm')
-        ignore.add('config_template')
         return super(Location, self).read(entity, attrs, ignore, params)
 
     def update(self, fields=None):
@@ -5154,7 +5152,6 @@ class Organization(
             'compute_resource': entity_fields.OneToManyField(
                 AbstractComputeResource
             ),
-            'config_template': entity_fields.OneToManyField(ConfigTemplate),
             'description': entity_fields.StringField(),
             'domain': entity_fields.OneToManyField(Domain),
             'environment': entity_fields.OneToManyField(Environment),
@@ -5248,7 +5245,6 @@ class Organization(
         if ignore is None:
             ignore = set()
         ignore.add('realm')
-        ignore.add('config_template')
         return super(Organization, self).read(entity, attrs, ignore, params)
 
     def update(self, fields=None):


### PR DESCRIPTION
Fixes #714 : Setup for UI testing failed

Add the 'config_template' `ignore` in `read()` can fix the issue, works fine for virt-who ui-testing