### PR TITLE
subnet fix mt to mtu [1-liner]

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -7304,7 +7304,7 @@ class Subnet(
             ),
             'location': entity_fields.OneToManyField(Location),
             'mask': entity_fields.NetmaskField(required=True),
-            'mt': entity_fields.IntegerField(min_val=68, max_val=4294967295),
+            'mtu': entity_fields.IntegerField(min_val=68, max_val=4294967295),
             'name': entity_fields.StringField(
                 required=True,
                 str_type='alpha',


### PR DESCRIPTION
Causing errors with subnet entity. 

This mistake was done accidentally in #702 
Look at entities and search for `mtu`, you can see it was deleted during replacement process, probably macro looked like `u'`

I tested it with `test_positive_create_with_subnet`. But all test in automation using API subnet calls should be fixed by this. 

```
test_host.py::HostTestCase::test_positive_create_with_subnet 

=================== 1 passed, 77 deselected in 76.68 seconds ===================
```