### PR TITLE
Fixes #721 - Added support for Tailoring file entity

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -7828,6 +7828,73 @@ class System(
         return super(System, self).read(entity, attrs, ignore, params)
 
 
+class TailoringFile(
+        Entity,
+        EntityCreateMixin,
+        EntityDeleteMixin,
+        EntityReadMixin,
+        EntitySearchMixin,
+        EntityUpdateMixin):
+    """A representation of a Tailoring File entity."""
+
+    def __init__(self, server_config=None, **kwargs):
+        self._fields = {
+            'name': entity_fields.StringField(
+                required=True,
+                str_type='alpha',
+                length=(4, 30),
+                unique=True
+            ),
+            'scap_file': entity_fields.StringField(),
+            'original_filename': entity_fields.StringField(),
+            'tailoring_file_profiles': entity_fields.StringField(),
+            'location': entity_fields.OneToManyField(Location),
+            'organization': entity_fields.OneToManyField(Organization),
+        }
+        if 'scap_file' in kwargs:
+            with open(kwargs['scap_file']) as input_file:
+                kwargs['scap_file'] = input_file.read()
+        self._meta = {
+            'api_path': 'api/v2/compliance/tailoring_files',
+            'server_modes': ('sat')
+        }
+        super(TailoringFile, self).__init__(server_config, **kwargs)
+
+    def create(self, create_missing=None):
+        """Do extra work to fetch a complete set of attributes for this entity.
+
+        For more information, see `Bugzilla #1381129
+        <https://bugzilla.redhat.com/show_bug.cgi?id=1381129>`_.
+
+        """
+        return type(self)(
+            self._server_config,
+            id=self.create_json(create_missing)['id'],
+        ).read()
+
+    def create_payload(self, **kwargs):
+        """Wrap submitted data within an extra dict."""
+        return {'tailoring_file': super(TailoringFile, self).create_payload()}
+
+    def read(self, entity=None, attrs=None, ignore=None, params=None):
+        """Ignore ``scap_file`` field.
+        """
+        if ignore is None:
+            ignore = set()
+        ignore.update(['scap_file'])
+        return super(TailoringFile, self).read(entity, attrs, ignore, params)
+
+    def update(self, fields=None):
+        """Fetch a complete set of attributes for this entity.
+
+        For more information, see `Bugzilla #1234964
+        <https://bugzilla.redhat.com/show_bug.cgi?id=1234964>`_.
+
+        """
+        self.update_json(fields)
+        return self.read()
+
+
 class Template(Entity):
     """A representation of a Template entity."""
 
@@ -8231,11 +8298,26 @@ class ScapContents(
             'organization': entity_fields.OneToManyField(Organization),
             'scap_content_profiles': entity_fields.StringField(),
         }
+        if 'scap_file' in kwargs:
+            with open(kwargs['scap_file']) as input_file:
+                kwargs['scap_file'] = input_file.read()
         self._meta = {
             'api_path': 'api/compliance/scap_contents',
             'server_modes': ('sat'),
         }
         super(ScapContents, self).__init__(server_config, **kwargs)
+
+    def create(self, create_missing=None):
+        """Do extra work to fetch a complete set of attributes for this entity.
+
+        For more information, see `Bugzilla #1381129
+        <https://bugzilla.redhat.com/show_bug.cgi?id=1381129>`_.
+
+        """
+        return type(self)(
+            self._server_config,
+            id=self.create_json(create_missing)['id'],
+        ).read()
 
     def read(self, entity=None, attrs=None, ignore=None, params=None):
         """Override :meth:`nailgun.entity_mixins.EntityReadMixin.read` to ignore

--- a/tests/data/ssg-rhel7-ds-tailoring.xml
+++ b/tests/data/ssg-rhel7-ds-tailoring.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xccdf:Tailoring xmlns:xccdf="http://checklists.nist.gov/xccdf/1.2" id="xccdf_scap-workbench_tailoring_default">
+  <xccdf:benchmark href="/usr/share/xml/scap/ssg/content/ssg-rhel7-ds.xml"/>
+  <xccdf:version time="2019-08-01T13:46:35">1</xccdf:version>
+  <xccdf:Profile id="xccdf_org.ssgproject.content_profile_standard_customized" extends="xccdf_org.ssgproject.content_profile_standard">
+    <xccdf:title xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">Standard System Security Profile for Red Hat Enterprise Linux 7 [CUSTOMIZED]</xccdf:title>
+    <xccdf:description xmlns:xhtml="http://www.w3.org/1999/xhtml" xml:lang="en-US" override="true">This profile contains rules to ensure standard security baseline
+of a Red Hat Enterprise Linux 7 system. Regardless of your system's workload
+all of these checks should pass.</xccdf:description>
+    <xccdf:select idref="xccdf_org.ssgproject.content_rule_partition_for_var_log" selected="false"/>
+    <xccdf:select idref="xccdf_org.ssgproject.content_rule_partition_for_var_log_audit" selected="false"/>
+    <xccdf:select idref="xccdf_org.ssgproject.content_group_disk_partitioning" selected="false"/>
+    <xccdf:select idref="xccdf_org.ssgproject.content_rule_file_permissions_unauthorized_world_writable" selected="false"/>
+    <xccdf:select idref="xccdf_org.ssgproject.content_rule_dir_perms_world_writable_sticky_bits" selected="false"/>
+    <xccdf:select idref="xccdf_org.ssgproject.content_rule_file_permissions_unauthorized_suid" selected="false"/>
+    <xccdf:select idref="xccdf_org.ssgproject.content_rule_service_autofs_disabled" selected="false"/>
+    <xccdf:select idref="xccdf_org.ssgproject.content_group_mounting" selected="false"/>
+    <xccdf:select idref="xccdf_org.ssgproject.content_group_partitions" selected="false"/>
+    <xccdf:select idref="xccdf_org.ssgproject.content_rule_mount_option_dev_shm_nodev" selected="false"/>
+    <xccdf:select idref="xccdf_org.ssgproject.content_rule_mount_option_var_tmp_nosuid" selected="false"/>
+    <xccdf:select idref="xccdf_org.ssgproject.content_rule_mount_option_var_tmp_noexec" selected="false"/>
+    <xccdf:select idref="xccdf_org.ssgproject.content_rule_mount_option_home_nodev" selected="false"/>
+    <xccdf:select idref="xccdf_org.ssgproject.content_rule_mount_option_nodev_removable_partitions" selected="false"/>
+    <xccdf:select idref="xccdf_org.ssgproject.content_rule_mount_option_noexec_removable_partitions" selected="false"/>
+    <xccdf:select idref="xccdf_org.ssgproject.content_rule_mount_option_var_tmp_bind" selected="false"/>
+    <xccdf:select idref="xccdf_org.ssgproject.content_rule_mount_option_nodev_nonroot_local_partitions" selected="false"/>
+    <xccdf:select idref="xccdf_org.ssgproject.content_rule_mount_option_nosuid_removable_partitions" selected="false"/>
+    <xccdf:select idref="xccdf_org.ssgproject.content_rule_mount_option_var_tmp_nodev" selected="false"/>
+    <xccdf:select idref="xccdf_org.ssgproject.content_rule_mount_option_tmp_nosuid" selected="false"/>
+    <xccdf:select idref="xccdf_org.ssgproject.content_rule_mount_option_home_nosuid" selected="false"/>
+    <xccdf:select idref="xccdf_org.ssgproject.content_rule_mount_option_tmp_noexec" selected="false"/>
+    <xccdf:select idref="xccdf_org.ssgproject.content_rule_mount_option_tmp_nodev" selected="false"/>
+    <xccdf:select idref="xccdf_org.ssgproject.content_rule_mount_option_dev_shm_noexec" selected="false"/>
+    <xccdf:select idref="xccdf_org.ssgproject.content_rule_mount_option_dev_shm_nosuid" selected="false"/>
+    <xccdf:select idref="xccdf_org.ssgproject.content_rule_file_permissions_unauthorized_sgid" selected="false"/>
+    <xccdf:select idref="xccdf_org.ssgproject.content_group_files" selected="false"/>
+    <xccdf:select idref="xccdf_org.ssgproject.content_group_permissions" selected="false"/>
+  </xccdf:Profile>
+</xccdf:Tailoring>

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -176,6 +176,7 @@ class InitTestCase(TestCase):
                 entities.Subscription,
                 # entities.System,  # see below
                 # entities.SystemPackage,  # see below
+                entities.TailoringFile,
                 entities.TemplateCombination,
                 entities.Template,
                 entities.TemplateKind,
@@ -694,6 +695,7 @@ class CreateTestCase(TestCase):
             entities.Realm(self.cfg),
             entities.ScapContents(self.cfg),
             entities.SmartProxy(self.cfg),
+            entities.TailoringFile(self.cfg),
             entities.UserGroup(self.cfg),
             entities.VirtWhoConfig(self.cfg)
         )
@@ -757,6 +759,7 @@ class CreatePayloadTestCase(TestCase):
                 entities.ScapContents,
                 entities.SmartVariable,
                 entities.Subnet,
+                entities.TailoringFile,
                 entities.User,
                 entities.UserGroup,
                 entities.VirtWhoConfig
@@ -1431,6 +1434,7 @@ class ReadTestCase(TestCase):
                 (entities.Repository, {'organization', 'upstream_password'}),
                 (entities.User, {'password'}),
                 (entities.ScapContents, {'scap_file'}),
+                (entities.TailoringFile, {'scap_file'}),
                 (entities.VirtWhoConfig, {'hypervisor_password'}),
                 (entities.VMWareComputeResource, {'password'}),
                 (entities.DiscoveredHost, {'ip', 'mac', 'root_pass', 'hostgroup'}),
@@ -1623,9 +1627,7 @@ class ReadTestCase(TestCase):
 
     def test_http_proxy_ignore_arg(self):
         """Call :meth:`nailgun.entities.HTTPProxy.read`.
-
         Assert that the entity ignores the ``password, organization and location`` field.
-
         """
         with mock.patch.object(EntityReadMixin, 'read') as read:
             with mock.patch.object(EntityReadMixin, 'read_json'):
@@ -1885,6 +1887,7 @@ class UpdateTestCase(TestCase):
             entities.Organization(self.cfg),
             entities.ScapContents(self.cfg),
             entities.SmartProxy(self.cfg),
+            entities.TailoringFile(self.cfg),
             entities.User(self.cfg),
             entities.UserGroup(self.cfg),
         )
@@ -4235,3 +4238,47 @@ class JobInvocationTestCase(TestCase):
                     'targeting_type': 'foo'
                 })
         self.assertEqual(poll_task.call_count, 1)
+
+
+class TailoringFileTestCase(TestCase):
+    """Tests for :class:`nailgun.entities.TailoringFile`."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set ``self.server_config``."""
+        cls.server_config = config.ServerConfig('http://example.com')
+
+    def test_scap_tailoring_file(self):
+        """Test ``nailgun.entities.TailoringFile.create``.
+        """
+        entity = entities.TailoringFile(
+            self.server_config, name="TF1",
+            scap_file="tests/data/ssg-rhel7-ds-tailoring.xml",
+        )
+        with mock.patch.object(EntityCreateMixin, 'create_missing'):
+            entity.create_missing()
+        self.assertEqual({'name'}, _get_required_field_names(entity).union())
+
+
+class ScapContentsTestCase(TestCase):
+    """Tests for :class:`nailgun.entities.ScapContents`."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set ``self.server_config``."""
+        cls.server_config = config.ServerConfig('http://example.com')
+
+    def test_scap_tailoring_file(self):
+        """Test ``nailgun.entities.ScapContents.create``.
+        """
+        entity = entities.ScapContents(
+            self.server_config,
+            title="TF1",
+            scap_file="tests/data/ssg-rhel7-ds-tailoring.xml"
+        )
+        with mock.patch.object(EntityCreateMixin, 'create_missing'):
+            entity.create_missing()
+        self.assertEqual(
+            _get_required_field_names(entity),
+            set(entity.get_values().keys()),
+        )


### PR DESCRIPTION
```
In [2]: tf = entities.TailoringFile( scap_file="/home/jpathan/Downloads/ssg-rhel7-ds-tailoring.xml", organization=[1], location=[2], name='tailoring_file1').create()                    

In [3]: tf                                                                                                                                                                               
Out[3]: nailgun.entities.TailoringFile(name='tailoring_file1', original_filename=None, id=20)

In [4]: tf.read()                                                                                                                                                                        
Out[4]: nailgun.entities.TailoringFile(name='tailoring_file1', original_filename=None, id=20)

In [7]: tf = entities.TailoringFile(id=tf.id, name="updated_TF", original_filename="ssg_tf").update()                                                                                  

In [8]: tf                                                                                                                                                                               
Out[8]: nailgun.entities.TailoringFile(name='updated_TF', original_filename='ssg_tf', id=20)

In [9]: tf.delete()                                                                                                                                                                      
Out[9]: 
{'id': 20,
 'name': 'updated_TF',
 'scap_file': '<?xml version="1.0" encoding="UTF-8"?> *****  output omitted ******</xccdf:Profile>\n</xccdf:Tailoring>',
 'original_filename': 'ssg_tf',
 'created_at': '2020-05-13T12:39:10.353Z',
 'updated_at': '2020-05-13T12:41:58.450Z',
 'digest': '2e222e14f397f1e45c438ff29949c22556376dd0108936051e4ec12d8abfa12f'}



In [12]: entities.TailoringFile(name='t').search()                                                                                                                                         
Out[12]: 
[nailgun.entities.TailoringFile(name='t1', original_filename=None, location=[nailgun.entities.Location(id=2)], organization=[nailgun.entities.Organization(id=1)], id=1),
 nailgun.entities.TailoringFile(name='t3', original_filename=None, location=[nailgun.entities.Location(id=2)], organization=[nailgun.entities.Organization(id=1)], id=3),
 nailgun.entities.TailoringFile(name='t4', original_filename=None, location=[nailgun.entities.Location(id=2)], organization=[nailgun.entities.Organization(id=1)], id=4),

```