### PR TITLE
 deleting all occurencies of config template

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -1530,130 +1530,6 @@ class ConfigGroup(
         super(ConfigGroup, self).__init__(server_config, **kwargs)
 
 
-class ConfigTemplate(
-        Entity,
-        EntityCreateMixin,
-        EntityDeleteMixin,
-        EntityReadMixin,
-        EntitySearchMixin,
-        EntityUpdateMixin):
-    """A representation of a Config Template entity."""
-
-    def __init__(self, server_config=None, **kwargs):
-        self._fields = {
-            'audit_comment': entity_fields.StringField(),
-            'locked': entity_fields.BooleanField(),
-            'name': entity_fields.StringField(
-                required=True,
-                str_type='alpha',
-                length=(6, 12),
-                unique=True
-            ),
-            'operatingsystem': entity_fields.OneToManyField(OperatingSystem),
-            'organization': entity_fields.OneToManyField(Organization),
-            'location': entity_fields.OneToManyField(Location),
-            'snippet': entity_fields.BooleanField(required=True),
-            'template': entity_fields.StringField(required=True),
-            'template_combinations': entity_fields.ListField(),
-            'template_kind': entity_fields.OneToOneField(TemplateKind),
-        }
-        self._meta = {
-            'api_path': 'api/v2/config_templates',
-            'server_modes': ('sat'),
-        }
-        super(ConfigTemplate, self).__init__(server_config, **kwargs)
-
-    def create_missing(self):
-        """Customize the process of auto-generating instance attributes.
-
-        Populate ``template_kind`` if:
-
-        * this template is not a snippet, and
-        * the ``template_kind`` instance attribute is unset.
-
-        """
-        super(ConfigTemplate, self).create_missing()
-        if (getattr(self, 'snippet', None) is False and
-                not hasattr(self, 'template_kind')):
-            self.template_kind = TemplateKind(self._server_config, id=1)
-
-    def create_payload(self):
-        """Wrap submitted data within an extra dict.
-
-        For more information, see `Bugzilla #1151220
-        <https://bugzilla.redhat.com/show_bug.cgi?id=1151220>`_.
-
-        """
-        payload = super(ConfigTemplate, self).create_payload()
-        if 'template_combinations' in payload:
-            payload['template_combinations_attributes'] = payload.pop(
-                'template_combinations')
-        return {'config_template': payload}
-
-    def update_payload(self, fields=None):
-        """Wrap submitted data within an extra dict."""
-        payload = super(ConfigTemplate, self).update_payload(fields)
-        if 'template_combinations' in payload:
-            payload['template_combinations_attributes'] = payload.pop(
-                'template_combinations')
-        return {'config_template': payload}
-
-    def path(self, which=None):
-        """Extend ``nailgun.entity_mixins.Entity.path``.
-
-        The format of the returned path depends on the value of ``which``:
-
-        build_pxe_default
-            /config_templates/build_pxe_default
-        clone
-            /config_templates/clone
-        revision
-            /config_templates/revision
-
-        ``super`` is called otherwise.
-
-        """
-        if which in ('build_pxe_default', 'clone', 'revision'):
-            prefix = 'self' if which == 'clone' else 'base'
-            return '{0}/{1}'.format(
-                super(ConfigTemplate, self).path(prefix),
-                which
-            )
-        return super(ConfigTemplate, self).path(which)
-
-    def build_pxe_default(self, synchronous=True, **kwargs):
-        """Helper to build pxe default template.
-
-        :param synchronous: What should happen if the server returns an HTTP
-            202 (accepted) status code? Wait for the task to complete if
-            ``True``. Immediately return the server's response otherwise.
-        :param kwargs: Arguments to pass to requests.
-        :returns: The server's response, with all JSON decoded.
-        :raises: ``requests.exceptions.HTTPError`` If the server responds with
-            an HTTP 4XX or 5XX message.
-        """
-        kwargs = kwargs.copy()  # shadow the passed-in kwargs
-        kwargs.update(self._server_config.get_client_kwargs())
-        response = client.post(self.path('build_pxe_default'), **kwargs)
-        return _handle_response(response, self._server_config, synchronous)
-
-    def clone(self, synchronous=True, **kwargs):
-        """Helper to clone an existing provision template
-
-        :param synchronous: What should happen if the server returns an HTTP
-            202 (accepted) status code? Wait for the task to complete if
-            ``True``. Immediately return the server's response otherwise.
-        :param kwargs: Arguments to pass to requests.
-        :returns: The server's response, with all JSON decoded.
-        :raises: ``requests.exceptions.HTTPError`` If the server responds with
-            an HTTP 4XX or 5XX message.
-        """
-        kwargs = kwargs.copy()  # shadow the passed-in kwargs
-        kwargs.update(self._server_config.get_client_kwargs())
-        response = client.post(self.path('clone'), **kwargs)
-        return _handle_response(response, self._server_config, synchronous)
-
-
 class TemplateInput(
     Entity,
     EntityCreateMixin,
@@ -5073,7 +4949,6 @@ class OperatingSystem(
                 unique=True
             ),
             'ptable': entity_fields.OneToManyField(PartitionTable),
-            'config_template': entity_fields.OneToManyField(ConfigTemplate),
             'provisioning_template': entity_fields.OneToManyField(
                 ProvisioningTemplate),
             'release_name': entity_fields.StringField(),
@@ -5339,7 +5214,6 @@ class OSDefaultTemplate(
     def __init__(self, server_config=None, **kwargs):
         _check_for_value('operatingsystem', kwargs)
         self._fields = {
-            'config_template': entity_fields.OneToOneField(ConfigTemplate),
             'operatingsystem': entity_fields.OneToOneField(
                 OperatingSystem,
                 required=True,
@@ -7892,7 +7766,6 @@ class TemplateCombination(Entity, EntityDeleteMixin, EntityReadMixin):
 
     def __init__(self, server_config=None, **kwargs):
         self._fields = {
-            'config_template': entity_fields.OneToOneField(ConfigTemplate),
             'environment': entity_fields.OneToOneField(Environment),
             'hostgroup': entity_fields.OneToOneField(HostGroup),
             'provisioning_template': entity_fields.OneToOneField(

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -107,7 +107,6 @@ class InitTestCase(TestCase):
                 entities.ComputeAttribute,
                 entities.ComputeProfile,
                 entities.ConfigGroup,
-                entities.ConfigTemplate,
                 entities.CompliancePolicies,
                 entities.ProvisioningTemplate,
                 entities.ReportTemplate,
@@ -274,7 +273,6 @@ class PathTestCase(TestCase):
         for entity, path in (
                 (entities.ActivationKey, '/activation_keys'),
                 (entities.Capsule, '/capsules'),
-                (entities.ConfigTemplate, '/config_templates'),
                 (entities.ProvisioningTemplate, '/provisioning_templates'),
                 (entities.ReportTemplate, '/report_templates'),
                 (entities.Role, '/roles'),
@@ -334,7 +332,6 @@ class PathTestCase(TestCase):
                 (entities.AbstractComputeResource, 'associate'),
                 (entities.AbstractComputeResource, 'images'),
                 (entities.ArfReport, 'download_html'),
-                (entities.ConfigTemplate, 'clone'),
                 (entities.ProvisioningTemplate, 'clone'),
                 (entities.ReportTemplate, 'clone'),
                 (entities.Role, 'clone'),
@@ -388,8 +385,6 @@ class PathTestCase(TestCase):
     def test_noid_and_which(self):
         """Execute ``entity().path(which=…)``."""
         for entity, which in (
-                (entities.ConfigTemplate, 'build_pxe_default'),
-                (entities.ConfigTemplate, 'revision'),
                 (entities.ProductBulkAction, 'destroy'),
                 (entities.ProductBulkAction, 'sync'),
                 (entities.ProductBulkAction, 'http_proxy'),
@@ -736,7 +731,6 @@ class CreatePayloadTestCase(TestCase):
                 entities.AbstractComputeResource,
                 entities.Architecture,
                 entities.ConfigGroup,
-                entities.ConfigTemplate,
                 entities.ProvisioningTemplate,
                 entities.ReportTemplate,
                 entities.DiscoveredHost,
@@ -952,45 +946,6 @@ class CreateMissingTestCase(TestCase):
         for key, value in attrs.items():
             with self.subTest((key, value)):
                 self.assertEqual(getattr(entity, key), value)
-
-    def test_config_template_v1(self):
-        """Test ``ConfigTemplate(snippet=True)``."""
-        entity = entities.ConfigTemplate(self.cfg, snippet=True)
-        with mock.patch.object(EntityCreateMixin, 'create_raw'):
-            with mock.patch.object(EntityReadMixin, 'read_raw'):
-                entity.create_missing()
-        self.assertEqual(
-            _get_required_field_names(entity),
-            set(entity.get_values().keys()),
-        )
-
-    def test_config_template_v2(self):
-        """Test ``ConfigTemplate(snippet=False)``."""
-        entity = entities.ConfigTemplate(self.cfg, snippet=False)
-        with mock.patch.object(EntityCreateMixin, 'create_raw'):
-            with mock.patch.object(EntityReadMixin, 'read_raw'):
-                entity.create_missing()
-        self.assertEqual(
-            _get_required_field_names(entity).union(['template_kind']),
-            set(entity.get_values().keys()),
-        )
-
-    def test_config_template_v3(self):
-        """Test ``ConfigTemplate(snippet=False, template_kind=…)``."""
-        tk_id = gen_integer()
-        entity = entities.ConfigTemplate(
-            self.cfg,
-            snippet=False,
-            template_kind=tk_id,
-        )
-        with mock.patch.object(EntityCreateMixin, 'create_raw'):
-            with mock.patch.object(EntityReadMixin, 'read_raw'):
-                entity.create_missing()
-        self.assertEqual(
-            _get_required_field_names(entity).union(['template_kind']),
-            set(entity.get_values().keys()),
-        )
-        self.assertEqual(entity.template_kind.id, tk_id)
 
     def test_report_template_v1(self):
         """Test ``ReportTemplate(name='testName')``."""
@@ -1997,7 +1952,6 @@ class UpdatePayloadTestCase(TestCase):
         """Instantiate a variety of entities and call ``update_payload``."""
         entities_payloads = [
             (entities.AbstractComputeResource, {'compute_resource': {}}),
-            (entities.ConfigTemplate, {'config_template': {}}),
             (entities.Filter, {'filter': {}}),
             (entities.ProvisioningTemplate, {'provisioning_template': {}}),
             (entities.ReportTemplate, {'report_template': {}}),
@@ -2255,8 +2209,6 @@ class GenericTestCase(TestCase):
                 'get'
             ),
             (entities.Capsule(**generic).content_sync, 'post'),
-            (entities.ConfigTemplate(**generic).build_pxe_default, 'post'),
-            (entities.ConfigTemplate(**generic).clone, 'post'),
             (entities.Role(**generic).clone, 'post'),
             (
                 entities.ProvisioningTemplate(**generic).build_pxe_default,
@@ -2463,52 +2415,6 @@ class ForemanTaskTestCase(TestCase):
                     poll_task.call_args[0][3],
                     kwargs.get('timeout', None),
                 )
-
-
-class ConfigTemplateTestCase(TestCase):
-    """Tests for :class:`nailgun.entities.ConfigTemplate`."""
-
-    def test_creation_and_update(self):
-        """Check template combinations as json or entity is set on correct
-        attribute template_combinations_attributes ( check #333)
-        """
-        cfg = config.ServerConfig(url='foo')
-        env = entities.Environment(cfg, id=2, name='env')
-        hostgroup = entities.HostGroup(cfg, id=2, name='hgroup')
-        combination = entities.TemplateCombination(
-            cfg,
-            hostgroup=hostgroup,
-            environment=env)
-        template_combinations = [
-            {'hostgroup_id': 1, 'environment_id': 1},
-            combination]
-        cfg_template = entities.ConfigTemplate(
-            cfg, name='cfg',
-            snippet=False,
-            template='cat',
-            template_kind=8,
-            template_combinations=template_combinations)
-        expected_dct = {
-            'config_template': {
-                'name': 'cfg', 'snippet': False, 'template': 'cat',
-                'template_kind_id': 8, 'template_combinations_attributes': [
-                    {'environment_id': 1, 'hostgroup_id': 1},
-                    {'environment_id': 2, 'hostgroup_id': 2}]
-            }
-        }
-        self.assertEqual(expected_dct, cfg_template.create_payload())
-        # Testing update
-        env3 = entities.Environment(cfg, id=3, name='env3')
-        combination3 = entities.TemplateCombination(
-            cfg,
-            hostgroup=hostgroup,
-            environment=env3)
-        cfg_template.template_combinations.append(combination3)
-        attrs = expected_dct['config_template']
-        attrs['template_combinations_attributes'].append(
-            {'environment_id': 3, 'hostgroup_id': 2}
-        )
-        self.assertEqual(expected_dct, cfg_template.update_payload())
 
 
 class ContentUploadTestCase(TestCase):


### PR DESCRIPTION
config template was causing error in `test_positive_get_per_page`
I would like to finish here what was started in #714 

And I would like open discussion here, what we are going to do with all other occurencies which are still in `entities.py`: 
```
output of command grep -nr 'config_template'

entities.py:1561:            'api_path': 'api/v2/config_templates',
entities.py:1591:        return {'config_template': payload}
entities.py:1599:        return {'config_template': payload}
entities.py:1607:            /config_templates/build_pxe_default
entities.py:1609:            /config_templates/clone
entities.py:1611:            /config_templates/revision
``` 

I had local problems with `test_positive_get_per_page`:
```
 # Compute Resource related entities
        cls.compresource_libvirt = entities.LibvirtComputeResource(
            organization=[cls.org], location=[cls.loc]
        ).create()
>       cls.image = entities.Image(compute_resource=cls.compresource_libvirt).create()
```
Test result after change:
```
=================== 1 passed, 77 deselected in 42.77 seconds ===================
```