### PR TITLE
Host creation fix.

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -3890,11 +3890,11 @@ class Host(
         else:
             if not hasattr(self.environment, 'organization'):
                 self.environment = self.environment.read()
-            if self.location.id not in [
+            if int(self.location.id) not in [
                     loc.id for loc in self.environment.location]:
                 self.environment.location.append(self.location)
                 self.environment.update(['location'])
-            if self.organization.id not in [
+            if int(self.organization.id) not in [
                     org.id for org in self.environment.organization]:
                 self.environment.organization.append(self.organization)
                 self.environment.update(['organization'])


### PR DESCRIPTION
Currently, all the CLI classparameters tests are failing in setup during the host creation here:

tests/foreman/cli/test_classparameters.py:
```
73         cls.host = entities.Host(
74             organization=cls.org['id'], location=cls.loc['id'], environment=cls.env['name']
75         ).create()
```

The problem appears in the create_missing() method of nailgun entities:

venv/lib64/python3.7/site-packages/nailgun/entities.py:
```
3891             if not hasattr(self.environment, 'organization'):
3892                 self.environment = self.environment.read()
3893             if self.location.id not in [
3894                     loc.id for loc in self.environment.location]:
3895                 self.environment.location.append(self.location)
3896                 self.environment.update(['location'])
3897             if self.organization.id not in [
3898                     org.id for org in self.environment.organization]:
3899                 self.environment.organization.append(self.organization)
3900                 self.environment.update(['organization'])
```

As the env has no org assigned, self.environment.read() is called (L3892), which returns the entitiy:
`nailgun.entities.Environment(location=[nailgun.entities.Location(id=42)], name='KT_0xvfrp_Library_fEERJUiTZI_51', organization=[nailgun.entities.Organization(id=41)], id=32)`

As you can see the location and organization ids are of integer type, while host's (self.) location and organization are of string type:
```
nailgun.entities.Location(id='42')
nailgun.entities.Organization(id='41')
```

That's why the subsequent 'in' operator results false and self.environment.location.append() is called, adding second location and organization to the host.

Subsequent self.environment.update() will fail for 6.8 (but is fine for 6.7) with HTTP 500 as the request has two locations in it:
`body = {str} '{"environment": {"location_ids": [42, "42"]}}'`

Although this commit provides a fix, I am not sure if it's on the right place or shouldn't be done differently. Any advices and ideas how to fix this would be highly appreciated.