### PR TITLE
[cherry-pick] Deprecation of 'use_puppet_default'

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -5248,7 +5248,6 @@ class OverrideValue(
             'smart_class_parameter': entity_fields.OneToOneField(
                 SmartClassParameters),
             'smart_variable': entity_fields.OneToOneField(SmartVariable),
-            'use_puppet_default': entity_fields.BooleanField(),
             'omit': entity_fields.BooleanField(),
         }
         super(OverrideValue, self).__init__(server_config, **kwargs)
@@ -6859,7 +6858,7 @@ class SmartClassParameters(
             'default_value': entity_fields.StringField(),
             'hidden_value': entity_fields.BooleanField(),
             'hidden_value?': entity_fields.BooleanField(),
-            'use_puppet_default': entity_fields.BooleanField(),
+            'omit': entity_fields.BooleanField(),
             'validator_type': entity_fields.StringField(
                 choices=('regexp', 'list')
             ),


### PR DESCRIPTION
'use_puppet_default' was deprecated and removed from Satellite 6.8, we shall use 'omit' instead.

Reference:
https://bugzilla.redhat.com/show_bug.cgi?id=1791659
https://projects.theforeman.org/issues/28583