### PR TITLE
Add bulk_add_subscriptions (#733)

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -4087,6 +4087,23 @@ class Host(
         response = client.put(self.path('bulk/install_content'), **kwargs)
         return _handle_response(response, self._server_config, synchronous)
 
+    def bulk_add_subscriptions(self, synchronous=True, **kwargs):
+        """Add subscriptions to one or more hosts
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all content decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+
+        """
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.put(self.path('bulk/add_subscriptions'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous)
+
     def get_facts(self, synchronous=True, **kwargs):
         """List all fact values of a given host
 
@@ -4244,6 +4261,11 @@ class Host(
                 which
             )
         elif which in ('bulk/install_content',):
+            return '{0}/{1}'.format(
+                super(Host, self).path(which='base'),
+                which
+            )
+        elif which in ('bulk/add_subscriptions',):
             return '{0}/{1}'.format(
                 super(Host, self).path(which='base'),
                 which


### PR DESCRIPTION
Hello

I need to write test[1] which has to use `bulk/add_subscriptions` API. Therefore, need nailgun support for this API [2]


[1]  https://github.com/SatelliteQE/robottelo/blob/0d0bec299cad1d587e64b53cf48561aa3d4c46dd/tests/foreman/api/test_hostcollection.py#L383
[2] https://theforeman.org/plugins/katello/3.15/api/apidoc/v2/hosts_bulk_actions/add_subscriptions.html