### PR TITLE
[cherry-pick] removed resource-type parameter from Permission entity

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -5381,7 +5381,6 @@ class Permission(Entity, EntityReadMixin, EntitySearchMixin):
                 length=(6, 12),
                 unique=True
             ),
-            'resource_type': entity_fields.StringField(required=True),
         }
         self._meta = {
             'api_path': 'api/v2/permissions',


### PR DESCRIPTION
cherry-picking #737 into `stable-satellite`.