### PR TITLE
restore permissions resource type

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -5442,6 +5442,7 @@ class Permission(Entity, EntityReadMixin, EntitySearchMixin):
                 length=(6, 12),
                 unique=True
             ),
+            'resource_type': entity_fields.StringField(required=True),
         }
         self._meta = {
             'api_path': 'api/v2/permissions',


### PR DESCRIPTION
Turns out that removing the parameter in #737 was premature, the permissions search test depends on listing those resource types which led to unforeseen failure 