### PR TITLE
katello-tracer component implementation

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -187,6 +187,44 @@ def _get_version(server_config):
     """
     return getattr(server_config, 'version', Version('1!0'))
 
+class Trace(
+        Entity,
+        EntityUpdateMixin):
+    """A representation of Host Trace entity."""
+
+    def __init__(self, server_config=None, **kwargs):
+        self._meta = {
+            'api_path': 'katello/api/traces',
+        }
+        super(Trace, self).__init__(server_config, **kwargs)
+
+    def path(self, which=None):
+        """Extend ``nailgun.entity_mixins.Entity.path``.
+        There's only a single path for the traces endpoint: /traces
+        """
+        if which in ('resolve'):
+            return '{0}/{1}'.format(
+                super(Trace, self).path('base'),
+                which
+        )
+        return super(Trace, self).path(which),
+
+    def resolve(self, synchronous=True, **kwargs):
+        """Resolve the supplied list of traces
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+
+        """
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.put(self.path('resolve'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous)
 
 class ActivationKey(
         Entity,

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -7968,46 +7968,6 @@ class TemplateKind(Entity, EntityReadMixin, EntitySearchMixin):
         super(TemplateKind, self).__init__(server_config, **kwargs)
 
 
-class Trace(
-        Entity,
-        EntityUpdateMixin):
-    """A representation of Host Trace entity."""
-
-    def __init__(self, server_config=None, **kwargs):
-        self._meta = {
-            'api_path': 'katello/api/traces',
-        }
-        super(Trace, self).__init__(server_config, **kwargs)
-
-    def path(self, which=None):
-        """Extend ``nailgun.entity_mixins.Entity.path``.
-        There's only a single path for the traces endpoint: /traces
-        """
-        if which in ('resolve'):
-            return '{0}/{1}'.format(
-                super(Trace, self).path('base'),
-                which
-            )
-        return super(Trace, self).path(which),
-
-    def resolve(self, synchronous=True, **kwargs):
-        """Resolve the supplied list of traces
-
-        :param synchronous: What should happen if the server returns an HTTP
-            202 (accepted) status code? Wait for the task to complete if
-            ``True``. Immediately return the server's response otherwise.
-        :param kwargs: Arguments to pass to requests.
-        :returns: The server's response, with all JSON decoded.
-        :raises: ``requests.exceptions.HTTPError`` If the server responds with
-            an HTTP 4XX or 5XX message.
-
-        """
-        kwargs = kwargs.copy()  # shadow the passed-in kwargs
-        kwargs.update(self._server_config.get_client_kwargs())
-        response = client.put(self.path('resolve'), **kwargs)
-        return _handle_response(response, self._server_config, synchronous)
-
-
 class UserGroup(
         Entity,
         EntityCreateMixin,

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -4036,6 +4036,23 @@ class Host(
         response = client.get(self.path('errata'), **kwargs)
         return _handle_response(response, self._server_config, synchronous)
 
+    def traces(self, synchronous=True, **kwargs):
+        """List services that need restarting on the host
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all content decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+
+        """
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.get(self.path('traces'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous)
+
     def packages(self, synchronous=True, **kwargs):
         """List packages installed on the host
 
@@ -4305,6 +4322,7 @@ class Host(
                 'smart_variables',
                 'module_streams',
                 'disassociate',
+                'traces',
         ):
             return '{0}/{1}'.format(
                 super(Host, self).path(which='self'),

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -187,44 +187,6 @@ def _get_version(server_config):
     """
     return getattr(server_config, 'version', Version('1!0'))
 
-class Trace(
-        Entity,
-        EntityUpdateMixin):
-    """A representation of Host Trace entity."""
-
-    def __init__(self, server_config=None, **kwargs):
-        self._meta = {
-            'api_path': 'katello/api/traces',
-        }
-        super(Trace, self).__init__(server_config, **kwargs)
-
-    def path(self, which=None):
-        """Extend ``nailgun.entity_mixins.Entity.path``.
-        There's only a single path for the traces endpoint: /traces
-        """
-        if which in ('resolve'):
-            return '{0}/{1}'.format(
-                super(Trace, self).path('base'),
-                which
-        )
-        return super(Trace, self).path(which),
-
-    def resolve(self, synchronous=True, **kwargs):
-        """Resolve the supplied list of traces
-
-        :param synchronous: What should happen if the server returns an HTTP
-            202 (accepted) status code? Wait for the task to complete if
-            ``True``. Immediately return the server's response otherwise.
-        :param kwargs: Arguments to pass to requests.
-        :returns: The server's response, with all JSON decoded.
-        :raises: ``requests.exceptions.HTTPError`` If the server responds with
-            an HTTP 4XX or 5XX message.
-
-        """
-        kwargs = kwargs.copy()  # shadow the passed-in kwargs
-        kwargs.update(self._server_config.get_client_kwargs())
-        response = client.put(self.path('resolve'), **kwargs)
-        return _handle_response(response, self._server_config, synchronous)
 
 class ActivationKey(
         Entity,
@@ -7987,6 +7949,46 @@ class TemplateKind(Entity, EntityReadMixin, EntitySearchMixin):
             'server_modes': ('sat'),
         }
         super(TemplateKind, self).__init__(server_config, **kwargs)
+
+
+class Trace(
+        Entity,
+        EntityUpdateMixin):
+    """A representation of Host Trace entity."""
+
+    def __init__(self, server_config=None, **kwargs):
+        self._meta = {
+            'api_path': 'katello/api/traces',
+        }
+        super(Trace, self).__init__(server_config, **kwargs)
+
+    def path(self, which=None):
+        """Extend ``nailgun.entity_mixins.Entity.path``.
+        There's only a single path for the traces endpoint: /traces
+        """
+        if which in ('resolve'):
+            return '{0}/{1}'.format(
+                super(Trace, self).path('base'),
+                which
+            )
+        return super(Trace, self).path(which),
+
+    def resolve(self, synchronous=True, **kwargs):
+        """Resolve the supplied list of traces
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+
+        """
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.put(self.path('resolve'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous)
 
 
 class UserGroup(

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -3813,6 +3813,7 @@ class Host(
             'root_pass': entity_fields.StringField(
                 length=(8, 30), str_type='alpha'),
             'subnet': entity_fields.OneToOneField(Subnet),
+            'traces_status_label': entity_fields.StringField(),
             'uuid': entity_fields.StringField(),
         }
         self._owner_type = None  # actual ``owner_type`` value

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -4046,12 +4046,28 @@ class Host(
         :returns: The server's response, with all content decoded.
         :raises: ``requests.exceptions.HTTPError`` If the server responds with
             an HTTP 4XX or 5XX message.
-
         """
         kwargs = kwargs.copy()  # shadow the passed-in kwargs
         kwargs.update(self._server_config.get_client_kwargs())
         response = client.get(self.path('traces'), **kwargs)
         return _handle_response(response, self._server_config, synchronous)
+
+    def resolve_traces(self, synchronous=True, **kwargs):
+        """Resolve traces the host
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all content decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+        """
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.put(self.path('traces/resolve'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous)
+
 
     def packages(self, synchronous=True, **kwargs):
         """List packages installed on the host
@@ -4323,6 +4339,7 @@ class Host(
                 'module_streams',
                 'disassociate',
                 'traces',
+                'traces/resolve',
         ):
             return '{0}/{1}'.format(
                 super(Host, self).path(which='self'),

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -4052,6 +4052,22 @@ class Host(
         response = client.get(self.path('traces'), **kwargs)
         return _handle_response(response, self._server_config, synchronous)
 
+    def bulk_traces(self, synchronous=True, **kwargs):
+        """List services that need restarting on the specified set of hosts
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all content decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+        """
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.post(self.path('bulk/traces'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous)
+
     def resolve_traces(self, synchronous=True, **kwargs):
         """Resolve traces the host
 
@@ -4068,6 +4084,21 @@ class Host(
         response = client.put(self.path('traces/resolve'), **kwargs)
         return _handle_response(response, self._server_config, synchronous)
 
+    def bulk_resolve_traces(self, synchronous=True, **kwargs):
+        """Resolve traces the host
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all content decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+        """
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.put(self.path('bulk/resolve_traces'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous)
 
     def packages(self, synchronous=True, **kwargs):
         """List packages installed on the host
@@ -4345,8 +4376,11 @@ class Host(
                 super(Host, self).path(which='self'),
                 which
             )
-        elif which in ('bulk/install_content', 'bulk/add_subscriptions',
-                       'bulk/remove_subscriptions'):
+        elif which in ('bulk/install_content',
+                       'bulk/add_subscriptions',
+                       'bulk/remove_subscriptions',
+                       'bulk/traces',
+                       'bulk/resolve_traces'):
             return '{0}/{1}'.format(
                 super(Host, self).path(which='base'),
                 which


### PR DESCRIPTION
This PR brings the possibility to work with Host Traces.
4 new methods in Katello API => 4 nailgun methods.

> GET /api/hosts/:host_id/traces | List services that need restarting on the host
> PUT /api/hosts/:host_id/traces/resolve | Resolve Traces
> POST /api/hosts/bulk/traces | Fetch traces for one or more hosts
> PUT /api/hosts/bulk/resolve_traces | Resolve traces for one or more hosts


