### PR TITLE
Add support for reading subscriptions

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -3701,6 +3701,23 @@ class HostSubscription(Entity):
             )
         return super(HostSubscription, self).path(which)
 
+    def subscriptions(self, synchronous=True, **kwargs):
+        """Helper for getting subscriptions from host
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+
+        """
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.get(self.path('base'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous)
+
     def add_subscriptions(self, synchronous=True, **kwargs):
         """Helper for adding subscriptions to host
 


### PR DESCRIPTION
Hello

committing for feedback, this does not work yet, I am getting  an extra `subscription` on the end. Somehow need to change this line:

`response = client.get(self.path('subscriptions'), **kwargs)`

 to not send the extra `subscription`

Edit: setting 'base'  works:
`response = client.get(self.path('base'), **kwargs)`

Ref:
https://theforeman.org/plugins/katello/3.15/api/apidoc/v2/host_subscriptions/index.html