### PR TITLE
Override update_payload in some entities to only include fields that actually can be updated in the payload. Add update capability to Model. This is required by a robottelo change that tests updating of many entity types, using update_payload (rather than create_payload as it used to be).

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2007,6 +2007,7 @@ class ContentCredential(
     """A representation of a Content Credential entity."""
 
     def __init__(self, server_config=None, **kwargs):
+        self.updatable_fields = ['name', 'content_type', 'content']
         self._fields = {
             'content': entity_fields.StringField(required=True),
             'name': entity_fields.StringField(
@@ -2030,17 +2031,6 @@ class ContentCredential(
             'server_modes': ('sat'),
         }
         super(ContentCredential, self).__init__(server_config, **kwargs)
-
-    def update_payload(self, fields=None):
-        """Override the method to only update fields that actually can be updated
-        """
-        updatable_fields = set.intersection({'name', 'content_type', 'content'},
-                                            self.get_values().keys())
-        if fields is None:
-            fields = updatable_fields
-        else:
-            fields = set.intersection(set(fields), updatable_fields)
-        return super().update_payload(fields=fields)
 
 
 class ContentUpload(
@@ -3318,6 +3308,7 @@ class HostCollection(
     """A representation of a Host Collection entity."""
 
     def __init__(self, server_config=None, **kwargs):
+        self.updatable_fields = ['name', 'description', 'host_ids', 'max_hosts', 'unlimited_hosts']
         self._fields = {
             'description': entity_fields.StringField(),
             'host': entity_fields.OneToManyField(Host),
@@ -3368,18 +3359,6 @@ class HostCollection(
             self._server_config,
             id=self.create_json(create_missing)['id'],
         ).read()
-
-    def update_payload(self, fields=None):
-        """Override the method to only update fields that actually can be updated
-        """
-        updatable_fields = set.intersection({'name', 'description', 'host_ids',
-                                            'max_hosts', 'unlimited_hosts'},
-                                            self.get_values().keys())
-        if fields is None:
-            fields = updatable_fields
-        else:
-            fields = set.intersection(set(fields), updatable_fields)
-        return super().update_payload(fields=fields)
 
 
 class HostGroup(
@@ -5877,6 +5856,7 @@ class PuppetClass(
     """A representation of a Puppet Class entity."""
 
     def __init__(self, server_config=None, **kwargs):
+        self.updatable_fields = ['name']
         self._fields = {
             'name': entity_fields.StringField(
                 required=True,
@@ -5956,16 +5936,6 @@ class PuppetClass(
         kwargs.update(self._server_config.get_client_kwargs())
         response = client.get(self.path('smart_variables'), **kwargs)
         return _handle_response(response, self._server_config, synchronous)
-
-    def update_payload(self, fields=None):
-        """Override the method to only update fields that actually can be updated
-        """
-        updatable_fields = set.intersection({'name'}, self.get_values().keys())
-        if fields is None:
-            fields = updatable_fields
-        else:
-            fields = set.intersection(set(fields), updatable_fields)
-        return super().update_payload(fields=fields)
 
 
 class PackageGroup(Entity, EntityReadMixin, EntitySearchMixin):

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2031,6 +2031,17 @@ class ContentCredential(
         }
         super(ContentCredential, self).__init__(server_config, **kwargs)
 
+    def update_payload(self, fields=None):
+        """Override the method to only update fields that actually can be updated
+        """
+        updatable_fields = set.intersection({'name', 'content_type', 'content'},
+                                            self.get_values().keys())
+        if fields is None:
+            fields = updatable_fields
+        else:
+            fields = set.intersection(set(fields), updatable_fields)
+        return super().update_payload(fields=fields)
+
 
 class ContentUpload(
         Entity,
@@ -3359,11 +3370,16 @@ class HostCollection(
         ).read()
 
     def update_payload(self, fields=None):
-        """Rename ``system_ids`` to ``system_uuids``."""
-        payload = super(HostCollection, self).update_payload(fields)
-        if 'system_ids' in payload:
-            payload['system_uuids'] = payload.pop('system_ids')
-        return payload
+        """Override the method to only update fields that actually can be updated
+        """
+        updatable_fields = set.intersection({'name', 'description', 'host_ids',
+                                            'max_hosts', 'unlimited_hosts'},
+                                            self.get_values().keys())
+        if fields is None:
+            fields = updatable_fields
+        else:
+            fields = set.intersection(set(fields), updatable_fields)
+        return super().update_payload(fields=fields)
 
 
 class HostGroup(
@@ -5027,7 +5043,7 @@ class Media(
 
 
 class Model(
-        Entity, EntityCreateMixin, EntityDeleteMixin, EntityReadMixin):
+        Entity, EntityCreateMixin, EntityDeleteMixin, EntityReadMixin, EntityUpdateMixin):
     """A representation of a Model entity."""
 
     def __init__(self, server_config=None, **kwargs):
@@ -5856,6 +5872,7 @@ class PuppetClass(
         EntityCreateMixin,
         EntityDeleteMixin,
         EntityReadMixin,
+        EntityUpdateMixin,
         EntitySearchMixin):
     """A representation of a Puppet Class entity."""
 
@@ -5939,6 +5956,16 @@ class PuppetClass(
         kwargs.update(self._server_config.get_client_kwargs())
         response = client.get(self.path('smart_variables'), **kwargs)
         return _handle_response(response, self._server_config, synchronous)
+
+    def update_payload(self, fields=None):
+        """Override the method to only update fields that actually can be updated
+        """
+        updatable_fields = set.intersection({'name'}, self.get_values().keys())
+        if fields is None:
+            fields = updatable_fields
+        else:
+            fields = set.intersection(set(fields), updatable_fields)
+        return super().update_payload(fields=fields)
 
 
 class PackageGroup(Entity, EntityReadMixin, EntitySearchMixin):

--- a/nailgun/entity_mixins.py
+++ b/nailgun/entity_mixins.py
@@ -958,6 +958,7 @@ class EntityUpdateMixin(object):
     :meth:`update_payload`
         Assemble a payload of data that can be encoded and sent to the
         server.
+        Set self.updatable_fields (list of strings) to limit the fields that can be updated.
     :meth:`update_raw`
         Make an HTTP PUT request to the server, including the payload.
     :meth:`update_json`
@@ -979,8 +980,7 @@ class EntityUpdateMixin(object):
 
         """
         values = self.get_values()
-        updatable_fields =( self.updatable_fields if hasattr(self, 'updatable_fields') else
-                           values.keys() )
+        updatable_fields = getattr(self, 'updatable_fields', None) or list(values.keys())
         values = {field: value for field, value in values.items() if field in updatable_fields}
         if fields is not None:
             values = {field: values[field] for field in fields}

--- a/nailgun/entity_mixins.py
+++ b/nailgun/entity_mixins.py
@@ -979,6 +979,9 @@ class EntityUpdateMixin(object):
 
         """
         values = self.get_values()
+        updatable_fields =( self.updatable_fields if hasattr(self, 'updatable_fields') else
+                           values.keys() )
+        values = {field: value for field, value in values.items() if field in updatable_fields}
         if fields is not None:
             values = {field: values[field] for field in fields}
         return _payload(self.get_fields(), values)

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -2090,19 +2090,6 @@ class UpdatePayloadTestCase(TestCase):
         self.assertNotIn('path_', payload['medium'])
         self.assertIn('path', payload['medium'])
 
-    def test_hostcollection_system_uuid(self):
-        """Check whether ``HostCollection`` updates its ``system_ids`` field.
-
-        The field should be renamed from ``system_ids`` to ``system_uuids``
-        when ``update_payload`` is called.
-        """
-        payload = entities.HostCollection(
-            self.cfg_610,
-            system=[1],
-        ).update_payload()
-        self.assertNotIn('system_ids', payload)
-        self.assertIn('system_uuids', payload)
-
     def test_job_template(self):
         """Create a :class:`nailgun.entities.JobTemplate`."""
         payload = entities.JobTemplate(

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -2090,6 +2090,17 @@ class UpdatePayloadTestCase(TestCase):
         self.assertNotIn('path_', payload['medium'])
         self.assertIn('path', payload['medium'])
 
+    def test_hostcollection_updatable_fields(self):
+        org1 = entities.Organization(self.cfg, name='org1')
+        org2 = entities.Organization(self.cfg, name='org2')
+        host_collection = entities.HostCollection(self.cfg, name='oldname', organization=org1)
+        host_collection.name = 'newname'
+        host_collection.organization_id = org2
+        payload = host_collection.update_payload()
+        self.assertEquals(payload['name'], 'newname')
+        self.assertNotIn('organization', payload.keys())  # organization NOT changed
+        self.assertNotIn('organization_id', payload.keys())  # organization NOT changed
+
     def test_job_template(self):
         """Create a :class:`nailgun.entities.JobTemplate`."""
         payload = entities.JobTemplate(


### PR DESCRIPTION
Used by https://github.com/SatelliteQE/robottelo/pull/8046 that fixes automation failure in `tests/foreman/api/test_multiple_paths.py::EntityIdTestCase::test_positive_put_status_code`

This has potential to break something; tested by running all the tests in `tests/foreman/api/test_multiple_paths.py` with a result of
```
============================= 3 failed, 13 passed, 7 warnings in 864.63 seconds =============================
```
The 3 failures don't seem to be related.