### PR TITLE
traces status ignored

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -4260,6 +4260,9 @@ class Host(
         `content_facet_attributes` are returned only in case any of facet
         attributes were actually set.
 
+        `traces_status` and `traces_status_label` are returned only in case when
+        katello-host-tools-tracer is installed on the host
+
         Also add image to the response if needed, as
         :meth:`nailgun.entity_mixins.EntityReadMixin.read` can't initialize
         image.
@@ -4274,6 +4277,9 @@ class Host(
             ignore.add('host_parameters_attributes')
         if 'content_facet_attributes' not in attrs:
             ignore.add('content_facet_attributes')
+        if 'traces_status' not in attrs and 'traces_status_label' not in attrs:
+            ignore.add('traces_status')
+            ignore.add('traces_status_label')
         ignore.add('compute_attributes')
         ignore.add('interfaces_attributes')
         ignore.add('root_pass')
@@ -4307,10 +4313,6 @@ class Host(
             ]
         if 'build_status_label' in attrs:
             result.build_status_label = attrs['build_status_label']
-        if 'content_facet_attributes' in attrs and \
-                not attrs['content_facet_attributes']['katello_tracer_installed']:
-            ignore.add('traces_status')
-            ignore.add('traces_status_label')
         return result
 
     def update(self, fields=None):


### PR DESCRIPTION
Fixing the tests, 

Needs cherry-pick to `stable branch` and to `6.8.z`

Connected to #748 and  #758 

If there is no traces_status it should be ignored, on the other hand if there are traces it should be [read](https://github.com/tstrych/nailgun/blob/b46f8f13326dd4abb0fd3d3f24cd25cc0184f15f/nailgun/entities.py#L4252)

Thanks to @ogajduse it was tested also on host with  traces attributes:
Command below is using the same read method as the robotello tests mentioned below.
` entities.Host().search(query={'search': "dhcp-3-206.vms.sat.rdu2.redhat.com"})[0].read()`
shows:
![Screenshot from 2020-10-29 15-22-00](https://user-images.githubusercontent.com/19147547/97601464-7c292b00-1a0a-11eb-9d8d-9c2d8ebb2dd2.png)


Test results: 
```
collected 30 items / 26 deselected / 4 selected
test_host.py::test_positive_search_by_parameter 2020-10-29 15:30:09 - robottelo - DEBUG - Finished Test: test_host.py/test_positive_search_by_parameter
test_host.py::test_positive_search_by_parameter_with_different_values 2020-10-29 15:31:42 - robottelo - DEBUG - Finished Test: test_host.py/test_positive_search_by_parameter_with_different_values
test_host.py::test_positive_search_by_parameter_with_prefix 2020-10-29 15:33:18 - robottelo - DEBUG - Finished Test: test_host.py/test_positive_search_by_parameter_with_prefix
test_host.py::test_positive_search_by_parameter_with_operator 2020-10-29 15:34:54 - robottelo - DEBUG - Finished Test: test_host.py/test_positive_search_by_parameter_with_operator
=========== 4 passed, 26 deselected, 2 warnings in 383.27s (0:06:23) ===========
```
