### PR TITLE
Fix deprecation warning for collections import

### DIFF
--- a/nailgun/entity_mixins.py
+++ b/nailgun/entity_mixins.py
@@ -4,7 +4,7 @@ import http.client as http_client
 import json as std_json
 import threading
 import time
-from collections import Iterable
+from collections.abc import Iterable
 from datetime import date
 from datetime import datetime
 from urllib.parse import urljoin


### PR DESCRIPTION
Deprecation warning is seen during unit test execution, and will change in Python 3.9.