### PR TITLE
Minor change to allow for incoming robottelo Satellite class

### DIFF
--- a/nailgun/entity_mixins.py
+++ b/nailgun/entity_mixins.py
@@ -758,7 +758,12 @@ class EntityReadMixin:
 
         """
         if entity is None:
-            entity = type(self)(self._server_config)
+            try:
+                entity = type(self)(self._server_config)
+            except TypeError:
+                # in the event that an entity's init is overwritten
+                # with a positional server_config
+                entity = type(self)()
         if attrs is None:
             attrs = self.read_json(params=params)
         if ignore is None:


### PR DESCRIPTION
As part of the Satellite class, entity class inits are modified
to include the server_config by default.
This seems to conflict with existing argument structure when an
entity is created during create_missing.
This change will try the usual method and fall back to not passing
a server config if the TypeError is encountered