### PR TITLE
Update the virt-who entity temporary to fix the read error

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -7917,6 +7917,8 @@ class VirtWhoConfig(
         if not ignore:
             ignore = set()
         ignore.add('hypervisor_password')
+        # Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1902199
+        # This is temporary and need to be removed once related BZ is fixed.
         ignore.add('proxy')
         return super().read(entity, attrs, ignore, params)
 

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -7917,6 +7917,7 @@ class VirtWhoConfig(
         if not ignore:
             ignore = set()
         ignore.add('hypervisor_password')
+        ignore.add('proxy')
         return super().read(entity, attrs, ignore, params)
 
     def get_organization_configs(self, synchronous=True, **kwargs):

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1340,7 +1340,7 @@ class ReadTestCase(TestCase):
             (entities.User, {'password'}),
             (entities.ScapContents, {'scap_file'}),
             (entities.TailoringFile, {'scap_file'}),
-            (entities.VirtWhoConfig, {'hypervisor_password'}),
+            (entities.VirtWhoConfig, {'hypervisor_password', 'proxy'}),
             (entities.VMWareComputeResource, {'password'}),
             (entities.DiscoveredHost, {'ip', 'mac', 'root_pass', 'hostgroup'}),
         ):


### PR DESCRIPTION
**Description**
Fix #774 temporary as we cannot read the HTTP option for the virt-who entity now.
Ignore it for now so that we can test other cases.

Related bug: 
https://bugzilla.redhat.com/show_bug.cgi?id=1902199

**Test Result**
```
(venv) [hkx303@kuhuang api]$ pytest test_esx.py -k test_positive_deploy_configure_by_id -s
==================================== test session starts =====================================
platform linux -- Python 3.7.3, pytest-5.4.3, py-1.9.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/hkx303/Documents/CI/robottelo/robottelo, inifile: pytest.ini
plugins: metadata-1.10.0, html-2.1.1, cov-2.10.1, services-1.3.1, xdist-1.34.0, mock-1.10.4, forked-1.3.0, ibutsu-1.1.1
collecting ... 2020-11-27 10:32:31 - conftest - DEBUG - Collected 8 test cases
collected 8 items / 7 deselected / 1 selected   

================== 1 passed, 7 deselected, 2 warnings in 135.68s (0:02:15) ===================
```