### PR TITLE
add host_ids field to host collection

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -3212,6 +3212,7 @@ class HostCollection(
         self._fields = {
             'description': entity_fields.StringField(),
             'host': entity_fields.OneToManyField(Host),
+            'host_ids': entity_fields.ListField(),
             'max_hosts': entity_fields.IntegerField(),
             'name': entity_fields.StringField(
                 required=True, str_type='alpha', length=(6, 12), unique=True


### PR DESCRIPTION
Hello

This update is to enable adding hosts to a host collection. 

This has not been working before, but the problem only came to light after https://github.com/SatelliteQE/nailgun/pull/757



