### PR TITLE
Added "created_at" and "updated_at"  in the settings ignore field.

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -6686,6 +6686,16 @@ class Setting(Entity, EntityReadMixin, EntitySearchMixin, EntityUpdateMixin):
         }
         super().__init__(server_config, **kwargs)
 
+    def read(self, entity=None, attrs=None, ignore=None, params=None):
+        """Override :meth:`nailgun.entity_mixins.EntityReadMixin.read` to ignore
+        the ``created_at and updated_at``
+        """
+        if ignore is None:
+            ignore = set()
+        ignore.add('created_at')
+        ignore.add('updated_at')
+        return super().read(entity, attrs, ignore, params)
+
     def update_payload(self, fields=None):
         """Wrap submitted data within an extra dict."""
         return {'setting': super().update_payload(fields)}


### PR DESCRIPTION
All the settings update related test cases are getting failed due to missing keys error.
```

>               setattr(entity, field_name, attrs[field_name])
E               KeyError: 'created_at'

../../Nailgun/nailgun/nailgun/entity_mixins.py:804: KeyError

>               setattr(entity, field_name, attrs[field_name])
E               KeyError: 'updated_at'

../../Nailgun/nailgun/nailgun/entity_mixins.py:804: KeyError
```
After adding these filed in the ignore list all the test gets passed.

Before Fix:
```
$ pytest tests/foreman/api/test_setting.py
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.6.6, pytest-5.4.3, py-1.9.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/desingh/Satellite-QE/Robottelo/robottelo
plugins: rerunfailures-9.1.1, ibutsu-1.12, services-2.2.1, forked-1.1.3, mock-3.3.1, xdist-1.34.0, cov-2.8.1
collected 10 items                                                                                                                                                                                                

tests/foreman/api/test_setting.py FEFEFEsFEFEssFEFE                                                                                                                                                         [100%]
>               setattr(entity, field_name, attrs[field_name])
E               KeyError: 'created_at'

../../Nailgun/nailgun/nailgun/entity_mixins.py:804: KeyError
============================================================================================= short test summary info =============================================================================================
FAILED tests/foreman/api/test_setting.py::test_positive_update_login_page_footer_text[login_text] - KeyError: 'created_at'
FAILED tests/foreman/api/test_setting.py::test_positive_update_login_page_footer_text_without_value[login_text] - KeyError: 'created_at'
FAILED tests/foreman/api/test_setting.py::test_positive_update_login_page_footer_text_with_long_string[login_text] - KeyError: 'created_at'
FAILED tests/foreman/api/test_setting.py::test_positive_update_hostname_prefix_without_value[discovery_prefix] - requests.exceptions.HTTPError: 422 Client Error: Unprocessable Entity for url: https://qe-sat6-...
FAILED tests/foreman/api/test_setting.py::test_positive_update_hostname_default_prefix[discovery_prefix] - KeyError: 'created_at'
FAILED tests/foreman/api/test_setting.py::test_positive_custom_repo_download_policy[default_download_policy-immediate] - KeyError: 'created_at'
FAILED tests/foreman/api/test_setting.py::test_positive_custom_repo_download_policy[default_download_policy-on_demand] - KeyError: 'created_at'
ERROR tests/foreman/api/test_setting.py::test_positive_update_login_page_footer_text[login_text] - KeyError: 'created_at'
ERROR tests/foreman/api/test_setting.py::test_positive_update_login_page_footer_text_without_value[login_text] - KeyError: 'created_at'
ERROR tests/foreman/api/test_setting.py::test_positive_update_login_page_footer_text_with_long_string[login_text] - KeyError: 'created_at'
ERROR tests/foreman/api/test_setting.py::test_positive_update_hostname_prefix_without_value[discovery_prefix] - KeyError: 'created_at'
ERROR tests/foreman/api/test_setting.py::test_positive_update_hostname_default_prefix[discovery_prefix] - KeyError: 'created_at'
ERROR tests/foreman/api/test_setting.py::test_positive_custom_repo_download_policy[default_download_policy-immediate] - KeyError: 'created_at'
ERROR tests/foreman/api/test_setting.py::test_positive_custom_repo_download_policy[default_download_policy-on_demand] - KeyError: 'created_at'
================================================================================ 7 failed, 3 skipped, 7 errors in 67.56s (0:01:07) ================================================================================

```

After Fix

```
$ pytest tests/foreman/api/test_setting.py
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.6.6, pytest-5.4.3, py-1.9.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/desingh/Satellite-QE/Robottelo/robottelo
plugins: rerunfailures-9.1.1, ibutsu-1.12, services-2.2.1, forked-1.1.3, mock-3.3.1, xdist-1.34.0, cov-2.8.1
collected 10 items                                                                                                                                                                                                

tests/foreman/api/test_setting.py ...sF.ss..                                                                                                                                                                [100%]

==================================================================================================== FAILURES =====================================================================================================
============================================================================================= short test summary info =============================================================================================
FAILED tests/foreman/api/test_setting.py::test_positive_update_hostname_prefix_without_value[discovery_prefix] - requests.exceptions.HTTPError: 422 Client Error: Unprocessable Entity for url: https://qe-sat6-...
================================================================================ 1 failed, 6 passed, 3 skipped in 99.60s (0:01:39) ================================================================================