### PR TITLE
Update virt-who entity as http option has been changed

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -7806,6 +7806,8 @@ class VirtWhoConfig(
             'filtering_mode': entity_fields.IntegerField(
                 choices=[0, 1, 2], default=0, required=True
             ),
+            'http_proxy': entity_fields.OneToOneField(HTTPProxy),
+            'http_proxy_id': entity_fields.IntegerField(),
             'hypervisor_id': entity_fields.StringField(
                 choices=['hostname', 'uuid', 'hwuuid'], default='hostname', required=True
             ),
@@ -7823,7 +7825,6 @@ class VirtWhoConfig(
             'name': entity_fields.StringField(required=True),
             'no_proxy': entity_fields.StringField(),
             'organization_id': entity_fields.IntegerField(),
-            'proxy': entity_fields.StringField(),
             'satellite_url': entity_fields.StringField(required=True),
             'status': entity_fields.StringField(),
             'whitelist': entity_fields.StringField(),
@@ -7897,9 +7898,7 @@ class VirtWhoConfig(
         if not ignore:
             ignore = set()
         ignore.add('hypervisor_password')
-        # Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1902199
-        # This is temporary and need to be removed once related BZ is fixed.
-        ignore.add('proxy')
+        ignore.add('http_proxy_id')
         return super().read(entity, attrs, ignore, params)
 
     def get_organization_configs(self, synchronous=True, timeout=None, **kwargs):

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -7854,7 +7854,7 @@ class VirtWhoConfig(
             return (
                 f'{self._server_config.url}/'
                 f'foreman_virt_who_configure/api/v2/organizations/'
-                f'{self.read().organization_id}/'
+                f"{self.read(ignore={'http_proxy'}).organization_id}/"
                 f'{which}'
             )
         return super().path(which)

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1286,7 +1286,7 @@ class ReadTestCase(TestCase):
             (entities.User, {'password'}),
             (entities.ScapContents, {'scap_file'}),
             (entities.TailoringFile, {'scap_file'}),
-            (entities.VirtWhoConfig, {'hypervisor_password', 'proxy'}),
+            (entities.VirtWhoConfig, {'hypervisor_password', 'http_proxy_id'}),
             (entities.VMWareComputeResource, {'password'}),
             (entities.DiscoveredHost, {'ip', 'mac', 'root_pass', 'hostgroup'}),
         ):
@@ -3678,7 +3678,6 @@ class VirtWhoConfigTestCase(TestCase):
             organization_id=org.id,
             filtering_mode=1,
             whitelist='*.example.com',
-            proxy='proxy.example.com',
             no_proxy='*.proxy-bypass.example.com',
             satellite_url=self.server,
             hypervisor_type='libvirt',
@@ -3701,7 +3700,6 @@ class VirtWhoConfigTestCase(TestCase):
                 'name': 'vhtest1',
                 'no_proxy': '*.proxy-bypass.example.com',
                 'organization_id': 2,
-                'proxy': 'proxy.example.com',
                 'satellite_url': self.server,
                 'whitelist': '*.example.com',
             }
@@ -3716,7 +3714,6 @@ class VirtWhoConfigTestCase(TestCase):
             organization_id=org.id,
             filtering_mode=1,
             whitelist='*.example.com',
-            proxy='proxy.example.com',
             no_proxy='*.proxy-bypass.example.com',
             satellite_url=self.server,
             hypervisor_type='libvirt',


### PR DESCRIPTION
**Description**
Fix #774 

**Test Result**
```
(venv) [hkx303@kuhuang api]$ pytest test_esx.py -k test_positive_proxy_option -s
============================== test session starts ===============================
platform linux -- Python 3.7.3, pytest-6.2.1, py-1.9.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/hkx303/Documents/CI/robottelo/robottelo, configfile: pyproject.toml
plugins: services-2.2.1, metadata-1.10.0, html-2.1.1, mock-3.4.0, cov-2.10.1, xdist-2.2.0, ibutsu-1.13, forked-1.3.0
collected 8 items / 7 deselected / 1 selected   

============ 1 passed, 7 deselected, 9 warnings in 101.09s (0:01:41) =============
```


