### PR TITLE
Remove puppet module field from CV

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2193,7 +2193,6 @@ class ContentViewVersion(Entity, EntityDeleteMixin, EntityReadMixin, EntitySearc
             'minor': entity_fields.IntegerField(),
             'module_stream_count': entity_fields.IntegerField(),
             'package_count': entity_fields.IntegerField(),
-            'puppet_module': entity_fields.OneToManyField(PuppetModule),
             'repository': entity_fields.OneToManyField(Repository),
             'version': entity_fields.StringField(),
         }
@@ -2510,7 +2509,6 @@ class ContentView(
                 Organization,
                 required=True,
             ),
-            'puppet_module': entity_fields.OneToManyField(PuppetModule),
             'repository': entity_fields.OneToManyField(Repository),
             'solve_dependencies': entity_fields.BooleanField(),
             'version': entity_fields.OneToManyField(ContentViewVersion),


### PR DESCRIPTION
Removed `puppet_module` field from ContentView class.

What changed in Sat 6.10:
```
I want to clarify a bit about what is and is not deleted upon upgrade to
6.10.

The TLDR; the 6.10 upgrade doesn't delete puppet environments and
puppet content used by hosts. Puppet clients can still use the puppet
content from before the upgrade.

The longer explanation:

First let me explain how the puppet content support worked. There are
two aspects to it:

1. puppet repositories - these are the pulp entities that would hold
compressed puppet modules, a user could sync or upload puppet content to
them
2. puppet environments - these are the foreman entities that correspond
to an on disk directory on the satellite server and capsules where the
puppet modules are extracted. Hosts consume puppet modules from these

on 6.9 and earlier, when publishing a Content View with puppet modules,
a puppet repository (1) would be created, but also a puppet environment
(2) would be created. Hosts really only 'knew' about (2).

Upon upgrade to Satellite 6.10 only 1) is deleted. The foreman puppet
environments as well as the on disk puppet content remains
(/etc/puppetlabs/code/environments). Hosts that are using those puppet
modules can continue to use them and the customer could even continue to
use those puppet environments with Satellite. They will not be updated
by satellite itself anymore however.

So customers will really not lose puppet modules upon upgrade, no need
to back it up prior.

Justin
```

Sat 6.10 API stopped returning puppet_module_field:
```
# curl -kuadmin:changeme https://<69FQDN>/katello/api/content_views/1
  {"content_host_count":1,"composite":false,"component_ids":[],"default":true,"version_count":1,"latest_version":"1.0","latest_version_id":1,"auto_publish":false,"solve_dependencies":false,"import_only":false,"repository_ids":[],"id":1,"name":"Default Organization View","label":"Default_Organization_View","description":null,"organization_id":1,"organization":{"name":"Default Organization","label":"Default_Organization","id":1},"created_at":"2021-06-16 20:53:14 UTC","updated_at":"2021-06-16 20:53:14 UTC","last_task":null,"latest_version_environments":[{"id":1,"name":"Library","label":"Library"}],"environments":[{"id":1,"name":"Library","label":"Library","permissions":{"readable":true}}],"repositories":[],"versions":[{"id":1,"version":"1.0","published":"2021-06-16 20:53:15 UTC","environment_ids":[1]}],"components":[],"content_view_components":[],"activation_keys":[{"id":1,"name":"testak"}],"hosts":[{"id":3,"name":"<FQDN>"}],"next_version":"1.0","last_published":"2021-06-16 20:53:15 UTC","permissions":{"view_content_views":true,"edit_content_views":true,"destroy_content_views":true,"publish_content_views":true,"promote_or_remove_content_views":true},"duplicate_repositories_to_publish":[],"errors":null}
```
Also, `puppet_environment` doesn't get returned as puppet environments are no longer connected to CVs, according to Justin Sherrill. This was, however, never a field in Nailgun.