### PR TITLE
More changes needed for robottelo's config injection

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2507,7 +2507,12 @@ class ContentView(
             content_view_components = result.get('content_view_component')
             if content_view_components is not None:
                 del result['content_view_component']
-            entity = type(self)(self._server_config, **result)
+            try:
+                entity = type(self)(self._server_config, **result)
+            except TypeError:
+                # in the event that an entity's init is overwritten
+                # with a positional server_config
+                entity = type(self)(**result)
             if content_view_components:
                 entity.content_view_component = [
                     ContentViewComponent(
@@ -4405,7 +4410,12 @@ class Host(
             image = result.get('image')
             if image is not None:
                 del result['image']
-            entity = type(self)(self._server_config, **result)
+            try:
+                entity = type(self)(self._server_config, **result)
+            except TypeError:
+                # in the event that an entity's init is overwritten
+                # with a positional server_config
+                entity = type(self)(**result)
             if image:
                 entity.image = Image(
                     server_config=self._server_config,
@@ -5330,7 +5340,12 @@ class Parameter(Entity, EntityCreateMixin, EntityDeleteMixin, EntityReadMixin, E
         and are only added to entity to be able to use proper path.
         """
         if entity is None:
-            entity = type(self)(self._server_config, **{self._parent_type: self._parent_id})
+            try:
+                entity = type(self)(self._server_config, **{self._parent_type: self._parent_id})
+            except TypeError:
+                # in the event that an entity's init is overwritten
+                # with a positional server_config
+                entity = type(self)(**{self._parent_type: self._parent_id})
         if ignore is None:
             ignore = set()
         for field_name in self._path_fields:
@@ -5459,7 +5474,12 @@ class Product(
             sync_plan = result.get('sync_plan')
             if sync_plan is not None:
                 del result['sync_plan']
-            entity = type(self)(self._server_config, **result)
+            try:
+                entity = type(self)(self._server_config, **result)
+            except TypeError:
+                # in the event that an entity's init is overwritten
+                # with a positional server_config
+                entity = type(self)(**result)
             if sync_plan:
                 entity.sync_plan = SyncPlan(
                     server_config=self._server_config,

--- a/nailgun/entity_mixins.py
+++ b/nailgun/entity_mixins.py
@@ -1343,7 +1343,15 @@ class EntitySearchMixin:
         #
         results = self.search_json(fields, query)['results']
         results = self.search_normalize(results)
-        entities = [type(self)(self._server_config, **result) for result in results]
+        entities = []
+        for result in results:
+            try:
+                entity = type(self)(self._server_config, **result)
+            except TypeError:
+                # in the event that an entity's init is overwritten
+                # with a positional server_config
+                entity = type(self)(**result)
+            entities.append(entity)
         if filters is not None:
             entities = self.search_filter(entities, filters)
         return entities


### PR DESCRIPTION
This is a continuation of the change introduced in #770
Robottelo injects the server config in the init methods of each entity.
As a result, passing the server config as part of the instantiation in
these places will result in multiple server configs being passed in.