### PR TITLE
Adding size attribute to ContentUpload

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "/bin/python"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "/bin/python"
-}

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2090,7 +2090,7 @@ class ContentUpload(
         if ignore is None:
             ignore = set()
         ignore.add('repository')
-        ignore.add('size') 
+        ignore.add('size')
         return super().read(entity, attrs, ignore, params)
 
     def update(self, fields=None, **kwargs):

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2090,7 +2090,7 @@ class ContentUpload(
         if ignore is None:
             ignore = set()
         ignore.add('repository')
-        ignore.add('size')
+        ignore.add('size') 
         return super().read(entity, attrs, ignore, params)
 
     def update(self, fields=None, **kwargs):

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2056,6 +2056,7 @@ class ContentUpload(
                 Repository,
                 required=True,
             ),
+            'size': entity_fields.IntegerField(required=True, min_val=2097152),
         }
         super().__init__(server_config, **kwargs)
         # a ContentUpload does not have an id field, only an upload_id
@@ -2089,6 +2090,7 @@ class ContentUpload(
         if ignore is None:
             ignore = set()
         ignore.add('repository')
+        ignore.add('size')
         return super().read(entity, attrs, ignore, params)
 
     def update(self, fields=None, **kwargs):
@@ -2149,7 +2151,7 @@ class ContentUpload(
             with open(filepath, 'rb') as contentfile:
                 chunk = contentfile.read(content_chunk_size)
                 while len(chunk) > 0:
-                    data = {'offset': offset, 'content': chunk}
+                    data = {'offset': offset, 'content': chunk, 'size': content_chunk_size}
                     content_upload.update(data)
 
                     offset += len(chunk)

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2048,6 +2048,8 @@ class ContentUpload(
 ):
     """A representation of a Content Upload entity."""
 
+    content_chunk_size = 2 * 1024 * 1024
+
     def __init__(self, server_config=None, **kwargs):
         _check_for_value('repository', kwargs)
         self._fields = {
@@ -2056,7 +2058,7 @@ class ContentUpload(
                 Repository,
                 required=True,
             ),
-            'size': entity_fields.IntegerField(required=True, min_val=2097152),
+            'size': entity_fields.IntegerField(required=True, min_val=self.content_chunk_size),
         }
         super().__init__(server_config, **kwargs)
         # a ContentUpload does not have an id field, only an upload_id
@@ -2146,16 +2148,15 @@ class ContentUpload(
 
         try:
             offset = 0
-            content_chunk_size = 2 * 1024 * 1024
 
             with open(filepath, 'rb') as contentfile:
-                chunk = contentfile.read(content_chunk_size)
+                chunk = contentfile.read(self.content_chunk_size)
                 while len(chunk) > 0:
-                    data = {'offset': offset, 'content': chunk, 'size': content_chunk_size}
+                    data = {'offset': offset, 'content': chunk, 'size': self.content_chunk_size}
                     content_upload.update(data)
 
                     offset += len(chunk)
-                    chunk = contentfile.read(content_chunk_size)
+                    chunk = contentfile.read(self.content_chunk_size)
 
             size = 0
             checksum = hashlib.sha256()


### PR DESCRIPTION
##### Description of changes

I'm wondering if this is a valid way to add the size attribute to ContentUpload. I have to add the two lines in the `read()` function in order for the `super.read()` to pass. However, I am now having issues with the checksum not matching when the import upload is ran after this. I would like to get some feedback if this is valid, or if it could be causing the checksum issue.

##### Upstream API documentation, plugin, or feature links

None that I could find.

##### Functional demonstration

Example:
```
attrs
{'upload_id': '50ba7ca9-fc60-43ba-9...2a8ed31594', 'size': -9148830520927570858}
```