### PR TITLE
Handle dict/list repsonse

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -110,7 +110,10 @@ def _handle_response(response, server_config, synchronous=False, timeout=None):
     """
     response.raise_for_status()
     if synchronous is True and response.status_code == ACCEPTED:
-        return ForemanTask(server_config, id=response.json()['id']).poll(timeout=timeout)
+        response_json = response.json()
+        id = response_json['id'] if isinstance(response_json, dict) else response_json[0]['id']
+        return ForemanTask(
+            server_config, id=id).poll(timeout=timeout)
     if response.status_code == NO_CONTENT:
         return
     if 'application/json' in response.headers.get('content-type', '').lower():


### PR DESCRIPTION
##### Description of changes

Handle the response being a list instead of a dict.

##### Exception demonstration

```    
../../lib64/python3.8/site-packages/nailgun/entities.py:4015: in errata_applicability
    return _handle_response(response, self._server_config, synchronous, timeout)
../../lib64/python3.8/site-packages/nailgun/entities.py:113: in _handle_response
    return ForemanTask(server_config, id=response.json()['id']).poll(timeout=timeout)
E   TypeError: list indices must be integers or slices, not str
```

##### Additional Information

Testing in robottelo now with effected test case.
