### PR TITLE
Add ansible-collection related fields 

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -6089,6 +6089,9 @@ class Repository(
 
     def __init__(self, server_config=None, **kwargs):
         self._fields = {
+            'ansible_collection_auth_url': entity_fields.StringField(),
+            'ansible_collection_auth_token': entity_fields.StringField(),
+            'ansible_collection_requirements': entity_fields.StringField(),
             'backend_identifier': entity_fields.StringField(),
             'checksum_type': entity_fields.StringField(
                 choices=('sha1', 'sha256'),


### PR DESCRIPTION
##### Description of changes

Just adding new fields related to `ansible_collection` repository type so I can use it in test.

##### Upstream API documentation, plugin, or feature links

https://<sat_fqdn>/apidoc/v2/repositories/create.html

##### Functional demonstration

Provide an execution of the modified code, with ipython code blocks or screen shots.
You can exercise the code as raw API calls or using any other method.

test in robottelo like
```
    repo = entities.Repository(
        ansible_collection_auth_url="https://auth.redhat.com",
        ansible_collection_auth_token="auth_token",
        ansible_collection_requirements=requirements,
        content_type='ansible_collection',
        product=module_product,
        url='https://galaxy.ansible.com/',
    ).create()
    repo = repo.read()
```
successfully creates the repo with provided args and reads like
```
{
  ...
  "relative_path": "jUaneEUoSSLW/Library/custom/uAhljNDLMEJJ/HEYIcuAADk",
  "created_at": "2021-11-15 16:48:36 UTC",
  "updated_at": "2021-11-15 16:48:38 UTC",
  "full_path": "https://dhcp-2-243.vms.sat.rdu2.redhat.com/pulp_ansible/galaxy/jUaneEUoSSLW/Library/custom/uAhljNDLMEJJ/HEYIcuAADk/api/",
  "id": 27,
  "name": "HEYIcuAADk",
  "content_type": "ansible_collection",
  "url": "https://galaxy.ansible.com/",
  "content_label": "jUaneEUoSSLW_uAhljNDLMEJJ_HEYIcuAADk",
  ...
  "ansible_collection_requirements": "---\n        collections:\n        - name: theforeman.foreman",
  "ansible_collection_auth_url": "https://auth.redhat.com",
  "ansible_collection_auth_token": "auth_token",
  ...
}
```
