### PR TITLE
Sat webhooks

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -8150,70 +8150,74 @@ class Webhook(
                 required=True, str_type='alpha', length=(6, 12), unique=True
             ),
             'enabled': entity_fields.BooleanField(),
-            'event': entity_fields.StringField(required=True,
-                                               choices=[
-                                                   "actions.katello.content_view.promote_succeeded",
-                                                   "actions.katello.content_view.publish_succeeded",
-                                                   "actions.katello.repository.sync_succeeded",
-                                                   "actions.remote_execution.run_host_job_ansible_configure_cloud_connector_succeeded",
-                                                   "actions.remote_execution.run_host_job_ansible_enable_web_console_succeeded",
-                                                   "actions.remote_execution.run_host_job_ansible_run_capsule_upgrade_succeeded",
-                                                   "actions.remote_execution.run_host_job_ansible_run_host_succeeded",
-                                                   "actions.remote_execution.run_host_job_ansible_run_insights_plan_succeeded",
-                                                   "actions.remote_execution.run_host_job_ansible_run_playbook_succeeded",
-                                                   "actions.remote_execution.run_host_job_foreman_openscap_run_oval_scans_succeeded",
-                                                   "actions.remote_execution.run_host_job_foreman_openscap_run_scans_succeeded",
-                                                   "actions.remote_execution.run_host_job_katello_errata_install_succeeded",
-                                                   "actions.remote_execution.run_host_job_katello_group_install_succeeded",
-                                                   "actions.remote_execution.run_host_job_katello_group_remove_succeeded",
-                                                   "actions.remote_execution.run_host_job_katello_group_update_succeeded",
-                                                   "actions.remote_execution.run_host_job_katello_module_stream_action_succeeded",
-                                                   "actions.remote_execution.run_host_job_katello_package_install_succeeded",
-                                                   "actions.remote_execution.run_host_job_katello_package_remove_succeeded",
-                                                   "actions.remote_execution.run_host_job_katello_package_update_succeeded",
-                                                   "actions.remote_execution.run_host_job_katello_service_restart_succeeded",
-                                                   "actions.remote_execution.run_host_job_puppet_run_host_succeeded",
-                                                   "actions.remote_execution.run_host_job_rh_cloud_remediate_hosts_succeeded",
-                                                   "actions.remote_execution.run_host_job_succeeded",
-                                                   "build_entered",
-                                                   "build_exited",
-                                                   "content_view_created",
-                                                   "content_view_destroyed",
-                                                   "content_view_updated",
-                                                   "domain_created",
-                                                   "domain_destroyed",
-                                                   "domain_updated",
-                                                   "host_created",
-                                                   "host_destroyed",
-                                                   "host_updated",
-                                                   "hostgroup_created",
-                                                   "hostgroup_destroyed",
-                                                   "hostgroup_updated",
-                                                   "model_created",
-                                                   "model_destroyed",
-                                                   "model_updated",
-                                                   "status_changed",
-                                                   "subnet_created",
-                                                   "subnet_destroyed",
-                                                   "subnet_updated",
-                                                   "user_created",
-                                                   "user_destroyed",
-                                                   "user_updated",
-                                               ]),
+            'event': entity_fields.StringField(
+                required=True,
+                choices=[
+                    "actions.katello.content_view.promote_succeeded",
+                    "actions.katello.content_view.publish_succeeded",
+                    "actions.katello.repository.sync_succeeded",
+                    "actions.remote_execution.run_host_job_ansible_configure_cloud_connector_succeeded",  # noqa 501
+                    "actions.remote_execution.run_host_job_ansible_enable_web_console_succeeded",
+                    "actions.remote_execution.run_host_job_ansible_run_capsule_upgrade_succeeded",
+                    "actions.remote_execution.run_host_job_ansible_run_host_succeeded",
+                    "actions.remote_execution.run_host_job_ansible_run_insights_plan_succeeded",
+                    "actions.remote_execution.run_host_job_ansible_run_playbook_succeeded",
+                    "actions.remote_execution.run_host_job_foreman_openscap_run_oval_scans_succeeded",  # noqa 501
+                    "actions.remote_execution.run_host_job_foreman_openscap_run_scans_succeeded",
+                    "actions.remote_execution.run_host_job_katello_errata_install_succeeded",
+                    "actions.remote_execution.run_host_job_katello_group_install_succeeded",
+                    "actions.remote_execution.run_host_job_katello_group_remove_succeeded",
+                    "actions.remote_execution.run_host_job_katello_group_update_succeeded",
+                    "actions.remote_execution.run_host_job_katello_module_stream_action_succeeded",
+                    "actions.remote_execution.run_host_job_katello_package_install_succeeded",
+                    "actions.remote_execution.run_host_job_katello_package_remove_succeeded",
+                    "actions.remote_execution.run_host_job_katello_package_update_succeeded",
+                    "actions.remote_execution.run_host_job_katello_service_restart_succeeded",
+                    "actions.remote_execution.run_host_job_puppet_run_host_succeeded",
+                    "actions.remote_execution.run_host_job_rh_cloud_remediate_hosts_succeeded",
+                    "actions.remote_execution.run_host_job_succeeded",
+                    "build_entered",
+                    "build_exited",
+                    "content_view_created",
+                    "content_view_destroyed",
+                    "content_view_updated",
+                    "domain_created",
+                    "domain_destroyed",
+                    "domain_updated",
+                    "host_created",
+                    "host_destroyed",
+                    "host_updated",
+                    "hostgroup_created",
+                    "hostgroup_destroyed",
+                    "hostgroup_updated",
+                    "model_created",
+                    "model_destroyed",
+                    "model_updated",
+                    "status_changed",
+                    "subnet_created",
+                    "subnet_destroyed",
+                    "subnet_updated",
+                    "user_created",
+                    "user_destroyed",
+                    "user_updated",
+                ],
+            ),
             'http_content_type': entity_fields.StringField(),
-            'http_method': entity_fields.StringField(choices=[
-                "POST",
-                "GET",
-                "PUT",
-                "DELETE",
-                "PATCH",
-            ]),
+            'http_method': entity_fields.StringField(
+                choices=[
+                    "POST",
+                    "GET",
+                    "PUT",
+                    "DELETE",
+                    "PATCH",
+                ]
+            ),
             'password': entity_fields.StringField(),
             'proxy_authorization': entity_fields.BooleanField(),
             'target_url': entity_fields.URLField(required=True),
             'user': entity_fields.StringField(),
             'verify_ssl': entity_fields.BooleanField(),
-            'webhook_template': entity_fields.OneToOneField(WebhookTemplate)
+            'webhook_template': entity_fields.OneToOneField(WebhookTemplate),
         }
         self._meta = {
             'api_path': 'api/webhooks',
@@ -8221,9 +8225,11 @@ class Webhook(
         super().__init__(server_config, **kwargs)
 
     def create(self, create_missing=None):
-        original_return =  super().create(create_missing)
+        original_return = super().create(create_missing)
         webhook_template_id = original_return.webhook_template.id
-        original_return.webhook_template = WebhookTemplate(self._server_config, id=webhook_template_id).read()
+        original_return.webhook_template = WebhookTemplate(
+            self._server_config, id=webhook_template_id
+        ).read()
         return original_return
 
     def read(self, entity=None, attrs=None, ignore=None, params=None):
@@ -8245,24 +8251,17 @@ class WebhookTemplate(
     def __init__(self, server_config=None, **kwargs):
         self._fields = {
             'name': entity_fields.StringField(
-                required=True,
-                str_type='alpha',
-                length=(6, 12),
-                unique=True
+                required=True, str_type='alpha', length=(6, 12), unique=True
             ),
-            'template': entity_fields.StringField(
-                required=True
-            ),
+            'template': entity_fields.StringField(required=True),
             'default': entity_fields.BooleanField(),
             'snippet': entity_fields.BooleanField(),
             'locked': entity_fields.BooleanField(),
             'description': entity_fields.StringField(),
             'location': entity_fields.OneToManyField(Location),
-            'organization': entity_fields.OneToManyField(Organization)
+            'organization': entity_fields.OneToManyField(Organization),
         }
-        self._meta = {
-            'api_path': 'api/webhook_templates'
-        }
+        self._meta = {'api_path': 'api/webhook_templates'}
         super().__init__(server_config, **kwargs)
 
     def create(self, create_missing=None):

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -8132,3 +8132,141 @@ class Srpms(Entity, EntityReadMixin, EntitySearchMixin):
         }
         self._meta = {'api_path': 'katello/api/v2/srpms'}
         super().__init__(server_config, **kwargs)
+
+
+class Webhook(
+    Entity,
+    EntityCreateMixin,
+    EntityDeleteMixin,
+    EntityReadMixin,
+    EntitySearchMixin,
+    EntityUpdateMixin,
+):
+    """A representation of a Webhook entity."""
+
+    def __init__(self, server_config=None, **kwargs):
+        self._fields = {
+            'name': entity_fields.StringField(
+                required=True, str_type='alpha', length=(6, 12), unique=True
+            ),
+            'enabled': entity_fields.BooleanField(),
+            'event': entity_fields.StringField(required=True,
+                                               choices=[
+                                                   "actions.katello.content_view.promote_succeeded",
+                                                   "actions.katello.content_view.publish_succeeded",
+                                                   "actions.katello.repository.sync_succeeded",
+                                                   "actions.remote_execution.run_host_job_ansible_configure_cloud_connector_succeeded",
+                                                   "actions.remote_execution.run_host_job_ansible_enable_web_console_succeeded",
+                                                   "actions.remote_execution.run_host_job_ansible_run_capsule_upgrade_succeeded",
+                                                   "actions.remote_execution.run_host_job_ansible_run_host_succeeded",
+                                                   "actions.remote_execution.run_host_job_ansible_run_insights_plan_succeeded",
+                                                   "actions.remote_execution.run_host_job_ansible_run_playbook_succeeded",
+                                                   "actions.remote_execution.run_host_job_foreman_openscap_run_oval_scans_succeeded",
+                                                   "actions.remote_execution.run_host_job_foreman_openscap_run_scans_succeeded",
+                                                   "actions.remote_execution.run_host_job_katello_errata_install_succeeded",
+                                                   "actions.remote_execution.run_host_job_katello_group_install_succeeded",
+                                                   "actions.remote_execution.run_host_job_katello_group_remove_succeeded",
+                                                   "actions.remote_execution.run_host_job_katello_group_update_succeeded",
+                                                   "actions.remote_execution.run_host_job_katello_module_stream_action_succeeded",
+                                                   "actions.remote_execution.run_host_job_katello_package_install_succeeded",
+                                                   "actions.remote_execution.run_host_job_katello_package_remove_succeeded",
+                                                   "actions.remote_execution.run_host_job_katello_package_update_succeeded",
+                                                   "actions.remote_execution.run_host_job_katello_service_restart_succeeded",
+                                                   "actions.remote_execution.run_host_job_puppet_run_host_succeeded",
+                                                   "actions.remote_execution.run_host_job_rh_cloud_remediate_hosts_succeeded",
+                                                   "actions.remote_execution.run_host_job_succeeded",
+                                                   "build_entered",
+                                                   "build_exited",
+                                                   "content_view_created",
+                                                   "content_view_destroyed",
+                                                   "content_view_updated",
+                                                   "domain_created",
+                                                   "domain_destroyed",
+                                                   "domain_updated",
+                                                   "host_created",
+                                                   "host_destroyed",
+                                                   "host_updated",
+                                                   "hostgroup_created",
+                                                   "hostgroup_destroyed",
+                                                   "hostgroup_updated",
+                                                   "model_created",
+                                                   "model_destroyed",
+                                                   "model_updated",
+                                                   "status_changed",
+                                                   "subnet_created",
+                                                   "subnet_destroyed",
+                                                   "subnet_updated",
+                                                   "user_created",
+                                                   "user_destroyed",
+                                                   "user_updated",
+                                               ]),
+            'http_content_type': entity_fields.StringField(),
+            'http_method': entity_fields.StringField(choices=[
+                "POST",
+                "GET",
+                "PUT",
+                "DELETE",
+                "PATCH",
+            ]),
+            'password': entity_fields.StringField(),
+            'proxy_authorization': entity_fields.BooleanField(),
+            'target_url': entity_fields.URLField(required=True),
+            'user': entity_fields.StringField(),
+            'verify_ssl': entity_fields.BooleanField(),
+            'webhook_template': entity_fields.OneToOneField(WebhookTemplate)
+        }
+        self._meta = {
+            'api_path': 'api/webhooks',
+        }
+        super().__init__(server_config, **kwargs)
+
+    def create(self, create_missing=None):
+        original_return =  super().create(create_missing)
+        webhook_template_id = original_return.webhook_template.id
+        original_return.webhook_template = WebhookTemplate(self._server_config, id=webhook_template_id).read()
+        return original_return
+
+    def read(self, entity=None, attrs=None, ignore=None, params=None):
+        if ignore is None:
+            ignore = set()
+        ignore.add('password')
+        ignore.add('proxy_authorization')
+        return super().read(entity, attrs, ignore, params)
+
+
+class WebhookTemplate(
+    Entity,
+    EntityCreateMixin,
+    EntityDeleteMixin,
+    EntityReadMixin,
+    EntitySearchMixin,
+    EntityUpdateMixin,
+):
+    def __init__(self, server_config=None, **kwargs):
+        self._fields = {
+            'name': entity_fields.StringField(
+                required=True,
+                str_type='alpha',
+                length=(6, 12),
+                unique=True
+            ),
+            'template': entity_fields.StringField(
+                required=True
+            ),
+            'default': entity_fields.BooleanField(),
+            'snippet': entity_fields.BooleanField(),
+            'locked': entity_fields.BooleanField(),
+            'description': entity_fields.StringField(),
+            'location': entity_fields.OneToManyField(Location),
+            'organization': entity_fields.OneToManyField(Organization)
+        }
+        self._meta = {
+            'api_path': 'api/webhook_templates'
+        }
+        super().__init__(server_config, **kwargs)
+
+    def create(self, create_missing=None):
+        return type(self)(
+            self._server_config,
+            id=self.create_json(create_missing)['id'],
+        ).read()

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -181,6 +181,8 @@ class InitTestCase(TestCase):
                 entities.UserGroup,
                 entities.VirtWhoConfig,
                 entities.VMWareComputeResource,
+                entities.Webhook,
+                entities.WebhookTemplate,
             )
         ]
         entities_.extend(
@@ -284,6 +286,8 @@ class PathTestCase(TestCase):
             (entities.Subscription, '/subscriptions'),
             (entities.ScapContents, '/scap_contents'),
             (entities.VirtWhoConfig, '/foreman_virt_who_configure/api/v2/configs'),
+            (entities.Webhook, '/webhooks'),
+            (entities.WebhookTemplate, '/webhook_templates'),
         ):
             with self.subTest((entity, path)):
                 self.assertIn(path, entity(self.cfg).path())
@@ -678,6 +682,7 @@ class CreatePayloadTestCase(TestCase):
                 entities.User,
                 entities.UserGroup,
                 entities.VirtWhoConfig,
+                entities.Webhook,
             )
         ]
         entities_.extend(


### PR DESCRIPTION
##### Description of changes

Initial support for Webhooks and WebhookTemplates objects, implemented in Sat 6.10

##### Upstream API documentation, plugin, or feature links

https://<satellite_server>/apidoc/v2/webhooks.html
https:///<satellite_server>/apidoc/v2/webhook_templates.html

##### Functional demonstration

```
In [86]: whtest = Webhook(server_config, name="webhooktest", event="host_created", target_url="http://localhost/neco", http_method="GET", http_content_type="application/json", verify_ssl=False).create()                                 

In [87]: whtest.name                                                                                                                                                                                                                       
Out[87]: 'webhooktest'

In [88]: whtest.id                                                                                                                                                                                                                         
Out[88]: 62

In [89]: whtest = Webhook(server_config, id=62, name="diffname").update()                                                                                                                                                                  

In [90]: whtest.name                                                                                                                                                                                                                       
Out[90]: 'diffname'

In [91]: whtest.id                                                                                                                                                                                                                         
Out[91]: 62

In [92]: whtest.delete()                                                                                                                                                                                                                   
Out[92]: 
{'id': 62,
 'name': 'diffname',
 'target_url': 'http://localhost/neco',
 'events': ['host_created.event.foreman'],
 'created_at': '2021-12-07T11:12:30.701Z',
 'updated_at': '2021-12-07T11:14:06.901Z',
 'webhook_template_id': 201,
 'http_method': 'GET',
 'http_content_type': 'application/json',
 'enabled': True,
 'verify_ssl': False,
 'ssl_ca_certs': None,
 'user': None,
 'password': None,
 'http_headers': None,
 'proxy_authorization': False}

In [93]: whtest = Webhook(server_config, id=62).read()                                                                                                                                                                                     
WARNING:nailgun.client:Received HTTP 404 response: {
  "error": {"message":"Resource webhook not found by id '62'"}
}

---------------------------------------------------------------------------
HTTPError                                 Traceback (most recent call last)
<ipython-input-93-1081119b78f9> in <module>
----> 1 whtest = Webhook(server_config, id=62).read()

~/PycharmProjects/nailgun/nailgun/entities.py in read(self, entity, attrs, ignore, params)
   8232         ignore.add('password')
   8233         ignore.add('proxy_authorization')
-> 8234         return super().read(entity, attrs, ignore, params)
   8235 
   8236 

~/PycharmProjects/nailgun/nailgun/entity_mixins.py in read(self, entity, attrs, ignore, params)
    780                 entity = type(self)()
    781         if attrs is None:
--> 782             attrs = self.read_json(params=params)
    783         if ignore is None:
    784             ignore = set()

~/PycharmProjects/nailgun/nailgun/entity_mixins.py in read_json(self, params)
    726         """
    727         response = self.read_raw(params=params)
--> 728         response.raise_for_status()
    729         return response.json()
    730 

~/.virtualenvs/nailgun/lib/python3.9/site-packages/requests/models.py in raise_for_status(self)
    951 
    952         if http_error_msg:
--> 953             raise HTTPError(http_error_msg, response=self)
    954 
    955     def close(self):

HTTPError: 404 Client Error: Not Found for url: https://dhcp-2-175.vms.sat.rdu2.redhat.com/api/webhooks/62

```
