### PR TITLE
Add support for missing Puppet environment entity

### DIFF
--- a/nailgun/entity_mixins.py
+++ b/nailgun/entity_mixins.py
@@ -418,7 +418,7 @@ class Entity:
                 # follows the "ask forgiveness" principle. However, a TypeError
                 # could be raised for any number of reasons. For example,
                 # `field_value` could have a faulty __iter__ implementation.
-                if not isinstance(field_value, Iterable):
+                if field_value and not isinstance(field_value, Iterable):
                     raise BadValueError(
                         f'An inappropriate value was assigned to the "{field_name}" '
                         'field. An iterable of entities and/or entity IDs '


### PR DESCRIPTION
##### Description of changes
Hello


Nailgun failed to create an org in Satellite 7 snap 2

`E           nailgun.entity_mixins.MissingValueError: Cannot find a value for the "environment" field.`

I presume due to removal of default Puppet environment support.

##### Upstream API documentation, plugin, or feature links

On 6.10.1 and Sat7.0

http://<satellite_server>/apidoc/v2/organizations/create.html
organization[environment_ids]optional , nil allowed


##### Functional demonstration

Provide an execution of the modified code, with ipython code blocks or screen shots.
You can exercise the code as raw API calls or using any other method.

```
pytest tests/foreman/api/test_organization.py -k test_positive_create_with_name_and_description
=================================== test session starts ==========================
platform linux -- Python 3.9.9, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/sjw/sat6/robottelo, configfile: pyproject.toml
plugins: mock-3.6.1, ibutsu-1.16, forked-1.3.0, services-2.2.1, cov-3.0.0, reportportal-5.0.8, xdist-2.4.0
collected 43 items / 36 deselected / 7 selected                                                                                                                                                   

tests/foreman/api/test_organization.py .......  

============== 7 passed, 36 deselected, 15 warnings in 55.27s =======================
```

Your contribution should include updates to the unit tests, covering the modified portions or adding new coverage.

Example:
```
# Demonstrate functional Snapshot read in ipython
In [1]: from nailgun.entities import Snapshot
In [2]: Snapshot(host='sat.instance.addr.com', id='snap_uuid').read()
Out [2]: <read method result>
```

##### Additional Information

Any additional notes for reviewers, comments about the change, TODO lists on WIP PRs, etc.
