### PR TITLE
Add httpboot proxy attribute to Subnet

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -7201,6 +7201,7 @@ class Subnet(
             'domain': entity_fields.OneToManyField(Domain),
             'from_': entity_fields.IPAddressField(),
             'gateway': entity_fields.StringField(),
+            'httpboot': entity_fields.OneToOneField(SmartProxy),
             'ipam': entity_fields.StringField(
                 choices=('DHCP', 'Internal DB'),
                 default='DHCP',


### PR DESCRIPTION
##### Description of changes

An attribute was added to the `Subnet` class.

##### Upstream API documentation, plugin, or feature links

https://github.com/SatelliteQE/robottelo/pull/9246 depends on this

##### Functional demonstration


https://github.com/SatelliteQE/robottelo/blob/9bbec8c836b3ef345c9f27896c40c801b3c43303/tests/foreman/cli/test_provisioning.py#L66-L145


`subnet` instance:
```
robottelo.hosts.DecClass(boot_mode='DHCP', cidr=29, description=None, dhcp=nailgun.entities.SmartProxy(id=1), dns=nailgun.entities.SmartProxy(id=1), dns_primary='10.5.30.160', dns_secondary='10.11.5.19', domain=[nailgun.entities.Domain(id=18)], from_='10.1.5.90', gateway='10.1.5.94', httpboot=nailgun.entities.SmartProxy(id=1), ipam='None', location=[nailgun.entities.Location(id=22)], mask='255.255.255.248', mtu=1500, name='PTxwMv', network='10.1.5.88', network_type='IPv4', organization=[nailgun.entities.Organization(id=21)], subnet_parameters_attributes=[], template=nailgun.entities.SmartProxy(id=1), to='10.1.5.93', tftp=nailgun.entities.SmartProxy(id=1), vlanid=None, id=3)
```

