### PR TITLE
Add description, content view and PXE loader to HG

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -3239,10 +3239,12 @@ class HostGroup(
     def __init__(self, server_config=None, **kwargs):
         self._fields = {
             'architecture': entity_fields.OneToOneField(Architecture),
+            'description': entity_fields.StringField(),
             'domain': entity_fields.OneToOneField(Domain),
             'puppet_proxy': entity_fields.OneToOneField(SmartProxy),
             'puppet_ca_proxy': entity_fields.OneToOneField(SmartProxy),
             'content_source': entity_fields.OneToOneField(SmartProxy),
+            'content_view': entity_fields.OneToOneField(ContentView),
             'compute_resource': entity_fields.OneToOneField(AbstractComputeResource),
             'compute_profile': entity_fields.OneToOneField(ComputeProfile),
             'environment': entity_fields.OneToOneField(Environment),
@@ -3258,6 +3260,25 @@ class HostGroup(
             'organization': entity_fields.OneToManyField(Organization),
             'parent': entity_fields.OneToOneField(HostGroup),
             'ptable': entity_fields.OneToOneField(PartitionTable),
+            'pxe_loader': entity_fields.StringField(
+                choices=(
+                    'PXELinux BIOS',
+                    'PXELinux UEFI',
+                    'Grub UEFI',
+                    'Grub2 BIOS'
+                    'Grub2 ELF'
+                    'Grub2 UEFI'
+                    'Grub2 UEFI SecureBoot'
+                    'Grub2 UEFI HTTP'
+                    'Grub2 UEFI HTTPS'
+                    'Grub2 UEFI HTTPS SecureBoot'
+                    'iPXE Embedded'
+                    'iPXE UEFI HTTP'
+                    'iPXE Chain BIOS'
+                    'iPXE Chain UEFI',
+                ),
+                default='PXELinux BIOS',
+            ),
             'realm': entity_fields.OneToOneField(Realm),
             'subnet': entity_fields.OneToOneField(Subnet),
             'group_parameters_attributes': entity_fields.ListField(),


### PR DESCRIPTION
##### Description of changes

Attributes were added to the `HostGroup` class.

##### Upstream API documentation, plugin, or feature links

https://github.com/SatelliteQE/robottelo/pull/9246 depends on this

##### Functional demonstration

https://github.com/SatelliteQE/robottelo/blob/ecf0a9cd61863bc9674c2bc9481dea6f52ef1bec/tests/foreman/cli/test_provisioning.py#L190-L204


`hostgroup` instance:
```
robottelo.hosts.DecClass(organization=[nailgun.entities.Organization(compute_resource=[], description=None, domain=[], environment=[], hostgroup=[], label='uzyDYcFG', medium=[], name='uzyDYcFG', provisioning_template=[nailgun.entities.ProvisioningTemplate(id=44), nailgun.entities.ProvisioningTemplate(id=28), nailgun.entities.ProvisioningTemplate(id=10), nailgun.entities.ProvisioningTemplate(id=61), nailgun.entities.ProvisioningTemplate(id=63), nailgun.entities.ProvisioningTemplate(id=64), nailgun.entities.ProvisioningTemplate(id=65), nailgun.entities.ProvisioningTemplate(id=45), nailgun.entities.ProvisioningTemplate(id=46), nailgun.entities.ProvisioningTemplate(id=37), nailgun.entities.ProvisioningTemplate(id=11), nailgun.entities.ProvisioningTemplate(id=106), nailgun.entities.ProvisioningTemplate(id=47), nailgun.entities.ProvisioningTemplate(id=66), nailgun.entities.ProvisioningTemplate(id=67), nailgun.entities.ProvisioningTemplate(id=144), nailgun.entities.ProvisioningTemplate(id=143), nailgun.entities.ProvisioningTemplate(id=145), nailgun.entities.ProvisioningTemplate(id=142), nailgun.entities.ProvisioningTemplate(id=68), nailgun.entities.ProvisioningTemplate(id=69), nailgun.entities.ProvisioningTemplate(id=27), nailgun.entities.ProvisioningTemplate(id=70), nailgun.entities.ProvisioningTemplate(id=48), nailgun.entities.ProvisioningTemplate(id=12), nailgun.entities.ProvisioningTemplate(id=71), nailgun.entities.ProvisioningTemplate(id=72), nailgun.entities.ProvisioningTemplate(id=147), nailgun.entities.ProvisioningTemplate(id=146), nailgun.entities.ProvisioningTemplate(id=73), nailgun.entities.ProvisioningTemplate(id=74), nailgun.entities.ProvisioningTemplate(id=75), nailgun.entities.ProvisioningTemplate(id=76), nailgun.entities.ProvisioningTemplate(id=77), nailgun.entities.ProvisioningTemplate(id=29), nailgun.entities.ProvisioningTemplate(id=49), nailgun.entities.ProvisioningTemplate(id=13), nailgun.entities.ProvisioningTemplate(id=78), nailgun.entities.ProvisioningTemplate(id=58), nailgun.entities.ProvisioningTemplate(id=59), nailgun.entities.ProvisioningTemplate(id=79), nailgun.entities.ProvisioningTemplate(id=80), nailgun.entities.ProvisioningTemplate(id=38), nailgun.entities.ProvisioningTemplate(id=39), nailgun.entities.ProvisioningTemplate(id=40), nailgun.entities.ProvisioningTemplate(id=50), nailgun.entities.ProvisioningTemplate(id=30), nailgun.entities.ProvisioningTemplate(id=2), nailgun.entities.ProvisioningTemplate(id=31), nailgun.entities.ProvisioningTemplate(id=51), nailgun.entities.ProvisioningTemplate(id=26), nailgun.entities.ProvisioningTemplate(id=52), nailgun.entities.ProvisioningTemplate(id=32), nailgun.entities.ProvisioningTemplate(id=41), nailgun.entities.ProvisioningTemplate(id=3), nailgun.entities.ProvisioningTemplate(id=6), nailgun.entities.ProvisioningTemplate(id=14), nailgun.entities.ProvisioningTemplate(id=107), nailgun.entities.ProvisioningTemplate(id=83), nailgun.entities.ProvisioningTemplate(id=81), nailgun.entities.ProvisioningTemplate(id=84), nailgun.entities.ProvisioningTemplate(id=86), nailgun.entities.ProvisioningTemplate(id=87), nailgun.entities.ProvisioningTemplate(id=88), nailgun.entities.ProvisioningTemplate(id=53), nailgun.entities.ProvisioningTemplate(id=15), nailgun.entities.ProvisioningTemplate(id=36), nailgun.entities.ProvisioningTemplate(id=89), nailgun.entities.ProvisioningTemplate(id=1), nailgun.entities.ProvisioningTemplate(id=54), nailgun.entities.ProvisioningTemplate(id=33), nailgun.entities.ProvisioningTemplate(id=42), nailgun.entities.ProvisioningTemplate(id=7), nailgun.entities.ProvisioningTemplate(id=16), nailgun.entities.ProvisioningTemplate(id=108), nailgun.entities.ProvisioningTemplate(id=90), nailgun.entities.ProvisioningTemplate(id=91), nailgun.entities.ProvisioningTemplate(id=93), nailgun.entities.ProvisioningTemplate(id=92), nailgun.entities.ProvisioningTemplate(id=94), nailgun.entities.ProvisioningTemplate(id=8), nailgun.entities.ProvisioningTemplate(id=95), nailgun.entities.ProvisioningTemplate(id=9), nailgun.entities.ProvisioningTemplate(id=96), nailgun.entities.ProvisioningTemplate(id=97), nailgun.entities.ProvisioningTemplate(id=4), nailgun.entities.ProvisioningTemplate(id=98), nailgun.entities.ProvisioningTemplate(id=5), nailgun.entities.ProvisioningTemplate(id=17), nailgun.entities.ProvisioningTemplate(id=18), nailgun.entities.ProvisioningTemplate(id=99), nailgun.entities.ProvisioningTemplate(id=19), nailgun.entities.ProvisioningTemplate(id=20), nailgun.entities.ProvisioningTemplate(id=100), nailgun.entities.ProvisioningTemplate(id=21), nailgun.entities.ProvisioningTemplate(id=101), nailgun.entities.ProvisioningTemplate(id=55), nailgun.entities.ProvisioningTemplate(id=22), nailgun.entities.ProvisioningTemplate(id=102), nailgun.entities.ProvisioningTemplate(id=103), nailgun.entities.ProvisioningTemplate(id=104), nailgun.entities.ProvisioningTemplate(id=105), nailgun.entities.ProvisioningTemplate(id=82), nailgun.entities.ProvisioningTemplate(id=109), nailgun.entities.ProvisioningTemplate(id=110), nailgun.entities.ProvisioningTemplate(id=23), nailgun.entities.ProvisioningTemplate(id=34), nailgun.entities.ProvisioningTemplate(id=43), nailgun.entities.ProvisioningTemplate(id=56), nailgun.entities.ProvisioningTemplate(id=24), nailgun.entities.ProvisioningTemplate(id=85), nailgun.entities.ProvisioningTemplate(id=60), nailgun.entities.ProvisioningTemplate(id=57), nailgun.entities.ProvisioningTemplate(id=35), nailgun.entities.ProvisioningTemplate(id=25), nailgun.entities.ProvisioningTemplate(id=62)], redhat_repository_url='https://cdn.redhat.com', smart_proxy=[nailgun.entities.SmartProxy(id=1)], subnet=[], title='uzyDYcFG', user=[], simple_content_access=False, default_content_view=nailgun.entities.ContentView(id=20), library=nailgun.entities.LifecycleEnvironment(id=20), id=35)], location=[nailgun.entities.Location(compute_resource=[], description=None, domain=[], environment=[], hostgroup=[], medium=[], name='LouQLv', organization=[nailgun.entities.Organization(id=36)], parent=None, provisioning_template=[nailgun.entities.ProvisioningTemplate(id=44), nailgun.entities.ProvisioningTemplate(id=28), nailgun.entities.ProvisioningTemplate(id=10), nailgun.entities.ProvisioningTemplate(id=61), nailgun.entities.ProvisioningTemplate(id=63), nailgun.entities.ProvisioningTemplate(id=64), nailgun.entities.ProvisioningTemplate(id=65), nailgun.entities.ProvisioningTemplate(id=45), nailgun.entities.ProvisioningTemplate(id=46), nailgun.entities.ProvisioningTemplate(id=37), nailgun.entities.ProvisioningTemplate(id=11), nailgun.entities.ProvisioningTemplate(id=106), nailgun.entities.ProvisioningTemplate(id=47), nailgun.entities.ProvisioningTemplate(id=66), nailgun.entities.ProvisioningTemplate(id=67), nailgun.entities.ProvisioningTemplate(id=144), nailgun.entities.ProvisioningTemplate(id=143), nailgun.entities.ProvisioningTemplate(id=145), nailgun.entities.ProvisioningTemplate(id=142), nailgun.entities.ProvisioningTemplate(id=68), nailgun.entities.ProvisioningTemplate(id=69), nailgun.entities.ProvisioningTemplate(id=27), nailgun.entities.ProvisioningTemplate(id=70), nailgun.entities.ProvisioningTemplate(id=48), nailgun.entities.ProvisioningTemplate(id=12), nailgun.entities.ProvisioningTemplate(id=71), nailgun.entities.ProvisioningTemplate(id=72), nailgun.entities.ProvisioningTemplate(id=147), nailgun.entities.ProvisioningTemplate(id=146), nailgun.entities.ProvisioningTemplate(id=73), nailgun.entities.ProvisioningTemplate(id=74), nailgun.entities.ProvisioningTemplate(id=75), nailgun.entities.ProvisioningTemplate(id=76), nailgun.entities.ProvisioningTemplate(id=77), nailgun.entities.ProvisioningTemplate(id=29), nailgun.entities.ProvisioningTemplate(id=49), nailgun.entities.ProvisioningTemplate(id=13), nailgun.entities.ProvisioningTemplate(id=78), nailgun.entities.ProvisioningTemplate(id=58), nailgun.entities.ProvisioningTemplate(id=59), nailgun.entities.ProvisioningTemplate(id=79), nailgun.entities.ProvisioningTemplate(id=80), nailgun.entities.ProvisioningTemplate(id=38), nailgun.entities.ProvisioningTemplate(id=39), nailgun.entities.ProvisioningTemplate(id=40), nailgun.entities.ProvisioningTemplate(id=50), nailgun.entities.ProvisioningTemplate(id=30), nailgun.entities.ProvisioningTemplate(id=2), nailgun.entities.ProvisioningTemplate(id=31), nailgun.entities.ProvisioningTemplate(id=51), nailgun.entities.ProvisioningTemplate(id=26), nailgun.entities.ProvisioningTemplate(id=52), nailgun.entities.ProvisioningTemplate(id=32), nailgun.entities.ProvisioningTemplate(id=41), nailgun.entities.ProvisioningTemplate(id=3), nailgun.entities.ProvisioningTemplate(id=6), nailgun.entities.ProvisioningTemplate(id=14), nailgun.entities.ProvisioningTemplate(id=107), nailgun.entities.ProvisioningTemplate(id=83), nailgun.entities.ProvisioningTemplate(id=81), nailgun.entities.ProvisioningTemplate(id=84), nailgun.entities.ProvisioningTemplate(id=86), nailgun.entities.ProvisioningTemplate(id=87), nailgun.entities.ProvisioningTemplate(id=88), nailgun.entities.ProvisioningTemplate(id=53), nailgun.entities.ProvisioningTemplate(id=15), nailgun.entities.ProvisioningTemplate(id=36), nailgun.entities.ProvisioningTemplate(id=89), nailgun.entities.ProvisioningTemplate(id=1), nailgun.entities.ProvisioningTemplate(id=54), nailgun.entities.ProvisioningTemplate(id=33), nailgun.entities.ProvisioningTemplate(id=42), nailgun.entities.ProvisioningTemplate(id=7), nailgun.entities.ProvisioningTemplate(id=16), nailgun.entities.ProvisioningTemplate(id=108), nailgun.entities.ProvisioningTemplate(id=90), nailgun.entities.ProvisioningTemplate(id=91), nailgun.entities.ProvisioningTemplate(id=93), nailgun.entities.ProvisioningTemplate(id=92), nailgun.entities.ProvisioningTemplate(id=94), nailgun.entities.ProvisioningTemplate(id=8), nailgun.entities.ProvisioningTemplate(id=95), nailgun.entities.ProvisioningTemplate(id=9), nailgun.entities.ProvisioningTemplate(id=96), nailgun.entities.ProvisioningTemplate(id=97), nailgun.entities.ProvisioningTemplate(id=4), nailgun.entities.ProvisioningTemplate(id=98), nailgun.entities.ProvisioningTemplate(id=5), nailgun.entities.ProvisioningTemplate(id=17), nailgun.entities.ProvisioningTemplate(id=18), nailgun.entities.ProvisioningTemplate(id=99), nailgun.entities.ProvisioningTemplate(id=19), nailgun.entities.ProvisioningTemplate(id=20), nailgun.entities.ProvisioningTemplate(id=100), nailgun.entities.ProvisioningTemplate(id=21), nailgun.entities.ProvisioningTemplate(id=101), nailgun.entities.ProvisioningTemplate(id=55), nailgun.entities.ProvisioningTemplate(id=22), nailgun.entities.ProvisioningTemplate(id=102), nailgun.entities.ProvisioningTemplate(id=103), nailgun.entities.ProvisioningTemplate(id=104), nailgun.entities.ProvisioningTemplate(id=105), nailgun.entities.ProvisioningTemplate(id=82), nailgun.entities.ProvisioningTemplate(id=109), nailgun.entities.ProvisioningTemplate(id=110), nailgun.entities.ProvisioningTemplate(id=23), nailgun.entities.ProvisioningTemplate(id=34), nailgun.entities.ProvisioningTemplate(id=43), nailgun.entities.ProvisioningTemplate(id=56), nailgun.entities.ProvisioningTemplate(id=24), nailgun.entities.ProvisioningTemplate(id=85), nailgun.entities.ProvisioningTemplate(id=60), nailgun.entities.ProvisioningTemplate(id=57), nailgun.entities.ProvisioningTemplate(id=35), nailgun.entities.ProvisioningTemplate(id=25), nailgun.entities.ProvisioningTemplate(id=62)], smart_proxy=[], subnet=[], user=[], id=37)], architecture=nailgun.entities.Architecture(name='x86_64', operatingsystem=[nailgun.entities.OperatingSystem(id=1), nailgun.entities.OperatingSystem(id=2)], id=1), domain=nailgun.entities.Domain(dns=nailgun.entities.SmartProxy(id=1), domain_parameters_attributes=[], fullname=None, location=[nailgun.entities.Location(id=37)], name='hzcnegwbcv.foo', organization=[nailgun.entities.Organization(id=35)], id=23), content_source=nailgun.entities.SmartProxy(id=1), content_view=robottelo.hosts.DecClass(auto_publish=False, component=[], composite=False, content_host_count=0, description=None, environment=[nailgun.entities.LifecycleEnvironment(id=20)], label='Default_Organization_View', last_published='2021-12-19 21:22:41 UTC', name='Default Organization View', next_version='1.0', organization=nailgun.entities.Organization(id=35), repository=[], solve_dependencies=False, version=[nailgun.entities.ContentViewVersion(id=20)], id=20), kickstart_repository=robottelo.hosts.DecClass(ansible_collection_auth_url=None, ansible_collection_auth_token=None, ansible_collection_requirements=None, backend_identifier='71e453fd-f053-43fd-abd1-dd424d13140c', checksum_type=None, content_counts={'ostree_branch': 0, 'docker_manifest': 0, 'docker_manifest_list': 0, 'docker_tag': 0, 'rpm': 1709, 'srpm': 0, 'package': 1709, 'package_group': 35, 'erratum': 0, 'file': 0, 'deb': 0, 'module_stream': 0, 'ansible_collection': 0}, content_type='yum', container_repository_name=None, docker_upstream_name=None, docker_tags_whitelist=None, download_policy='on_demand', full_path='https://dhcp-2-143.vms.sat.rdu2.redhat.com/pulp/content/uzyDYcFG/Library/content/dist/rhel8/8.4/x86_64/baseos/kickstart/', gpg_key=None, ignorable_content=None, label='Red_Hat_Enterprise_Linux_8_for_x86_64_-_BaseOS_Kickstart_8_4', last_sync=nailgun.entities.ForemanTask(id='2653a5f2-1291-4aaf-a2e7-36af36334595'), mirror_on_sync=True, name='Red Hat Enterprise Linux 8 for x86_64 - BaseOS Kickstart 8.4', product=nailgun.entities.Product(id=260), unprotected=True, url='https://cdn.redhat.com/content/dist/rhel8/8.4/x86_64/baseos/kickstart', upstream_username=None, verify_ssl_on_sync=True, http_proxy_policy='global_default_http_proxy', http_proxy_id=None, id=5), lifecycle_environment=robottelo.hosts.DecClass(description=None, label='Library', name='Library', organization=nailgun.entities.Organization(id=35), prior=None, registry_name_pattern=None, registry_unauthenticated_pull=False, id=20), root_pass='changeme', operatingsystem=robottelo.hosts.DecClass(architecture=[nailgun.entities.Architecture(id=1)], description=None, family='Redhat', major='8', medium=[], minor='4', name='RedHat', ptable=[nailgun.entities.PartitionTable(id=121)], provisioning_template=[nailgun.entities.ProvisioningTemplate(id=146), nailgun.entities.ProvisioningTemplate(id=52), nailgun.entities.ProvisioningTemplate(id=32), nailgun.entities.ProvisioningTemplate(id=41), nailgun.entities.ProvisioningTemplate(id=3), nailgun.entities.ProvisioningTemplate(id=6), nailgun.entities.ProvisioningTemplate(id=14), nailgun.entities.ProvisioningTemplate(id=107), nailgun.entities.ProvisioningTemplate(id=36)], release_name=None, password_hash='SHA256', title='RedHat 8.4', id=2), ptable=robottelo.hosts.DecClass(layout="<%#\nkind: ptable\nname: Kickstart default\nmodel: Ptable\noses:\n- AlmaLinux\n- CentOS\n- Fedora\n- RedHat\n- Rocky\n%>\nzerombr\nclearpart --all --initlabel\nautopart <%= host_param('autopart_options') %>\n", location=[nailgun.entities.Location(id=18), nailgun.entities.Location(id=31), nailgun.entities.Location(id=2), nailgun.entities.Location(id=28), nailgun.entities.Location(id=10), nailgun.entities.Location(id=20), nailgun.entities.Location(id=16), nailgun.entities.Location(id=25), nailgun.entities.Location(id=37), nailgun.entities.Location(id=6), nailgun.entities.Location(id=8), nailgun.entities.Location(id=12), nailgun.entities.Location(id=34), nailgun.entities.Location(id=22), nailgun.entities.Location(id=4), nailgun.entities.Location(id=14)], locked=True, name='Kickstart default', organization=[nailgun.entities.Organization(id=9), nailgun.entities.Organization(id=33), nailgun.entities.Organization(id=17), nailgun.entities.Organization(id=24), nailgun.entities.Organization(id=21), nailgun.entities.Organization(id=1), nailgun.entities.Organization(id=15), nailgun.entities.Organization(id=19), nailgun.entities.Organization(id=3), nailgun.entities.Organization(id=23), nailgun.entities.Organization(id=11), nailgun.entities.Organization(id=5), nailgun.entities.Organization(id=29), nailgun.entities.Organization(id=7), nailgun.entities.Organization(id=26), nailgun.entities.Organization(id=32), nailgun.entities.Organization(id=35), nailgun.entities.Organization(id=36), nailgun.entities.Organization(id=13), nailgun.entities.Organization(id=30), nailgun.entities.Organization(id=27)], os_family='Redhat', id=121), subnet=robottelo.hosts.DecClass(boot_mode='DHCP', cidr=29, description=None, dhcp=nailgun.entities.SmartProxy(id=1), dns=nailgun.entities.SmartProxy(id=1), dns_primary='10.5.30.160', dns_secondary='10.11.5.19', domain=[nailgun.entities.Domain(id=23)], from_='10.1.5.90', gateway='10.1.5.94', httpboot=nailgun.entities.SmartProxy(id=1), ipam='None', location=[nailgun.entities.Location(id=37)], mask='255.255.255.248', mtu=1500, name='jFJysIjjQ', network='10.1.5.88', network_type='IPv4', organization=[nailgun.entities.Organization(id=35)], subnet_parameters_attributes=[], template=nailgun.entities.SmartProxy(id=1), to='10.1.5.93', tftp=nailgun.entities.SmartProxy(id=1), vlanid=None, id=8), pxe_loader='PXELinux BIOS')
```
