### PR TITLE
Fix puppet-related URLs

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -1539,7 +1539,12 @@ class AzureRMComputeResource(AbstractComputeResource):
 
 
 class ConfigGroup(
-    Entity, EntityCreateMixin, EntityReadMixin, EntitySearchMixin, EntityUpdateMixin
+    Entity,
+    EntityCreateMixin,
+    EntityReadMixin,
+    EntitySearchMixin,
+    EntityUpdateMixin,
+    EntityDeleteMixin,
 ):
     """A representation of a Config Group entity."""
 
@@ -1550,7 +1555,7 @@ class ConfigGroup(
             ),
         }
         self._meta = {
-            'api_path': 'api/v2/config_groups',
+            'api_path': 'foreman_puppet/api/config_groups',
         }
         super().__init__(server_config, **kwargs)
 
@@ -2826,7 +2831,7 @@ class Environment(
             'organization': entity_fields.OneToManyField(Organization),
         }
         self._meta = {
-            'api_path': 'api/v2/environments',
+            'api_path': 'foreman_puppet/api/environments',
         }
         super().__init__(server_config, **kwargs)
 
@@ -2858,7 +2863,7 @@ class Environment(
         The format of the returned path depends on the value of ``which``:
 
         smart_class_parameters
-            /api/environments/:environment_id/smart_class_parameters
+            /foreman_puppet/api/environments/:environment_id/smart_class_parameters
 
         Otherwise, call ``super``.
 
@@ -5805,7 +5810,7 @@ class PuppetClass(
             'hostgroup': entity_fields.OneToManyField(HostGroup),
         }
         self._meta = {
-            'api_path': 'api/v2/puppetclasses',
+            'api_path': 'foreman_puppet/api/puppetclasses',
         }
         super().__init__(server_config, **kwargs)
 
@@ -5828,7 +5833,7 @@ class PuppetClass(
         The format of the returned path depends on the value of ``which``:
 
         smart_class_parameters
-            /api/puppetclasses/:puppetclass_id/smart_class_parameters
+            /foreman_puppet/api/puppetclasses/:puppetclass_id/smart_class_parameters
 
         Otherwise, call ``super``.
 
@@ -6943,7 +6948,7 @@ class SmartClassParameters(Entity, EntityReadMixin, EntitySearchMixin, EntityUpd
             'override_values': entity_fields.DictField(),
         }
         self._meta = {
-            'api_path': 'api/v2/smart_class_parameters',
+            'api_path': 'foreman_puppet/api/smart_class_parameters',
         }
         super().__init__(server_config, **kwargs)
 


### PR DESCRIPTION
##### Description of changes

The puppet-related URLs have changed with movement into a plugin in 7.0.

##### Upstream API documentation, plugin, or feature links

https://community.theforeman.org/t/the-road-to-making-puppet-optional/17983
or see the apidoc of a puppet-enabled Satellite

##### Functional demonstration

CRUD like the following with entities passed:
```
>>> from nailgun import entities
>>> cg = entities.ConfigGroup(name='ahoy').create()
>>> res = cg.read()
>>> res
nailgun.entities.ConfigGroup(name='ahoy', id=1)
>>> cg.name = 'astalavista'; res = cg.update(['name'])
>>> cg = entities.ConfigGroup().search(query={'search':f'name="astalavista"'})[0].read()
>>> cg
nailgun.entities.ConfigGroup(name='astalavista', id=1)
>>> res = cg.delete()
>>> res
{'id': 1, 'name': 'astalavista', 'created_at': '2021-12-20T15:29:41.261Z', 'updated_at': '2021-12-20T15:29:57.987Z'}
```
