### PR TITLE
[#799 - v1] Remove environment param from Organization entity

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -5073,7 +5073,6 @@ class Organization(
             'compute_resource': entity_fields.OneToManyField(AbstractComputeResource),
             'description': entity_fields.StringField(),
             'domain': entity_fields.OneToManyField(Domain),
-            'environment': entity_fields.OneToManyField(Environment),
             'hostgroup': entity_fields.OneToManyField(HostGroup),
             'label': entity_fields.StringField(str_type='alpha'),
             'medium': entity_fields.OneToManyField(Media),


### PR DESCRIPTION
##### Description of changes
This is version - 1 of #799 that was initially raised by @swadeley to remove the environment param from the organization entity. 

This PR is being raised to fix the tons of failures we have due to #799 is not yet merged or the discussions are still happening on that to support the optional puppet feature even though it's not the default anymore with sat 7.0 but still some components would enable them and use them until they are depreciated.

So let's merge this PR to unblock with the current count of failures vs later we can work on #799 to address the entities using environment/puppet facility with fewer failures.

Refer #799 for [results](https://github.com/SatelliteQE/nailgun/pull/799#issue-1078591248) and discussions.