### PR TITLE
Fix issue related to environment and puppetclass field for Host Entity.

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -3779,7 +3779,9 @@ class Host(
                 if int(self.location.id) not in [loc.id for loc in self.environment.location]:
                     self.environment.location.append(self.location)
                     self.environment.update(['location'])
-                if int(self.organization.id) not in [org.id for org in self.environment.organization]:
+                if int(self.organization.id) not in [
+                    org.id for org in self.environment.organization
+                ]:
                     self.environment.organization.append(self.organization)
                     self.environment.update(['organization'])
         if not hasattr(self, 'architecture'):
@@ -4209,6 +4211,8 @@ class Host(
         # host id is required for interface initialization
         ignore.add('interface')
         ignore.add('build_status_label')
+        if 'Puppet' not in _feature_list(self._server_config):
+            ignore.add('puppetclass')
         result = super().read(entity, attrs, ignore, params)
         if attrs.get('image_id'):
             result.image = Image(

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -189,10 +189,8 @@ def _get_version(server_config):
 
 def _feature_list(server_config, smart_proxy_id=1):
     """Get list of features enabled on capsule"""
-    path = f'{server_config.url}/api/v2/smart_proxies/{smart_proxy_id}'
-    response = client.get(path, **server_config.get_client_kwargs())
-    response.raise_for_status()
-    return [feature['name'] for feature in response.json()['features']]
+    smart_proxy = SmartProxy(server_config, id=smart_proxy_id).read_json()
+    return [feature['name'] for feature in smart_proxy['features']]
 
 
 class ActivationKey(

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -23,6 +23,7 @@ workings of entity classes.
 import hashlib
 import os.path
 from datetime import datetime
+from functools import lru_cache
 from http.client import ACCEPTED
 from http.client import NO_CONTENT
 from urllib.parse import urljoin  # noqa:F0401,E0611
@@ -187,6 +188,7 @@ def _get_version(server_config):
     return getattr(server_config, 'version', Version('1!0'))
 
 
+@lru_cache()
 def _feature_list(server_config, smart_proxy_id=1):
     """Get list of features enabled on capsule"""
     smart_proxy = SmartProxy(server_config, id=smart_proxy_id).read_json()

--- a/nailgun/entity_mixins.py
+++ b/nailgun/entity_mixins.py
@@ -698,8 +698,8 @@ class EntityReadMixin:
 
     """
 
-    ignore_fields = ['environment']
-    ignore_entities = ['Environment']
+    ignore_fields = ['environment', 'smart_class_parameter', 'puppetclass']
+    ignore_entities = ['Environment', 'SmartClassParameters', 'PuppetClass']
 
     def read_raw(self, params=None):
         """Get information about the current entity.

--- a/nailgun/entity_mixins.py
+++ b/nailgun/entity_mixins.py
@@ -698,8 +698,8 @@ class EntityReadMixin:
 
     """
 
-    ignore_fields = ['environment', 'smart_class_parameter', 'puppetclass']
-    ignore_entities = ['Environment', 'SmartClassParameters', 'PuppetClass']
+    ignore_fields = ['environment']
+    ignore_entities = ['Environment']
 
     def read_raw(self, params=None):
         """Get information about the current entity.

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -964,10 +964,11 @@ class CreateMissingTestCase(TestCase):
     def test_host_v1(self):
         """Test ``Host()``."""
         entity = entities.Host(self.cfg)
-        with mock.patch.object(EntityCreateMixin, 'create_json'):
-            with mock.patch.object(EntityReadMixin, 'read_json'):
-                with mock.patch.object(EntityReadMixin, 'read'):
-                    entity.create_missing()
+        with mock.patch.object(entities, '_feature_list', return_value={'Puppet'}):
+            with mock.patch.object(EntityCreateMixin, 'create_json'):
+                with mock.patch.object(EntityReadMixin, 'read_json'):
+                    with mock.patch.object(EntityReadMixin, 'read'):
+                        entity.create_missing()
         self.assertEqual(
             set(entity.get_values().keys()),
             _get_required_field_names(entity).union(
@@ -1031,11 +1032,12 @@ class CreateMissingTestCase(TestCase):
             organization=org,
             ptable=ptable,
         )
-        with mock.patch.object(EntityCreateMixin, 'create_json'):
-            with mock.patch.object(EntityReadMixin, 'read_json'):
-                with mock.patch.object(EntityUpdateMixin, 'update_json'):
-                    with mock.patch.object(EntityReadMixin, 'read'):
-                        entity.create_missing()
+        with mock.patch.object(entities, '_feature_list', return_value={'Puppet'}):
+            with mock.patch.object(EntityCreateMixin, 'create_json'):
+                with mock.patch.object(EntityReadMixin, 'read_json'):
+                    with mock.patch.object(EntityUpdateMixin, 'update_json'):
+                        with mock.patch.object(EntityReadMixin, 'read'):
+                            entity.create_missing()
         for subentity in domain, env, media:
             self.assertIn(loc.id, [loc_.id for loc_ in subentity.location])
             self.assertIn(org.id, [org_.id for org_ in subentity.organization])
@@ -1190,10 +1192,11 @@ class ReadTestCase(TestCase):
         ):
             with mock.patch.object(EntityReadMixin, 'read_json') as read_json:
                 with mock.patch.object(EntityReadMixin, 'read') as read:
-                    with self.subTest():
-                        entity(self.cfg).read()
-                        self.assertEqual(read_json.call_count, 1)
-                        self.assertEqual(read.call_count, 1)
+                    with mock.patch.object(entities, '_feature_list', return_value={'Puppet'}):
+                        with self.subTest():
+                            entity(self.cfg).read()
+                            self.assertEqual(read_json.call_count, 1)
+                            self.assertEqual(read.call_count, 1)
 
     def test_attrs_arg_v2(self):
         """Ensure ``read``, ``read_json`` and ``client.put`` are called once.
@@ -1246,7 +1249,8 @@ class ReadTestCase(TestCase):
         for entity, attrs_before, attrs_after in test_data:
             with self.subTest(entity):
                 with mock.patch.object(EntityReadMixin, 'read') as read:
-                    entity.read(attrs=attrs_before)
+                    with mock.patch.object(entities, '_feature_list', return_value={'Puppet'}):
+                        entity.read(attrs=attrs_before)
                 self.assertEqual(read.call_args[0][1], attrs_after)
 
     def test_ignore_arg_v1(self):
@@ -1278,7 +1282,12 @@ class ReadTestCase(TestCase):
                 with mock.patch.object(EntityReadMixin, 'read') as read, mock.patch.object(
                     EntityReadMixin, 'read_json'
                 ):
-                    entity(self.cfg).read()
+                    with mock.patch.object(
+                        entities,
+                        '_feature_list',
+                        return_value={'Puppet'},
+                    ):
+                        entity(self.cfg).read()
                 # `call_args` is a two-tuple of (positional, keyword) args.
                 self.assertEqual(ignored_attrs, read.call_args[0][2])
 
@@ -1436,7 +1445,12 @@ class ReadTestCase(TestCase):
                     'parameters': None,
                 },
             ):
-                host = entities.Host(self.cfg, id=2).read()
+                with mock.patch.object(
+                    entities,
+                    '_feature_list',
+                    return_value={'Puppet'},
+                ):
+                    host = entities.Host(self.cfg, id=2).read()
         self.assertTrue(hasattr(host, 'interface'))
         self.assertTrue(isinstance(host.interface, list))
         for interface in host.interface:
@@ -1710,24 +1724,25 @@ class SearchNormalizeTestCase(TestCase):
         host = entities.Host(self.cfg, id=1)
         with mock.patch.object(EntityReadMixin, 'read_json') as read_json:
             with mock.patch.object(EntityReadMixin, 'read') as read:
-                # Image was set
-                read_json.return_value = {
-                    'image_id': 1,
-                    'compute_resource_id': 1,
-                    'parameters': {},
-                }
-                read.return_value = host
-                host = host.read()
-                self.assertTrue(hasattr(host, 'image'))
-                self.assertEqual(host.image.id, image.id)
-                # Image wasn't set
-                read_json.return_value = {
-                    'parameters': {},
-                }
-                read.return_value = host
-                host = host.read()
-                self.assertTrue(hasattr(host, 'image'))
-                self.assertIsNone(host.image)
+                with mock.patch.object(entities, '_feature_list', return_value={'Puppet'}):
+                    # Image was set
+                    read_json.return_value = {
+                        'image_id': 1,
+                        'compute_resource_id': 1,
+                        'parameters': {},
+                    }
+                    read.return_value = host
+                    host = host.read()
+                    self.assertTrue(hasattr(host, 'image'))
+                    self.assertEqual(host.image.id, image.id)
+                    # Image wasn't set
+                    read_json.return_value = {
+                        'parameters': {},
+                    }
+                    read.return_value = host
+                    host = host.read()
+                    self.assertTrue(hasattr(host, 'image'))
+                    self.assertIsNone(host.image)
 
 
 class UpdateTestCase(TestCase):
@@ -2978,14 +2993,15 @@ class HostTestCase(TestCase):
         ``content_facet_attributes`` attribute is not returned for host
         """
         with mock.patch.object(EntityReadMixin, 'read') as read:
-            entities.Host(self.cfg).read(
-                attrs={
-                    'parameters': None,
-                    'puppetclasses': None,
-                }
-            )
-            self.assertNotIn('content_facet_attributes', read.call_args[0][1])
-            self.assertIn('content_facet_attributes', read.call_args[0][2])
+            with mock.patch.object(entities, '_feature_list', return_value={'Puppet'}):
+                entities.Host(self.cfg).read(
+                    attrs={
+                        'parameters': None,
+                        'puppetclasses': None,
+                    }
+                )
+                self.assertNotIn('content_facet_attributes', read.call_args[0][1])
+                self.assertIn('content_facet_attributes', read.call_args[0][2])
 
     def test_delete_puppetclass(self):
         """Check that helper method is sane.


### PR DESCRIPTION
##### Description of changes

Fixes issue related to `environment` and `puppetclass` field for `Host` and `SmartVariable` Entity.

##### Functional demonstration

```
(Pdb) entities.Host().create()
nailgun.entities.Host(all_parameters=[{'priority': 0, 'created_at': '2022-01-07 06:11:01 UTC', 'updated_at': '2022-01-07 06:11:01 UTC', 'id': 3, 'name': 'host_registration_remote_execution', 'parameter_type': 'boolean', 'value': True}, {'priority': 0, 'created_at': '2022-01-07 06:09:33 UTC', 'updated_at': '2022-01-07 06:09:33 UTC', 'id': 1, 'name': 'host_registration_insights', 'parameter_type': 'boolean', 'value': True}, {'priority': 0, 'created_at': '2022-01-07 06:11:01 UTC', 'updated_at': '2022-01-07 06:11:01 UTC', 'id': 4, 'name': 'host_packages', 'parameter_type': 'string', 'value': ''}, {'priority': 0, 'created_at': '2022-01-07 06:11:02 UTC', 'updated_at': '2022-01-07 06:11:02 UTC', 'id': 6, 'name': 'enable-puppet5', 'parameter_type': 'string', 'value': 'true'}, {'priority': 0, 'created_at': '2022-01-07 06:11:02 UTC', 'updated_at': '2022-01-07 06:11:02 UTC', 'id': 5, 'name': 'enable-epel', 'parameter_type': 'string', 'value': 'false'}, {'priority': 0, 'created_at': '2022-01-07 06:10:59 UTC', 'updated_at': '2022-01-07 06:10:59 UTC', 'id': 2, 'name': 'ansible_roles_check_mode', 'parameter_type': 'boolean', 'value': False}], architecture=nailgun.entities.Architecture(id=4), build=False, capabilities=['build'], comment=None, compute_profile=None, compute_resource=None, domain=nailgun.entities.Domain(id=3), enabled=True, hostgroup=None, host_parameters_attributes=[], ip=None, location=nailgun.entities.Location(id=7), mac='58:5a:c2:a6:de:cf', managed=True, medium=nailgun.entities.Media(id=16), model=None, name='pimfxeoxxg.uvatldk1zk', operatingsystem=nailgun.entities.OperatingSystem(id=3), organization=nailgun.entities.Organization(id=8), owner=nailgun.entities.User(id=4), provision_method='build', ptable=nailgun.entities.PartitionTable(id=212), puppet_ca_proxy=None, puppet_proxy=None, realm=None, subnet=None, uuid=None, id=4, image=None, interface=[nailgun.entities.Interface(host=nailgun.entities.Host(id=4), id=4)], build_status_label='Installed', owner_type='User')
(Pdb) entities.Host().search(query={'search': f'name="dhcp-3-4.example.com"'})
[nailgun.entities.Host(architecture=nailgun.entities.Architecture(id=1), build=False, build_status_label='Installed', capabilities=['build'], comment=None, compute_profile=None, compute_resource=None, domain=nailgun.entities.Domain(id=1), enabled=True, hostgroup=None, image=None, ip='1.2.3.4', location=nailgun.entities.Location(id=2), mac='6:f:d:2:c:7', managed=False, medium=None, model=nailgun.entities.Model(id=1), name='dhcp-3-4.example.com', operatingsystem=nailgun.entities.OperatingSystem(id=1), organization=nailgun.entities.Organization(id=1), owner=None, provision_method='build', ptable=None, puppet_ca_proxy=None, puppet_proxy=None, realm=None, subnet=None, uuid=None, id=2)]

```
