### PR TITLE
sat 7.0 environment fix

### DIFF
--- a/nailgun/entity_mixins.py
+++ b/nailgun/entity_mixins.py
@@ -247,6 +247,9 @@ def _get_entity_id(field_name, attrs):
             return attrs[field_name]['id']
     if field_name_id in attrs:
         return attrs[field_name_id]
+    elif field_name == 'environment':
+        attrs['environment'] = []
+        return attrs['environment']
     else:
         raise MissingValueError(
             f'Cannot find a value for the "{field_name}" field. '
@@ -280,6 +283,9 @@ def _get_entity_ids(field_name, attrs):
         return [entity['id'] for entity in attrs[field_name]]
     elif plural_field_name in attrs:
         return [entity['id'] for entity in attrs[plural_field_name]]
+    elif field_name == 'environment':
+        attrs['environment'] = []
+        return attrs['environment']
     else:
         raise MissingValueError(
             f'Cannot find a value for the "{field_name}" field. '
@@ -698,9 +704,6 @@ class EntityReadMixin:
 
     """
 
-    ignore_fields = ['environment']
-    ignore_entities = ['Environment']
-
     def read_raw(self, params=None):
         """Get information about the current entity.
 
@@ -787,8 +790,6 @@ class EntityReadMixin:
             ignore = set()
 
         for field_name, field in entity.get_fields().items():
-            if field_name in self.ignore_fields and field.entity.__name__ in self.ignore_entities:
-                continue
             if field_name in ignore:
                 continue
             if isinstance(field, OneToOneField):


### PR DESCRIPTION
##### Description of changes
TLDR 
reverts #805 
intorucing the new way of reading environment

global ignore fields were problematic once the puppet was enabled via installer

with puppet enabled read the entity that uses environment, but read method already ignores the environment variable, so test fail, because asserts on environment has no values inside the object as result of ignorance

introducing new way 
during read if puppet is enabled there is environment it will be returned in `if` or `elif` clauses above 
if is not and attr is environment append the variable with empty  list and return it -> no more errors :+1: 

One think I am not sure about.  
Changed method `_get_entity_ids` is used also for search.  If you search for environment and there is none,  should the error be raised here ? I think it does not, but had not time to dig more.
Let me know what you think. 

I did test it with some tests 