### PR TITLE
#808 Ignore mirror_on_sync

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -6198,6 +6198,7 @@ class Repository(
             ignore = set()
         ignore.add('organization')
         ignore.add('upstream_password')
+        ignore.add('mirror_on_sync')
         return super().read(entity, attrs, ignore, params)
 
     def create_missing(self):

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1270,7 +1270,7 @@ class ReadTestCase(TestCase):
                 {'discovery', 'remote_execution_proxy', 'subnet_parameters_attributes'},
             ),
             (entities.Subscription, {'organization'}),
-            (entities.Repository, {'organization', 'upstream_password'}),
+            (entities.Repository, {'organization', 'upstream_password', 'mirror_on_sync'}),
             (entities.User, {'password'}),
             (entities.ScapContents, {'scap_file'}),
             (entities.TailoringFile, {'scap_file'}),


### PR DESCRIPTION
Parameter mirror_on_sync has been added to API
in Katello PR 9834.
This is not returned as part of JSON on entity creation.
Consequently, read() fails.
It could be workarounded by ignoring errors when reading
non-required parameters. Also, this would be fixed if
Satellite started returning that value.
This solves the issue without unnecessary changes
in Nailgun's guts that might break something.