### PR TITLE
Adding resume and cancel to Foreman Tasks

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -3084,6 +3084,8 @@ class ForemanTask(Entity, EntityReadMixin, EntitySearchMixin):
 
         bulk_resume
             /foreman_tasks/api/tasks/bulk_resume
+        bulk_cancel
+            /foreman_tasks/api/tasks/bulk_cancel
         bulk_search
             /foreman_tasks/api/tasks/bulk_search
         summary
@@ -3092,7 +3094,7 @@ class ForemanTask(Entity, EntityReadMixin, EntitySearchMixin):
         Otherwise, call ``super``.
 
         """
-        if which in ("bulk_resume", "bulk_search", "summary"):
+        if which in ("bulk_resume", "bulk_search", "summary", "bulk_cancel"):
             return f'{super().path(which="base")}/{which}'
         return super().path(which)
 
@@ -3140,6 +3142,44 @@ class ForemanTask(Entity, EntityReadMixin, EntitySearchMixin):
         kwargs = kwargs.copy()  # shadow the passed-in kwargs
         kwargs.update(self._server_config.get_client_kwargs())
         response = client.get(self.path('summary'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous, timeout)
+
+    def bulk_cancel(self, synchronous=True, timeout=None, **kwargs):
+        """Cancels the task(s).
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param timeout: Maximum number of seconds to wait until timing out.
+            Defaults to ``nailgun.entity_mixins.TASK_TIMEOUT``.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+
+        """
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.post(self.path('bulk_cancel'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous, timeout)
+
+    def bulk_resume(self, synchronous=True, timeout=None, **kwargs):
+        """Resumes the task(s).
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param timeout: Maximum number of seconds to wait until timing out.
+            Defaults to ``nailgun.entity_mixins.TASK_TIMEOUT``.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+
+        """
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.post(self.path('bulk_resume'), **kwargs)
         return _handle_response(response, self._server_config, synchronous, timeout)
 
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -2313,6 +2313,34 @@ class ForemanTaskTestCase(TestCase):
                     kwargs.get('timeout', None),
                 )
 
+    def test_bulk_resume(self):
+        """Call :meth:`nailgun.entities.ForemanTask.bulk_resume`."""
+        for kwargs in (
+            {},
+            {'task_ids': self.foreman_task.id},
+            {'search': gen_string('alpha')},
+            {'task_ids': self.foreman_task.id, 'search': gen_string('alpha')},
+        ):
+            with self.subTest(kwargs):
+                with mock.patch.object(client, 'post') as post:
+                    self.foreman_task.bulk_resume(**kwargs)
+                    self.assertEqual(post.call_count, 1)
+                    self.assertEqual(post.mock_calls[2][1][0].ACCEPTED, 202)
+
+    def test_bulk_cancel(self):
+        """Call :meth:`nailgun.entities.ForemanTask.bulk_cancel`."""
+        for kwargs in (
+            {},
+            {'task_ids': self.foreman_task.id},
+            {'search': gen_string('alpha')},
+            {'task_ids': self.foreman_task.id, 'search': gen_string('alpha')},
+        ):
+            with self.subTest(kwargs):
+                with mock.patch.object(client, 'post') as post:
+                    self.foreman_task.bulk_cancel(**kwargs)
+                    self.assertEqual(post.call_count, 1)
+                    self.assertEqual(post.mock_calls[2][1][0].ACCEPTED, 202)
+
 
 class ContentUploadTestCase(TestCase):
     """Tests for :class:`nailgun.entities.ContentUpload`."""


### PR DESCRIPTION
##### Description of changes

Adding basic methods to bulk cancel or bulk resume Foreman Tasks. Follows conventional POST request methods found in other entities. No impact to existing tests.

##### Upstream API documentation, plugin, or feature links

Not available upstream, but API endpoints can be found in Satellite 7 API doc under Foreman Tasks.

##### Functional demonstration

```python
# Demonstrate cancel function
sync_task = repo.sync(synchronous=False)
entities.ForemanTask().cancel(data={"task_ids": [sync_task['id']]})

# Demonstrate resume function
publish_task = cv.publish(synchronous=False)
# Task gets stopped from reboot
entities.ForemanTask().resume(data={"task_ids": [publish_task['id']]})
```

##### Additional Information

You'll notice that I'm used `task_ids` and passing a list of task ids. That is because these are bulk cancel and bulk resume end points. Passing no data would cancel/resume any cancellable/resumable tasks. You can specify one or multiple tasks using `task_ids`.

I'm also unsure if `synchronous` even makes a difference at these end points, but it seems to be commonly passed in all throughout entities.py.
