### PR TITLE
Fix mirror_on_sync

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -6124,12 +6124,16 @@ class Repository(
             'ignorable_content': entity_fields.ListField(),
             'label': entity_fields.StringField(),
             'last_sync': entity_fields.OneToOneField(ForemanTask),
-            'mirror_on_sync': entity_fields.BooleanField(),
+            'mirroring_policy': entity_fields.StringField(
+                choices=('additive', 'mirror_content_only', 'mirror_complete'),
+                default='additive',
+            ),
             'name': entity_fields.StringField(
                 required=True, str_type='alpha', length=(6, 12), unique=True
             ),
             'organization': entity_fields.OneToOneField(Organization),
             'product': entity_fields.OneToOneField(Product, required=True),
+            'retain_package_versions_count': entity_fields.StringField(),
             'unprotected': entity_fields.BooleanField(),
             'url': entity_fields.URLField(
                 default=_FAKE_YUM_REPO,


### PR DESCRIPTION
Mirror on sync has been changed.  Changing it to reflect what's in repo setup page.  Testing still needs to be done in order to see if it passes and may reflect changes in airgun as well.

Here's the error that I got when I tested:
```
entities.Repository(name=repo_name, product=product).create()

{HTTPError}422 Client Error: Unprocessable Entity for url: <sat>:443/katello/api/v2/repositories
```