### PR TITLE
Cherry pick environment fixes

### DIFF
--- a/nailgun/entity_mixins.py
+++ b/nailgun/entity_mixins.py
@@ -247,6 +247,9 @@ def _get_entity_id(field_name, attrs):
             return attrs[field_name]['id']
     if field_name_id in attrs:
         return attrs[field_name_id]
+    elif field_name == 'environment':
+        attrs['environment'] = []
+        return attrs['environment']
     else:
         raise MissingValueError(
             f'Cannot find a value for the "{field_name}" field. '
@@ -280,6 +283,9 @@ def _get_entity_ids(field_name, attrs):
         return [entity['id'] for entity in attrs[field_name]]
     elif plural_field_name in attrs:
         return [entity['id'] for entity in attrs[plural_field_name]]
+    elif field_name == 'environment':
+        attrs['environment'] = []
+        return attrs['environment']
     else:
         raise MissingValueError(
             f'Cannot find a value for the "{field_name}" field. '


### PR DESCRIPTION
##### Description of changes

Hi

this is cherry-pick of two recent change related to environment and puppetclass field

 Fix issue related to environment and puppetclass field for Host Entity. #806 

 sat 7.0 environment fix #807 

##### Functional demonstration

Provide an execution of the modified code, with ipython code blocks or screen shots.
You can exercise the code as raw API calls or using any other method.

Your contribution should include updates to the unit tests, covering the modified portions or adding new coverage.

Example:
```
# Demonstrate functional Snapshot read in ipython
In [1]: from nailgun.entities import Snapshot
In [2]: Snapshot(host='sat.instance.addr.com', id='snap_uuid').read()
Out [2]: <read method result>
```

##### Additional Information

Any additional notes for reviewers, comments about the change, TODO lists on WIP PRs, etc.
