### PR TITLE
Mirror_on_sync (read ignored) and mirroring_policy for 6.10.z

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -6181,6 +6181,7 @@ class Repository(
             'ignorable_content': entity_fields.ListField(),
             'label': entity_fields.StringField(),
             'last_sync': entity_fields.OneToOneField(ForemanTask),
+            'mirror_on_sync': entity_fields.BooleanField(),
             'mirroring_policy': entity_fields.StringField(
                 choices=('additive', 'mirror_content_only', 'mirror_complete'),
                 default='additive',
@@ -6190,7 +6191,6 @@ class Repository(
             ),
             'organization': entity_fields.OneToOneField(Organization),
             'product': entity_fields.OneToOneField(Product, required=True),
-            'retain_package_versions_count': entity_fields.StringField(),
             'unprotected': entity_fields.BooleanField(),
             'url': entity_fields.URLField(
                 default=_FAKE_YUM_REPO,

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -6181,12 +6181,16 @@ class Repository(
             'ignorable_content': entity_fields.ListField(),
             'label': entity_fields.StringField(),
             'last_sync': entity_fields.OneToOneField(ForemanTask),
-            'mirror_on_sync': entity_fields.BooleanField(),
+            'mirroring_policy': entity_fields.StringField(
+                choices=('additive', 'mirror_content_only', 'mirror_complete'),
+                default='additive',
+            ),
             'name': entity_fields.StringField(
                 required=True, str_type='alpha', length=(6, 12), unique=True
             ),
             'organization': entity_fields.OneToOneField(Organization),
             'product': entity_fields.OneToOneField(Product, required=True),
+            'retain_package_versions_count': entity_fields.StringField(),
             'unprotected': entity_fields.BooleanField(),
             'url': entity_fields.URLField(
                 default=_FAKE_YUM_REPO,

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -6259,6 +6259,7 @@ class Repository(
             ignore = set()
         ignore.add('organization')
         ignore.add('upstream_password')
+        ignore.add('mirror_on_sync')
         return super().read(entity, attrs, ignore, params)
 
     def create_missing(self):

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1278,7 +1278,7 @@ class ReadTestCase(TestCase):
                 {'discovery', 'remote_execution_proxy', 'subnet_parameters_attributes'},
             ),
             (entities.Subscription, {'organization'}),
-            (entities.Repository, {'organization', 'upstream_password'}),
+            (entities.Repository, {'organization', 'upstream_password', 'mirror_on_sync'}),
             (entities.User, {'password'}),
             (entities.ScapContents, {'scap_file'}),
             (entities.TailoringFile, {'scap_file'}),


### PR DESCRIPTION
##### Description of changes

The tests are failing in 6.10.z due to missing `mirror_on_sync` in reading the repo entity as the `mirroring_policy` feature is cherrypicked to 6.10.z from 7.0

#### Resolution

This PR allows both mirror_on_sync (the reading ignored) and mirroring_policy in 6.10.z. Keeping `mirror_on_sync` for 6.10.z wont fail the existing 6.10 tests.

##### Functional demonstration

