### PR TITLE
Removed py3.6 from checks as InsightsQE has updated to 3.9

### DIFF
--- a/.github/workflows/merge_to_master.yml
+++ b/.github/workflows/merge_to_master.yml
@@ -15,8 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # python 3.6 is still used by IQE integration pipeline
-        python-version: [3.6, 3.8, '3.10']
+        python-version: [3.8, '3.10']
     steps:
       - name: Checkout Nailgun
         uses: actions/checkout@v2
@@ -71,10 +70,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - name: Setup python 3.6
+      - name: Setup python 3.8
         uses: actions/setup-python@v1
         with:
-          python-version: 3.6
+          python-version: 3.8
       - name: Install pypa/build
         run: python -m pip install build --user
       - name: Build a binary wheel and a source tarball

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.8, '3.10']
+        python-version: [3.8, '3.10']
     steps:
       - name: Checkout Nailgun
         uses: actions/checkout@v2


### PR DESCRIPTION
##### Description of changes

Removing the python 3.6 checks from GitHub Actions since it was being used by InsightsQE CI to execute the FiFi/Insights tests using nailgun having the python 3.6 version but now they have moved to python 3.9!

