### PR TITLE
Add token among host fields

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -3704,6 +3704,7 @@ class Host(
             'realm': entity_fields.OneToOneField(Realm),
             'root_pass': entity_fields.StringField(length=(8, 30), str_type='alpha'),
             'subnet': entity_fields.OneToOneField(Subnet),
+            'token': entity_fields.StringField(),
             'traces_status': entity_fields.IntegerField(min_val=-1, max_val=2),
             'traces_status_label': entity_fields.StringField(),
             'uuid': entity_fields.StringField(),


### PR DESCRIPTION
##### Description of changes

Just adding the `token` field in the Host class.

##### Functional demonstration

```
>>> entities.Host().search(query={'search': 'joey-altieri.vms.sat.rdu2.redhat.com'})[0].token
'6d361318-95e9-4d30-8543-bfa53242fd80'
```

##### Additional Information

I would like to use this field in a test where I would check rendered provisioning template for a puppet-specific content.
