### PR TITLE
Add token into the ignore list

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -4242,6 +4242,7 @@ class Host(
         ignore.add('root_pass')
         ignore.add('included')
         ignore.add('excluded')
+        ignore.add('token')
         # Image entity requires compute_resource_id to initialize as it is
         # part of its path. The thing is that entity_mixins.read() initializes
         # entities by id only.


### PR DESCRIPTION
##### Description of changes

In #817 I added token among Host fields but didn't realize it's not returned every time on Host().create().
Adding to the ignore list now.

##### Functional demonstration

```
$ pytest tests/foreman/api/test_host.py::test_positive_end_to_end_with_puppet_class
============================================= test session starts =============================================
platform linux -- Python 3.9.9, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/vsedmik/PycharmProjects/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, services-2.2.1, ibutsu-2.0.2, xdist-2.5.0, reportportal-5.0.11, mock-3.6.1
collected 1 item                                                                                              

tests/foreman/api/test_host.py .                                                                        [100%]

============================================= 1 passed in 59.17s ==============================================
```

Without this fix the test can not pass and ends up badly with `KeyError: 'token'`
