### PR TITLE
Condition for token ignore

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -4237,12 +4237,13 @@ class Host(
         if 'traces_status' not in attrs and 'traces_status_label' not in attrs:
             ignore.add('traces_status')
             ignore.add('traces_status_label')
+        if 'token' not in attrs:
+            ignore.add('token')
         ignore.add('compute_attributes')
         ignore.add('interfaces_attributes')
         ignore.add('root_pass')
         ignore.add('included')
         ignore.add('excluded')
-        ignore.add('token')
         # Image entity requires compute_resource_id to initialize as it is
         # part of its path. The thing is that entity_mixins.read() initializes
         # entities by id only.


### PR DESCRIPTION
##### Description of changes

In #819 I added the token field to the ignore list as it caused problems for other host tests, but missed @tstrych's comment while being on PTO. Fixing it now.

##### Functional demonstration

The first test uses the `token` field, the second does not (it's not returned from SAT there), both passed.

```
(venv39) [vsedmik@localhost robottelo]$ pytest tests/foreman/api/test_puppetbootstrap.py tests/foreman/api/test_host.py::test_positive_end_to_end_with_puppet_class
=========================================================================================================== test session starts ===========================================================================================================
platform linux -- Python 3.9.9, pytest-6.2.5, py-1.10.0, pluggy-0.13.1
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/vsedmik/PycharmProjects/robottelo, configfile: pyproject.toml
plugins: forked-1.3.0, services-2.2.1, mock-3.7.0, ibutsu-2.0.2, xdist-2.5.0, reportportal-5.0.12
collected 2 items                                                                                                                                                                                                                         

tests/foreman/api/test_puppetbootstrap.py .                                                                                                                                                                                         [ 50%]
tests/foreman/api/test_host.py .                                                                                                                                                                                                    [100%]

=============================================================================================== 2 passed, 28 warnings in 1636.42s (0:27:16) ===============================================================================================
```
