### PR TITLE
Fix override value

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -5449,10 +5449,17 @@ class OverrideValue(
         # object and passing it to super() lets this one avoid changing state.
         if entity is None:
             if hasattr(self, 'smart_class_parameter'):
-                entity = type(self)(
-                    self._server_config,
-                    smart_class_parameter=self.smart_class_parameter,
-                )
+                try:
+                    entity = type(self)(
+                        self._server_config,
+                        smart_class_parameter=self.smart_class_parameter,
+                    )
+                except TypeError:
+                    # in the event that an entity's init is overwritten
+                    # with a positional server_config
+                    entity = type(self)(
+                        smart_class_parameter=self.smart_class_parameter,
+                    )
         if ignore is None:
             ignore = set()
         ignore.update(['smart_class_parameter'])


### PR DESCRIPTION
##### Description of changes

In test fixes I need to replace `entities.OverrideValue(..).create()` with `default_sat.api.OverrideValue(..).create()`.
Without this the entity creation fails with `TypeError: __init__() got multiple values for argument 'server_config'`.

##### Functional demonstration
Robottelo classparam tests, original vs. fixed results:
```
tests/foreman/api/test_classparameters.py ...............F..FFFFFF.F..F
vs.
tests/foreman/api/test_classparameters.py .........................F...
```
(the last `F` is unrelated, fixed in https://github.com/SatelliteQE/robottelo/pull/9438)
