### PR TITLE
Add more OS to list for more coverage

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -73,13 +73,18 @@ _OPERATING_SYSTEMS = (
     'Altlinux',
     'Archlinux',
     'Debian',
+    'Coreos',
     'Freebsd',
     'Gentoo',
     'Junos',
+    'NXOS',
+    'Rancheros',
     'Redhat',
     'Solaris',
     'Suse',
+    'VRP',
     'Windows',
+    'Xenserver',
 )
 
 


### PR DESCRIPTION
There were more OS added to the list.  I've removed 'Debian' due to bz: 1709683.

