### PR TITLE
add ssl cert to repository

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -6121,6 +6121,7 @@ class Repository(
             ),
             'full_path': entity_fields.StringField(),
             'gpg_key': entity_fields.OneToOneField(ContentCredential),
+            'ssl_ca_cert': entity_fields.OneToOneField(ContentCredential),
             'ignorable_content': entity_fields.ListField(),
             'label': entity_fields.StringField(),
             'last_sync': entity_fields.OneToOneField(ForemanTask),


### PR DESCRIPTION
##### Description of changes

Adding option for SSL CA cert to repository entity. This option will be used in my upcoming PR for the convert2rhel feature in robottelo.

##### Functional demonstration

See linked robottelo PR.


