### PR TITLE
Fix for container_management-content

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -6178,7 +6178,7 @@ class Repository(
             # Just setting `str_type='alpha'` will fail with this error:
             # {"docker_upstream_name":["must be a valid docker name"]}}
             'docker_upstream_name': entity_fields.StringField(default='busybox'),
-            'docker_tags_whitelist': entity_fields.ListField(),
+            'include_tags': entity_fields.StringField(),
             'download_policy': entity_fields.StringField(
                 choices=('background', 'immediate', 'on_demand'),
                 default='immediate',


### PR DESCRIPTION
Minor change to fix - **test_positive_tag_whitelist**
Limit sync tag parameter was earlier used for white listing of tags
which now is taken care of by include/exclude tags.

BZ : https://bugzilla.redhat.com/show_bug.cgi?id=2057782
BZ : https://bugzilla.redhat.com/show_bug.cgi?id=2057848