### PR TITLE
Add nutanix support

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -7910,7 +7910,7 @@ class VirtWhoConfig(
             'hypervisor_password': entity_fields.StringField(),
             'hypervisor_server': entity_fields.StringField(required=True),
             'hypervisor_type': entity_fields.StringField(
-                choices=['esx', 'rhevm', 'hyperv', 'xen', 'libvirt', 'kubevirt'],
+                choices=['esx', 'rhevm', 'hyperv', 'xen', 'libvirt', 'kubevirt', 'ahv'],
                 default='libvirt',
                 required=True,
             ),
@@ -7924,6 +7924,7 @@ class VirtWhoConfig(
             'satellite_url': entity_fields.StringField(required=True),
             'status': entity_fields.StringField(),
             'whitelist': entity_fields.StringField(),
+            'prism_flavor': entity_fields.StringField(required=True),
         }
         self._meta = {
             'api_path': 'foreman_virt_who_configure/api/v2/configs',

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -7910,7 +7910,7 @@ class VirtWhoConfig(
             'hypervisor_password': entity_fields.StringField(),
             'hypervisor_server': entity_fields.StringField(required=True),
             'hypervisor_type': entity_fields.StringField(
-                choices=['esx', 'rhevm', 'hyperv', 'xen', 'libvirt', 'kubevirt', 'ahv'],
+                choices=['esx', 'hyperv', 'libvirt', 'kubevirt', 'ahv'],
                 default='libvirt',
                 required=True,
             ),

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -7925,7 +7925,7 @@ class VirtWhoConfig(
             'status': entity_fields.StringField(),
             'whitelist': entity_fields.StringField(),
             'prism_flavor': entity_fields.StringField(
-                choices=['central', 'element'], default='element', required=True
+                choices=['central', 'element'], default='element'
             ),
         }
         self._meta = {

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -7924,7 +7924,9 @@ class VirtWhoConfig(
             'satellite_url': entity_fields.StringField(required=True),
             'status': entity_fields.StringField(),
             'whitelist': entity_fields.StringField(),
-            'prism_flavor': entity_fields.StringField(required=True),
+            'prism_flavor': entity_fields.StringField(
+                choices=['central', 'element'], default='element', required=True
+            ),
         }
         self._meta = {
             'api_path': 'foreman_virt_who_configure/api/v2/configs',


### PR DESCRIPTION
##### Description of changes

Add the support for Nutanix

##### Upstream API documentation, plugin, or feature links

POST /foreman_virt_who_configure/api/v2/configs | Create a virt-who configuration

`foreman_virt_who_configure_config[prism_flavor]optional , nil allowed | Select the Prism flavor you are connecting toValidations:Must be one of: central, element.`


