### PR TITLE
Add kubeconfig_path and update hypervisor_server/username for kubevirt support

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -7908,13 +7908,13 @@ class VirtWhoConfig(
                 choices=['hostname', 'uuid', 'hwuuid'], default='hostname', required=True
             ),
             'hypervisor_password': entity_fields.StringField(),
-            'hypervisor_server': entity_fields.StringField(required=True),
+            'hypervisor_server': entity_fields.StringField(),
             'hypervisor_type': entity_fields.StringField(
                 choices=['esx', 'hyperv', 'libvirt', 'kubevirt', 'ahv'],
                 default='libvirt',
                 required=True,
             ),
-            'hypervisor_username': entity_fields.StringField(required=True),
+            'hypervisor_username': entity_fields.StringField(),
             'interval': entity_fields.IntegerField(
                 choices=[60, 120, 240, 480, 720, 1440, 2880, 4320], default=120, required=True
             ),
@@ -7927,6 +7927,7 @@ class VirtWhoConfig(
             'prism_flavor': entity_fields.StringField(
                 choices=['central', 'element'], default='element'
             ),
+            'kubeconfig_path': entity_fields.StringField(),
         }
         self._meta = {
             'api_path': 'foreman_virt_who_configure/api/v2/configs',


### PR DESCRIPTION
##### Description of changes

update kubeconfig_path and hypervisor_server/username for kubevirt support
1. Add kubeconfig_path to support kubevirt
2. Update hypervisor_server and hypervisor_username to not required to support kubevirt and according apidoc

Kubevirt cases: Pass
##### Upstream API documentation, plugin, or feature links

https://satelliteserver/apidoc/v2/configs/create.html

```
foreman_virt_who_configure_config[hypervisor_server]optional , nil allowed | Fully qualified host name or IP address of the hypervisorValidations:String
-- | --
foreman_virt_who_configure_config[hypervisor_username]optional , nil allowed | Account name by which virt-who is to connect to the hypervisor.Validations:String


foreman_virt_who_configure_config[kubeconfig_path]optional , nil allowed | Configuration file containing details about how to connect to the cluster and authentication details.Validations:String
-- | --

```

Link to any relevant upstream API documentation that relates to the content of the PR.

##### Functional demonstration



##### Additional Information


