### PR TITLE
Adding Webhooks entity

### DIFF
--- a/nailgun/entity_fields.py
+++ b/nailgun/entity_fields.py
@@ -255,8 +255,15 @@ class OneToManyField(Field):
 
 
 class URLField(StringField):
-    """Field that represents an URL"""
+    """Field that represents an URL
+
+    :param str scheme: The URL scheme can be one of ['http', 'https', 'ftp']
+    """
+
+    def __init__(self, scheme=None, *args, **kwargs):
+        self.scheme = scheme
+        super().__init__(*args, **kwargs)
 
     def gen_value(self):
         """Return a value suitable for a :class:`URLField`."""
-        return gen_url(subdomain=gen_alpha())
+        return gen_url(subdomain=gen_alpha(), scheme=self.scheme)


### PR DESCRIPTION
##### Description of changes

Added a new entity class for Webhooks. There is quite a long list of events that are valid for creating a Webhook. The Satellite API returns them as a list from `/api/webhooks/events`. That is why I am updating the `event` field in the create function. I also had to change the entity_field for URLField in order to provide only URLs starting with `http`.

##### Upstream API documentation, plugin, or feature links

See /apidoc/v2/webhooks

##### Functional demonstration
```
[in] hook = entities.Webhooks().create()
[in] hook
[out] nailgun.entities.Webhooks(name='𘌫彩ꞗ𓄨叵', target_url='http://fbFPSQNDiy.org', http_method='POST', event='actions.remote_execution.run_host_job_succeeded.event.foreman', http_content_type='application/json', enabled=True, verify_ssl=True, ssl_ca_certs=None, user=None, http_headers=None, id=217)

[in] hook.name = 'test'
[in] hook.update(['name'])
[out] nailgun.entities.Webhooks(name='test', target_url='http://fbFPSQNDiy.org', http_method='POST', event='actions.remote_execution.run_host_job_succeeded.event.foreman', http_content_type='application/json', enabled=True, verify_ssl=True, ssl_ca_certs=None, user=None, http_headers=None, id=217)

[in] hook.delete()
[out] {'id': 217, 'name': 'test', 'target_url': 'http://fbFPSQNDiy.org', 'events': ['actions.remote_execu...nt.foreman'], 'created_at': '2022-06-29T17:20:51.405Z', 'updated_at': '2022-06-29T17:21:32.332Z', 'webhook_template_id': 213, 'http_method': 'POST', 'http_content_type': 'application/json', 'enabled': True, 'verify_ssl': True, 'ssl_ca_certs': None, 'user': None, 'password': None, ...}
```

##### Additional Information

Would like any suggestions for better ways to inject the `event` options into the class on create.
