### PR TITLE
Adding build, org, and loc to discovered host

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -1080,6 +1080,9 @@ class DiscoveredHost(
             'mac': entity_fields.MACAddressField(required=True),
             'hostgroup': entity_fields.OneToOneField(HostGroup),
             'root_pass': entity_fields.StringField(),
+            'build': entity_fields.BooleanField(default=False),
+            'organization': entity_fields.OneToOneField(Organization),
+            'location': entity_fields.OneToOneField(Location),
         }
         self._meta = {
             'api_path': '/api/v2/discovered_hosts',
@@ -1165,13 +1168,16 @@ class DiscoveredHost(
         return _handle_response(response, self._server_config, synchronous, timeout)
 
     def read(self, entity=None, attrs=None, ignore=None, params=None):
-        """Make sure, ``ip, mac, root_pass and hostgroup`` are in the ignore list for read"""
+        """Make sure, everything except `id` and `name` are in the ignore list for read"""
         if ignore is None:
             ignore = set()
         ignore.add('ip')
         ignore.add('mac')
         ignore.add('root_pass')
         ignore.add('hostgroup')
+        ignore.add('build')
+        ignore.add('organization')
+        ignore.add('location')
         return super().read(entity, attrs, ignore, params)
 
     def reboot(self, synchronous=True, timeout=None, **kwargs):

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1278,7 +1278,10 @@ class ReadTestCase(TestCase):
             (entities.TailoringFile, {'scap_file'}),
             (entities.VirtWhoConfig, {'hypervisor_password', 'http_proxy_id'}),
             (entities.VMWareComputeResource, {'password'}),
-            (entities.DiscoveredHost, {'ip', 'mac', 'root_pass', 'hostgroup'}),
+            (
+                entities.DiscoveredHost,
+                {'ip', 'mac', 'root_pass', 'hostgroup', 'build', 'organization', 'location'},
+            ),
         ):
             with self.subTest(entity):
                 with mock.patch.object(EntityReadMixin, 'read') as read, mock.patch.object(


### PR DESCRIPTION
##### Description of changes

Need to add a field for `build`, `location`, and `organization` to DiscoveredHost. `True` for build forces the host to boot into anaconda and install the kickstart repo. `False` will boot the host's default template. Default behavior is `False`.

##### Upstream API documentation, plugin, or feature links

See PUT /api/v2/discovered_hosts/:id

##### Functional demonstration

```
discovered_host.build = True
discovered_host.update(['build'])
```
