### PR TITLE
Alligning ACP GHA with Robottelo

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,1 @@
+addAssignees: author

--- a/.github/workflows/auto_assignment.yaml
+++ b/.github/workflows/auto_assignment.yaml
@@ -1,0 +1,21 @@
+name: 'Auto Assign'
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - ready_for_review
+      - reopened
+      - synchronize
+
+
+jobs:
+  add-assignees: # This needed to create the gh issue in case of failed auto-cherry-pick
+    name: Add author to assignee
+    if: "!contains(github.event.pull_request.labels.*.name, 'Auto_Cherry_Picked')"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: kentaro-m/auto-assign-action@v1.2.4
+        with:
+          repo-token: "${{ secrets.CHERRYPICK_PAT || github.token }}"
+          configuration-path: ".github/auto_assign.yml"

--- a/.github/workflows/auto_cherry_pick.yml
+++ b/.github/workflows/auto_cherry_pick.yml
@@ -7,37 +7,68 @@ on:
       - closed
 
 jobs:
-  branch-matrix:
+  previous-branch:
     if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'CherryPick')
-    name: Generate a branch matrix to apply cherrypicks
+    name: Calculate previous branch name
     runs-on: ubuntu-latest
     outputs:
-      branches: ${{ steps.set-matrix.outputs.branches }}
+      previous_branch: ${{ steps.set-branch.outputs.previous_branch }}
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - id: set-matrix
-        run: echo "::set-output name=branches::$(git branch -rl --sort=-authordate 'origin/6.*.z' --format='%(refname:lstrip=-1)' | head -n2 | jq -cnR '[inputs | select(length>0)]')"
-  auto_cherry_picking:
+      - id: set-branch
+        run: echo "previous_branch=$(if [ $GITHUB_BASE_REF  == 'master' ]; then echo $(git branch -rl 'origin/6.*.z' --format='%(refname:lstrip=-1)' | sort --version-sort | tail -n1); else echo '6.'$(($(echo $GITHUB_BASE_REF | cut -d. -f2) - 1))'.z'; fi)" >> $GITHUB_OUTPUT
+
+  auto-cherry-pick:
+    name: Auto Cherry Pick to previous branch
     if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'CherryPick')
-    name: Auto Cherry picking
-    needs: branch-matrix
+    needs: previous-branch
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        to_branch: ${{ fromJson(needs.branch-matrix.outputs.branches) }}
+    env:
+      TO_BRANCH: ${{ needs.previous-branch.outputs.previous_branch }}
     steps:
-      - name: Checkout Nailgun
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-        if: matrix.to_branch != github.base_ref
-      - name: Cherry pick into ${{ matrix.to_branch }}
-        uses: carloscastrojumo/github-cherry-pick-action@v1.0.2
+      - name: Cherry pick into ${{ env.TO_BRANCH }}
+        uses: jyejare/github-cherry-pick-action@main
         with:
-          branch: ${{ matrix.to_branch }}
+          token: ${{ secrets.CHERRYPICK_PAT }}
+          branch: ${{ env.TO_BRANCH }}
           labels: |
             Auto_Cherry_Picked
-        # skipping PRs remote target_branch from cherrypicking into itself
-        if: matrix.to_branch != github.base_ref
+            ${{ env.TO_BRANCH }}
+          assignees: "${{ github.event.pull_request.assignee.login }}"
+
+  create-issue:
+    runs-on: ubuntu-latest
+    if: ${{ always() && contains(join(needs.*.result, ','), 'failure') }}
+    needs: [previous-branch, auto-cherry-pick]
+    env:
+      TO_BRANCH: ${{ needs.previous-branch.outputs.previous_branch }}
+    steps:
+      - name: Create Issue on Failed Auto Cherrypick
+        uses: dacbd/create-issue-action@main
+        with:
+          token: ${{ secrets.CHERRYPICK_PAT }}
+          title: "[Failed-AutoCherryPick] - ${{ github.event.pull_request.title }}"
+          body: |
+            #### Auto-Cherry-Pick WorkFlow Failure:
+            - To Branch: ${{ env.TO_BRANCH }}
+            - [Failed Cherrypick Action](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+            - [Parent Pull Request](https://github.com/${{ github.repository }}/pull/${{ github.event.number }})
+          labels: Failed_AutoCherryPick,${{ env.TO_BRANCH }}
+          assignees: "${{ github.event.pull_request.assignee.login }}"
+
+  google-chat-notification:
+    runs-on: ubuntu-latest
+    if: ${{ always() && contains(join(needs.*.result, ','), 'failure') }}
+    needs: auto-cherry-pick
+    steps:
+      - name: Google Chat Notification - Nailgun
+        uses: Co-qn/google-chat-notification@releases/v1
+        with:
+          name: "${{ github.event.pull_request.title }}"
+          url: ${{ secrets.GCHAT_REVIEWERS_WEBHOOK }}
+          status: failure


### PR DESCRIPTION
##### Description of changes

Aligning AutoCherrypick GHA with Robottelo

- Mainly, switching to `https://github.com/jyejare/github-cherry-pick-action` from existing where we have new features satisfies our needs. One can see the recent commits we made after forking the original repo.
- Adding branch labels
- Assigning the autocherrypicked PR to original user
- Switching to the one branch per auto cherry-pick strategy from existing n-2
- Adding Notifications to GChat group improvement on failed auto cherrypick
- Adding Create issue on failed auto cherrypick
- [New] Added AutoAssign