### PR TITLE
fix for ContentView server_config auth values

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2489,6 +2489,15 @@ class ContentView(
         attrs = attrs or self.read_json()
         ignore = ignore or set()
         ignore.add('content_view_component')
+        if entity is None:
+            try:
+                entity = type(self)(self._server_config)
+            except TypeError:
+                # in the event that an entity's init is overwritten
+                # with a positional server_config
+                entity = type(self)()
+                if self._server_config:
+                    entity._server_config = self._server_config
         result = super().read(entity, attrs, ignore, params)
         if 'content_view_components' in attrs and attrs['content_view_components']:
             result.content_view_component = [


### PR DESCRIPTION
##### Description of problem

- from api/tests function of test_contentview.py at [line 1176](https://github.com/SatelliteQE/robottelo/blob/master/tests/foreman/api/test_contentview.py#L1176) after call to read() get resolve auth values of "custom user" changes to "admin user". 
- server_config changed inside EntityReadMixin > read() [line 826](https://github.com/SatelliteQE/nailgun/blob/master/nailgun/entity_mixins.py#L826)
- So the custom user with readonly role able to perform other operations on ContentView, operations like delete, update, publish and pramote.