### PR TITLE
[6.13.z] Changing inputs as a optional parameter in job-invocation

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -1656,8 +1656,8 @@ class JobInvocation(Entity, EntityReadMixin, EntitySearchMixin):
                     job_template_id/feature,
                     targeting_type,
                     search_query/bookmark_id,
-                    inputs
                 optional:
+                    inputs,
                     description_format,
                     concurrency_control
                     scheduling,
@@ -1675,9 +1675,8 @@ class JobInvocation(Entity, EntityReadMixin, EntitySearchMixin):
                 raise KeyError('Provide either job_template_id or feature value')
             if 'search_query' not in kwargs['data'] and 'bookmark_id' not in kwargs['data']:
                 raise KeyError('Provide either search_query or bookmark_id value')
-            for param_name in ['targeting_type', 'inputs']:
-                if param_name not in kwargs['data']:
-                    raise KeyError(f'Provide {param_name} value')
+            if 'targeting_type' not in kwargs['data']:
+                raise KeyError('Provide targeting_type value')
             kwargs['data'] = {'job_invocation': kwargs['data']}
         response = client.post(self.path('base'), **kwargs)
         response.raise_for_status()

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -3798,7 +3798,7 @@ class JobInvocationTestCase(TestCase):
             {'feature': 'foo', 'inputs': 'ls'},
             {'job_template_id': 1, 'search_query': 'foo'},
             {'feature': 'foo', 'bookmark_id': 1, 'inputs': 'ls'},
-            {'feature': 'foo', 'bookmark_id': 1, 'targeting_type': 'foo'},
+            {'feature': 'foo', 'job_template_id': 1, 'targeting_type': 'foo'},
         ]
         for data in data_list:
             with self.assertRaises(KeyError):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/nailgun/pull/866

Apidoc snippet:
```
job_invocation[inputs]optional , nil allowed | Inputs to useValidations:Hash
```
Usage:
```
job = entities.JobInvocation().run(
            data={
                'job_template_id': 89,
                'inputs': {'command': 'ls'},
                'targeting_type': 'static_query',
                'search_query': f'name = {rhel7_contenthost.hostname}',
            }
        )
```
I came across this when I was trying to invoke an ansible job on a host, which raises an key error for not having an input.




