### PR TITLE
[6.12.z] No Cherrypick by default

### DIFF
--- a/.github/workflows/auto_cherry_pick.yml
+++ b/.github/workflows/auto_cherry_pick.yml
@@ -40,6 +40,7 @@ jobs:
           branch: ${{ matrix.label }}
           labels: |
             Auto_Cherry_Picked
+            No-CherryPick
             ${{ matrix.label }}
           assignees: ${{ env.assignee }}
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/nailgun/pull/874

##### Description of changes

Cherrypicking of Robottelo PR https://github.com/SatelliteQE/robottelo/pull/10436 that says:
```
By default the AutoCherrypicked PRs to labeled branches need not to again decide for auto-cherrypicking. The decision has should have already been made in parent PR itself as to what branch the PR will be cherrypicked and assigned branch labels.
```
