### PR TITLE
Change path to point to proper endpoint

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -4322,7 +4322,7 @@ class Host(
         """
         if which in (
             'assign_ansible_roles',
-            'list_ansible_roles',
+            'ansible_roles',
             'disassociate',
             'enc',
             'errata',

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -325,7 +325,7 @@ class PathTestCase(TestCase):
             (entities.Host, 'packages'),
             (entities.Host, 'puppetclass_ids'),
             (entities.Host, 'smart_class_parameters'),
-            (entities.Host, 'list_ansible_roles'),
+            (entities.Host, 'ansible_roles'),
             (entities.Host, 'assign_ansible_roles'),
             (entities.HostGroup, 'clone'),
             (entities.HostGroup, 'puppetclass_ids'),


### PR DESCRIPTION
Small update to Ansible Nailgun PR recently merged, this properly sets the path to the endpoint it needs to point to.