### PR TITLE
Feature changes for GCE plugin

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -1519,15 +1519,20 @@ class GCEComputeResource(AbstractComputeResource):
 
     def __init__(self, server_config=None, **kwargs):
         self._fields = {
-            'email': entity_fields.StringField(required=True),
             'key_path': entity_fields.StringField(required=True),
-            'project': entity_fields.StringField(required=True),
             'zone': entity_fields.StringField(),
         }
         super().__init__(server_config, **kwargs)
         self._fields['provider'].default = 'GCE'
         self._fields['provider'].required = True
         self._fields['provider_friendly_name'].default = 'GCE'
+
+    def read(self, entity=None, attrs=None, ignore=None, params=None):
+        """Make sure, ``key_path`` is in the ignore list for read"""
+        if ignore is None:
+            ignore = set()
+        ignore.add('key_path')
+        return super().read(entity, attrs, ignore, params)
 
 
 class AzureRMComputeResource(AbstractComputeResource):


### PR DESCRIPTION
Email and project parameters are removed with the incoming of GCE as a plugin in 6.13 hence removing the params, also key_path is set to ignore as it's not getting collected in the response of API call

Signed-off-by: Adarsh Dubey <addubey@redhat.com>


