### PR TITLE
[6.11.z] Test fix for Networking tests

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -5452,7 +5452,9 @@ class Parameter(Entity, EntityCreateMixin, EntityDeleteMixin, EntityReadMixin, E
             ),
             'priority': entity_fields.IntegerField(),
             'value': entity_fields.StringField(required=True),
-            'parameter_type': entity_fields.StringField(required=True),
+            'parameter_type': entity_fields.StringField(
+                choices=('string', 'boolean', 'integer', 'real', 'array', 'hash', 'yaml', 'json')
+            ),
         }
         self._path_fields = {
             'domain': entity_fields.OneToOneField(Domain),


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/nailgun/pull/894

##### Description of changes

Adding `choices` for `parameter_type` field as it was populating random string for parameter_type causing Networking tests to fail

```
$ pytest tests/foreman/api/test_subnet.py
========================================= test session starts =================================================================
platform linux -- Python 3.11.1, pytest-7.2.1, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/sganar/satellite/robottelo, configfile: pyproject.toml
plugins: xdist-3.1.0, services-2.2.1, mock-3.10.0, cov-3.0.0, reportportal-5.1.3, ibutsu-2.2.4
collected 47 items / 7 deselected / 40 selected                                                                                                                                                                                                                                          

tests/foreman/api/test_subnet.py ........................................                                                                                                                                                                                                          [100%]

================================= 40 passed, 7 deselected  in 157.55s (0:02:37) =======================================================
```