### PR TITLE
Add support for reading a Provisioning Template

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -4344,6 +4344,7 @@ class Host(
             'disassociate',
             'traces',
             'traces/resolve',
+            'template',
         ):
             return f'{super().path(which="self")}/{which}'
         elif which in (
@@ -4408,6 +4409,33 @@ class Host(
         return _handle_response(
             client.delete(path, **kwargs), self._server_config, synchronous, timeout
         )
+
+    def read_template(self, synchronous=True, timeout=None, **kwargs):
+        """Fetches and reads the provisioning template for given host
+
+        Here is an example of how to use this method::
+            host.preview_template(data={'template_kind': 'iPXE'})
+
+        Constructs path:
+           api/hosts/:id/template/:kind
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param timeout: Maximum number of seconds to wait until timing out.
+            Defaults to ``nailgun.entity_mixins.TASK_TIMEOUT``.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all content decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+
+        """
+        kwargs = kwargs.copy()
+        kwargs.update(self._server_config.get_client_kwargs())
+        kind = f'{kwargs["data"].pop("template_kind")}'
+        path = f'{self.path("template")}/{kind}'
+        response = client.get(path, **kwargs)
+        return _handle_response(response, self._server_config, synchronous, timeout)
 
     def list_scparams(self, synchronous=True, timeout=None, **kwargs):
         """List all smart class parameters

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -4414,7 +4414,7 @@ class Host(
         """Fetches and reads the provisioning template for given host
 
         Here is an example of how to use this method::
-            host.preview_template(data={'template_kind': 'iPXE'})
+            host.read_template(data={'template_kind': 'iPXE'})
 
         Constructs path:
            api/hosts/:id/template/:kind


### PR DESCRIPTION
 Adding support for reading the Provisioning Template

 **Reason for this addition**: There are several closed loop scenarios where we need to read the content of provisioning templates.