### PR TITLE
[6.13.z] ahv_internal_debug option support for virt-who configuration

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -7972,6 +7972,7 @@ class VirtWhoConfig(
                 choices=['central', 'element'], default='element'
             ),
             'kubeconfig_path': entity_fields.StringField(),
+            'ahv_internal_debug': entity_fields.BooleanField(),
         }
         self._meta = {
             'api_path': 'foreman_virt_who_configure/api/v2/configs',


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/nailgun/pull/889

##### Description of changes

ahv_internal_debug option support for virt-who configuration

##### Upstream API documentation, plugin, or feature links

https://<satellite-server>/apidoc/v2/configs/create.en.html

```
foreman_virt_who_configure_config[ahv_internal_debug]optional , nil allowed | Option Enable debugging output is required to enable AHV internal debug. It provides extra AHV debug information when both options are enabledValidations:Must be one of: true, false, 1, 0.
-- | --
```

##### Functional demonstration
Can create  and update this option virt-who configuration
target_sat.api.VirtWhoConfig(**form_data).create()
virtwho_config.update(['ahv_internal_debug'])


Example:
```
target_sat.api.VirtWhoConfig(**form_data).create()
virtwho_config.update(['ahv_internal_debug'])
```

##### Additional Information

Test cases :PASS 
```
(robottelo_vv) [yanpliu@yanpliu robottelo]$ pytest ./tests/foreman/virtwho/api/test_nutanix.py -k test_positive_ahv_internal_debug_option 
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.10.9, pytest-7.2.0, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/yanpliu/gitrepository/robottelo, configfile: pyproject.toml
plugins: cov-3.0.0, xdist-3.1.0, services-2.2.1, mock-3.10.0, reportportal-5.1.3, ibutsu-2.2.4
collected 7 items / 13 deselected / -6 selected                                                                                                                                                                   

tests/foreman/virtwho/api/test_nutanix.py .                                                                                                                                                                 [100%]

================================================================================================ warnings summary =================================================================================================
tests/foreman/virtwho/api/test_nutanix.py::TestVirtWhoConfigforNutanix::test_positive_ahv_internal_debug_option
tests/foreman/virtwho/api/test_nutanix.py::TestVirtWhoConfigforNutanix::test_positive_ahv_internal_debug_option
tests/foreman/virtwho/api/test_nutanix.py::TestVirtWhoConfigforNutanix::test_positive_ahv_internal_debug_option
tests/foreman/virtwho/api/test_nutanix.py::TestVirtWhoConfigforNutanix::test_positive_ahv_internal_debug_option
tests/foreman/virtwho/api/test_nutanix.py::TestVirtWhoConfigforNutanix::test_positive_ahv_internal_debug_option
  /home/yanpliu/data/virtualenv_3_10_9/robottelo_vv/lib/python3.10/site-packages/urllib3/connectionpool.py:1045: InsecureRequestWarning: Unverified HTTPS request is being made to host 'dell-per740-68-vm-07.lab.eng.pek2.redhat.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================= 1 passed, 13 deselected, 5 warnings in 87.68s (0:01:27) =============================================================================

```
