### PR TITLE
Ignore puppetclass attribute conditionally

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -4258,7 +4258,11 @@ class Host(
         # host id is required for interface initialization
         ignore.add('interface')
         ignore.add('build_status_label')
-        if 'Puppet' not in _feature_list(self._server_config):
+        if (
+            'Puppet' not in _feature_list(self._server_config)
+            or 'puppetclasses' not in attrs
+            and not attrs['puppet_proxy_id']
+        ):
             ignore.add('puppetclass')
         result = super().read(entity, attrs, ignore, params)
         if attrs.get('image_id'):

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -4258,10 +4258,13 @@ class Host(
         # host id is required for interface initialization
         ignore.add('interface')
         ignore.add('build_status_label')
+        # Ignore puppetclass attribute if we are running against Puppet disabled
+        # instance. Ignore it also if the API does not return puppetclasses for
+        # the given host, but only if it does not have Puppet proxy assigned.
         if (
             'Puppet' not in _feature_list(self._server_config)
             or 'puppetclasses' not in attrs
-            and not attrs['puppet_proxy_id']
+            and not attrs['puppet_proxy']
         ):
             ignore.add('puppetclass')
         result = super().read(entity, attrs, ignore, params)

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1246,8 +1246,8 @@ class ReadTestCase(TestCase):
             ),
             (
                 entities.Host(self.cfg),
-                {'parameters': None},
-                {'host_parameters_attributes': None},
+                {'parameters': None, 'puppet_proxy': None},
+                {'host_parameters_attributes': None, 'puppet_proxy': None},
             ),
             (
                 entities.Filter(self.cfg),
@@ -1455,6 +1455,7 @@ class ReadTestCase(TestCase):
                 return_value={
                     'interfaces': [{'id': 2}, {'id': 3}],
                     'parameters': None,
+                    'puppet_proxy': None,
                 },
             ):
                 with mock.patch.object(
@@ -1742,6 +1743,7 @@ class SearchNormalizeTestCase(TestCase):
                         'image_id': 1,
                         'compute_resource_id': 1,
                         'parameters': {},
+                        'puppet_proxy': None,
                     }
                     read.return_value = host
                     host = host.read()
@@ -1750,6 +1752,7 @@ class SearchNormalizeTestCase(TestCase):
                     # Image wasn't set
                     read_json.return_value = {
                         'parameters': {},
+                        'puppet_proxy': None,
                     }
                     read.return_value = host
                     host = host.read()
@@ -3038,6 +3041,7 @@ class HostTestCase(TestCase):
                     attrs={
                         'parameters': None,
                         'puppetclasses': None,
+                        'puppet_proxy': None,
                     }
                 )
                 self.assertNotIn('content_facet_attributes', read.call_args[0][1])


### PR DESCRIPTION
##### Description of changes

Ignore puppetclass attribute if Puppet is enabled, but the host does not have Puppet proxy assigned.


##### Upstream API documentation, plugin, or feature links

None

##### Functional demonstration
![Screenshot from 2023-03-30 17-13-42](https://user-images.githubusercontent.com/20440883/228883649-0c2f0f64-7594-4131-83fc-16e9c1d5b3bd.png)

##### Additional Information


