### PR TITLE
[6.13.z] Ignore puppetclass attribute conditionally

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -4258,7 +4258,14 @@ class Host(
         # host id is required for interface initialization
         ignore.add('interface')
         ignore.add('build_status_label')
-        if 'Puppet' not in _feature_list(self._server_config):
+        # Ignore puppetclass attribute if we are running against Puppet disabled
+        # instance. Ignore it also if the API does not return puppetclasses for
+        # the given host, but only if it does not have Puppet proxy assigned.
+        if (
+            'Puppet' not in _feature_list(self._server_config)
+            or 'puppetclasses' not in attrs
+            and not attrs['puppet_proxy']
+        ):
             ignore.add('puppetclass')
         result = super().read(entity, attrs, ignore, params)
         if attrs.get('image_id'):

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1247,8 +1247,8 @@ class ReadTestCase(TestCase):
             ),
             (
                 entities.Host(self.cfg),
-                {'parameters': None},
-                {'host_parameters_attributes': None},
+                {'parameters': None, 'puppet_proxy': None},
+                {'host_parameters_attributes': None, 'puppet_proxy': None},
             ),
             (
                 entities.Filter(self.cfg),
@@ -1456,6 +1456,7 @@ class ReadTestCase(TestCase):
                 return_value={
                     'interfaces': [{'id': 2}, {'id': 3}],
                     'parameters': None,
+                    'puppet_proxy': None,
                 },
             ):
                 with mock.patch.object(
@@ -1743,6 +1744,7 @@ class SearchNormalizeTestCase(TestCase):
                         'image_id': 1,
                         'compute_resource_id': 1,
                         'parameters': {},
+                        'puppet_proxy': None,
                     }
                     read.return_value = host
                     host = host.read()
@@ -1751,6 +1753,7 @@ class SearchNormalizeTestCase(TestCase):
                     # Image wasn't set
                     read_json.return_value = {
                         'parameters': {},
+                        'puppet_proxy': None,
                     }
                     read.return_value = host
                     host = host.read()
@@ -3039,6 +3042,7 @@ class HostTestCase(TestCase):
                     attrs={
                         'parameters': None,
                         'puppetclasses': None,
+                        'puppet_proxy': None,
                     }
                 )
                 self.assertNotIn('content_facet_attributes', read.call_args[0][1])


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/nailgun/pull/906

##### Description of changes

Ignore puppetclass attribute if Puppet is enabled, but the host does not have Puppet proxy assigned.


##### Upstream API documentation, plugin, or feature links

None

##### Functional demonstration
![Screenshot from 2023-03-30 17-13-42](https://user-images.githubusercontent.com/20440883/228883649-0c2f0f64-7594-4131-83fc-16e9c1d5b3bd.png)

##### Additional Information


