### PR TITLE
host: add support for reading provisioning templates

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -4352,6 +4352,7 @@ class Host(
             'traces',
             'traces/resolve',
             'template',
+            'templates',
         ):
             return f'{super().path(which="self")}/{which}'
         elif which in (
@@ -4565,6 +4566,24 @@ class Host(
         kwargs.update(self._server_config.get_client_kwargs())
         response = client.get(self.path('ansible_roles'), **kwargs)
         return _handle_response(response, self._server_config, synchronous, timeout)
+
+    def list_provisioning_templates(self, synchronous=True, timeout=None, **kwargs):
+        """List all Provisioning templates assigned to a Host
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param timeout: Maximum number of seconds to wait until timing out.
+            Defaults to ``nailgun.entity_mixins.TASK_TIMEOUT``.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+        """
+        kwargs = kwargs.copy()
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.get(self.path('templates'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous, timeout)['templates']
 
 
 class Image(


### PR DESCRIPTION
##### Description of changes

Added new method `nailgun.entities.Host::list_provisioning_templates`
which returns all provisioning templates assigned to a host.

##### Upstream API documentation, plugin, or feature links

Local documentation via Satellite apidoc:

https://satellite.example.com/apidoc/v2/hosts/templates.en.html

##### Functional demonstration

Provide an execution of the modified code, with ipython code blocks or screen shots.
You can exercise the code as raw API calls or using any other method.

Your contribution should include updates to the unit tests, covering the modified portions or adding new coverage.

Example:
```
In [1]: from nailgun.entities import Host
In [2]: host = Host(host='sat.instance.addr.com', id='snap_uuid').read()
In [3]: print([template['name'] for template in host.list_provisioning_templates()])
Out [3]: ['Kickstart default finish', 'Linux host_init_config default', ...]
```

##### Additional Information

N/A
