### PR TITLE
[6.13.z] Add AlternateContentSource entity

### DIFF
--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -95,6 +95,7 @@ class InitTestCase(TestCase):
                 entities.AbstractComputeResource,
                 entities.AbstractContentViewFilter,
                 entities.ActivationKey,
+                entities.AlternateContentSource,
                 entities.AnsibleRoles,
                 entities.AnsiblePlaybooks,
                 entities.Architecture,
@@ -305,6 +306,7 @@ class PathTestCase(TestCase):
             (entities.AbstractComputeResource, 'available_networks'),
             (entities.AbstractComputeResource, 'associate'),
             (entities.AbstractComputeResource, 'images'),
+            (entities.AlternateContentSource, 'refresh'),
             (entities.ArfReport, 'download_html'),
             (entities.ProvisioningTemplate, 'clone'),
             (entities.ReportTemplate, 'clone'),
@@ -361,6 +363,8 @@ class PathTestCase(TestCase):
     def test_noid_and_which(self):
         """Execute ``entity().path(which=…)``."""
         for entity, which in (
+            (entities.AlternateContentSource, 'bulk/refresh'),
+            (entities.AlternateContentSource, 'bulk/destroy'),
             (entities.AnsibleRoles, 'sync'),
             (entities.AnsiblePlaybooks, 'sync'),
             (entities.AnsiblePlaybooks, 'fetch'),


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/nailgun/pull/911

##### Description of changes

Adds support for /katello/api/alternate_content_sources endpoints. 

##### Upstream API documentation, plugin, or feature links

https://{SAT}/apidoc/v2/alternate_content_sources.en.html

##### Functional demonstration
```
$ pytest tests/foreman/api/test_acs.py
==================================== test session starts ====================================
platform linux -- Python 3.10.10, pytest-7.2.2, pluggy-1.0.0
shared_function enabled - OFF - scope:  - storage: file
plugins: services-2.2.1, forked-1.4.0, ibutsu-2.2.4, mock-3.10.0, xdist-3.2.1, reportportal-
collected 7 items

tests/foreman/api/test_acs.py .....s.                                                 [100%]

===================================== warnings summary ======================================
```