### PR TITLE
Upgrade codecov dependency

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -16,4 +16,4 @@ wheel
 twine
 
 # For code coverage
-codecov==2.1.12
+codecov==2.1.13


### PR DESCRIPTION
~~codecov is no longer in PyPI.~~
UPDATE: codecov==2.1.12 has been removed from PyPI but developers uploaded
newer version 2.1.13 for those who still need it - like nailgun does.

More info:
https://about.codecov.io/blog/message-regarding-the-pypi-package/
