### PR TITLE
Add filters_applied field

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2368,6 +2368,7 @@ class ContentViewVersion(Entity, EntityDeleteMixin, EntityReadMixin, EntitySearc
             'environment': entity_fields.OneToManyField(LifecycleEnvironment),
             'errata_counts': entity_fields.DictField(),
             'file_count': entity_fields.IntegerField(),
+            'filters_applied': entity_fields.BooleanField(),
             'major': entity_fields.IntegerField(),
             'minor': entity_fields.IntegerField(),
             'module_stream_count': entity_fields.IntegerField(),


### PR DESCRIPTION
##### Description of changes

New field `filters_applied` is returned by CVV entitiy in 6.14 and I would use it for new tests.

https://github.com/Katello/katello/pull/10527

##### Functional demonstration

```
In [1]: from robottelo.hosts import Satellite
In [2]: sat = Satellite('<SAT_FQDN>')
In [3]: sat.api.ContentViewVersion(id=1).read()
Out[3]: robottelo.hosts.DecClass(content_view=nailgun.entities.ContentView(id=1), description=None, environment=[nailgun.entities.LifecycleEnvironment(id=1)], errata_counts={'security': 3, 'bugfix': 0, 'enhancement': 1, 'total': 4}, file_count=0, filters_applied=None, major=1, minor=0, module_stream_count=0, package_count=0, repository=[nailgun.entities.Repository(id=1)], version='1.0', id=1)
In [4]: sat.api.ContentViewVersion(id=9).read()
Out[4]: robottelo.hosts.DecClass(content_view=nailgun.entities.ContentView(id=2), description='', environment=[nailgun.entities.LifecycleEnvironment(id=1)], errata_counts={'security': 3, 'bugfix': 0, 'enhancement': 1, 'total': 4}, file_count=0, filters_applied=False, major=8, minor=0, module_stream_count=0, package_count=35, repository=[nailgun.entities.Repository(id=10)], version='8.0', id=9)
In [5]: sat.api.ContentViewVersion(id=10).read()
Out[5]: robottelo.hosts.DecClass(content_view=nailgun.entities.ContentView(id=2), description='', environment=[nailgun.entities.LifecycleEnvironment(id=1)], errata_counts={'security': 3, 'bugfix': 0, 'enhancement': 1, 'total': 4}, file_count=0, filters_applied=True, major=9, minor=0, module_stream_count=0, package_count=8, repository=[nailgun.entities.Repository(id=11)], version='9.0', id=10)
```

##### Additional Information

Though the https://github.com/Katello/katello/pull/10527 is merged already, it's still not in stream 12.0 (for the functional demonstration I patched the stream 12.0). Marking as DRAFT till it's in stream.
