### PR TITLE
[6.13.z] Add cacert to .fields in HttpProxy

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -5005,6 +5005,7 @@ class HTTPProxy(
             'password': entity_fields.StringField(),
             'organization': entity_fields.OneToManyField(Organization),
             'location': entity_fields.OneToManyField(Location),
+            'cacert': entity_fields.StringField(),
         }
         self._meta = {'api_path': 'api/v2/http_proxies'}
         super().__init__(server_config, **kwargs)
@@ -5030,6 +5031,7 @@ class HTTPProxy(
         ignore.add('password')
         ignore.add('organization')
         ignore.add('location')
+        ignore.add('cacert')
         return super().read(entity, attrs, ignore, params)
 
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/nailgun/pull/923

##### Description of changes

Add cacert to .fields in http_proxy, which is the path within the host to the cacert for the proxy.
Supports robottelo PR# [11454](https://github.com/SatelliteQE/robottelo/pull/11454)

