### PR TITLE
[6.12.z] poll for task intended to fail

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -3095,7 +3095,7 @@ class ForemanTask(Entity, EntityReadMixin, EntitySearchMixin):
             return f'{super().path(which="base")}/{which}'
         return super().path(which)
 
-    def poll(self, poll_rate=None, timeout=None):
+    def poll(self, poll_rate=None, timeout=None, must_succeed=True):
         """Return the status of a task or timeout.
 
         There are several API calls that trigger asynchronous tasks, such as
@@ -3109,6 +3109,8 @@ class ForemanTask(Entity, EntityReadMixin, EntitySearchMixin):
             ``nailgun.entity_mixins.TASK_POLL_RATE``.
         :param timeout: Maximum number of seconds to wait until timing out.
             Defaults to ``nailgun.entity_mixins.TASK_TIMEOUT``.
+        :param must_succeed: Raise error when task finishes with other then success
+            result.
         :returns: Information about the asynchronous task.
         :raises: ``nailgun.entity_mixins.TaskTimedOutError`` if the task
             completes with any result other than "success".
@@ -3120,7 +3122,7 @@ class ForemanTask(Entity, EntityReadMixin, EntitySearchMixin):
         """
         # See nailgun.entity_mixins._poll_task for an explanation of why a
         # private method is called.
-        return _poll_task(self.id, self._server_config, poll_rate, timeout)
+        return _poll_task(self.id, self._server_config, poll_rate, timeout, must_succeed)
 
     def summary(self, synchronous=True, timeout=None, **kwargs):
         """Helper to view a summary of tasks.

--- a/nailgun/entity_mixins.py
+++ b/nailgun/entity_mixins.py
@@ -82,7 +82,7 @@ class TaskFailedError(Exception):
         self.task_id = task_id
 
 
-def _poll_task(task_id, server_config, poll_rate=None, timeout=None):
+def _poll_task(task_id, server_config, poll_rate=None, timeout=None, must_succeed=True):
     """Implement :meth:`nailgun.entities.ForemanTask.poll`.
 
     See :meth:`nailgun.entities.ForemanTask.poll` for a full description of how
@@ -130,7 +130,7 @@ def _poll_task(task_id, server_config, poll_rate=None, timeout=None):
         timer.cancel()
 
     # Check for task success or failure.
-    if task_info['result'] != 'success':
+    if must_succeed and task_info['result'] != 'success':
         raise TaskFailedError(
             f"Task {task_id} did not succeed. Task information: {task_info}", task_id
         )


### PR DESCRIPTION
##### Description of changes

Cherrypick of  #888, requested to fix some issues in upgrade scenarios. No need to update callers in 6.12 robotello branch as the default is kept the same 


