### PR TITLE
Add TablePreferences entity

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -8723,9 +8723,14 @@ class TablePreferences(
         }
         self._fields.update(self._path_fields)
         self.user = kwargs.get('user')
-        self._meta = {
-            'api_path': f'/api/v2/users/{self.user.id}/table_preferences',
-        }
+        if isinstance(self.user, int):
+            self._meta = {
+                'api_path': f'/api/v2/users/{self.user}/table_preferences',
+            }
+        else:
+            self._meta = {
+                'api_path': f'/api/v2/users/{self.user.id}/table_preferences',
+            }
         super().__init__(server_config, **kwargs)
 
     def read(self, entity=None, attrs=None, ignore=None, params=None):

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -8698,3 +8698,50 @@ class AnsibleRoles(
         kwargs.update(self._server_config.get_client_kwargs())
         response = client.put(self.path('sync'), **kwargs)
         return _handle_response(response, self._server_config, synchronous, timeout)
+
+
+class TablePreferences(
+    Entity,
+    EntityCreateMixin,
+    EntityDeleteMixin,
+    EntityReadMixin,
+    EntitySearchMixin,
+    EntityUpdateMixin,
+):
+    """A representation of a Table Preference entity."""
+
+    def __init__(self, server_config=None, **kwargs):
+        _check_for_value('user', kwargs)
+        self._fields = {
+            'name': entity_fields.StringField(),
+            'columns': entity_fields.ListField(),
+            'created_at': entity_fields.DateTimeField(),
+            'updated_at': entity_fields.DateTimeField(),
+        }
+        self._path_fields = {
+            'user': entity_fields.OneToOneField(User),
+        }
+        self._fields.update(self._path_fields)
+        self.user = kwargs.get('user')
+        self._meta = {
+            'api_path': f'/api/v2/users/{self.user.id}/table_preferences',
+        }
+        super().__init__(server_config, **kwargs)
+
+    def read(self, entity=None, attrs=None, ignore=None, params=None):
+        """Ignore path related fields as they're never returned by the server
+        and are only added to entity to be able to use proper path.
+        """
+        entity = entity or self.entity_with_parent(user=self.user)
+        if ignore is None:
+            ignore = set()
+        ignore.add('user')
+        return super().read(entity, attrs, ignore, params)
+
+    def search(self, fields=None, query=None, filters=None):
+        """List/search for TablePreferences.
+        Field 'user' is only used for path and is not returned.
+        """
+        return super().search(
+            fields=fields, query=query, filters=filters, path_fields={'user': self.user}
+        )

--- a/nailgun/entity_mixins.py
+++ b/nailgun/entity_mixins.py
@@ -1308,7 +1308,7 @@ class EntitySearchMixin:
             normalized.append(attrs)
         return normalized
 
-    def search(self, fields=None, query=None, filters=None):
+    def search(self, fields=None, query=None, filters=None, path_fields={}):
         """Search for entities.
 
         At its simplest, this method searches for all entities of a given kind.
@@ -1396,7 +1396,7 @@ class EntitySearchMixin:
             except TypeError:
                 # in the event that an entity's init is overwritten
                 # with a positional server_config
-                entity = type(self)(**result)
+                entity = type(self)(**path_fields, **result)
             entities.append(entity)
         if filters is not None:
             entities = self.search_filter(entities, filters)

--- a/nailgun/entity_mixins.py
+++ b/nailgun/entity_mixins.py
@@ -1392,7 +1392,7 @@ class EntitySearchMixin:
         entities = []
         for result in results:
             try:
-                entity = type(self)(self._server_config, **result)
+                entity = type(self)(self._server_config, **path_fields, **result)
             except TypeError:
                 # in the event that an entity's init is overwritten
                 # with a positional server_config

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -214,6 +214,7 @@ class InitTestCase(TestCase):
                 (entities.SSHKey, {'user': 1}),
                 (entities.SyncPlan, {'organization': 1}),
                 (entities.TemplateInput, {'template': 1}),
+                (entities.TablePreferences, {'user': 1}),
             ]
         )
         for entity, params in entities_:
@@ -2864,6 +2865,52 @@ class JobTemplateTestCase(TestCase):
         self.assertIsInstance(template_input.template, entities.JobTemplate)
         self.assertEqual(template_input.id, self.template_input_data['id'])
         self.assertEqual(template_input.template.id, self.template_input_data['template'])
+
+
+class TablePreferencesTestCase(TestCase):
+    """Tests for :class:`nailgun.entities.TablePreferences`."""
+
+    def setUp(self):
+        self.sc = config.ServerConfig('some url')
+
+    def test_read(self):
+        user_id = gen_integer(min_value=1)
+        user = entities.User(self.sc, id=user_id)
+        entity = entities.TablePreferences(self.sc, user=user)
+        self.assertEqual(entity.user.id, user_id)
+        self.assertIn(f'/{user_id}/', entity._meta['api_path'])
+        read_json_patcher = mock.patch.object(entity, 'read_json')
+        read_json = read_json_patcher.start()
+        table_id = gen_integer(min_value=1)
+        read_json.return_value = {
+            'id': table_id,
+            'name': 'testname',
+            'columns': ['testcol'],
+            'created_at': '2023-06-01 12:38:05 UTC',
+            'updated_at': '2023-06-01 12:38:05 UTC',
+        }
+        res = entity.read()
+        read_json_patcher.stop()
+        self.assertEqual(read_json.call_count, 1)
+        self.assertEqual(res.name, 'testname')
+        self.assertEqual(res.id, table_id)
+        self.assertEqual(res.columns, ['testcol'])
+
+    def test_search(self):
+        user_id = gen_integer(min_value=1)
+        user = entities.User(self.sc, id=user_id)
+        ret = {
+            'total': 1,
+            'page': 1,
+            'results': [{'id': 1, 'name': 'testname', 'columns': ['testcol']}],
+        }
+        entity = entities.TablePreferences(self.sc, user=user)
+        with mock.patch.object(entity, 'search_json', return_value=ret):
+            res = entity.search()
+        self.assertEqual(len(res), 1)
+        self.assertEqual(res[0].name, 'testname')
+        self.assertEqual(res[0].id, 1)
+        self.assertEqual(res[0].columns, ['testcol'])
 
 
 class HostGroupTestCase(TestCase):


### PR DESCRIPTION
##### Description of changes
Added TablePreferences entity.

##### Functional demonstration

Shouldn't cause regression, this test uses search and hasn't changed:
```
$ pytest tests/foreman/api/test_contentview.py::test_positive_admin_user_actions
================================================================= test session starts =================================================================
platform linux -- Python 3.9.16, pytest-7.3.1, pluggy-1.0.0 -- /home/lhellebr/git/robottelo/venv/bin/python
Mandatory Requirements Available: jinja2==3.1.2 broker[docker]==0.3.2 pytest-xdist==3.3.1 wrapanapi==3.5.15 requests==2.31.0 pytest-reportportal==5.1.8
Optional Requirements Available: pre-commit==3.3.2 redis==4.5.5 manage>=0.1.13 sphinx==7.0.1
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/lhellebr/git/robottelo
configfile: pytest.ini
plugins: cov-3.0.0, services-2.2.1, xdist-3.2.1, reportportal-5.1.7, mock-3.10.0, ibutsu-2.2.4
collected 1 item                                                                                                                                      

tests/foreman/api/test_contentview.py::test_positive_admin_user_actions PASSED                                                                  [100%]

================================================================= 1 passed in 56.59s ==================================================================

```
The same happens when I change that test to use ServerConfig explicitly, and don't change anything else (so it doesn't specify the new argument).

This is a new test using it:
```
$ pytest tests/foreman/api/test_user.py::TestUser::test_positive_table_preferences
================================================================= test session starts =================================================================
platform linux -- Python 3.9.16, pytest-7.3.1, pluggy-1.0.0 -- /home/lhellebr/git/robottelo/venv/bin/python
Mandatory Requirements Available: jinja2==3.1.2 pytest-xdist==3.3.1 broker[docker]==0.3.2 requests==2.31.0 wrapanapi==3.5.15 pytest-reportportal==5.1.8
Optional Requirements Available: redis==4.5.5 pre-commit==3.3.2 manage>=0.1.13 sphinx==7.0.1
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/lhellebr/git/robottelo
configfile: pytest.ini
plugins: cov-3.0.0, services-2.2.1, xdist-3.2.1, reportportal-5.1.7, mock-3.10.0, ibutsu-2.2.4
collected 1 item                                                                                                                                      

tests/foreman/api/test_user.py::TestUser::test_positive_create_with_username 
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> PDB set_trace (IO-capturing turned off) >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
> /home/lhellebr/git/robottelo/tests/foreman/api/test_user.py(428)test_positive_create_with_username()
-> assert hasattr(tp, 'name')
(Pdb) c

>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> PDB continue (IO-capturing resumed) >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
PASSED                                                             [100%]

================================================================= 1 passed in 58.13s ==================================================================

```