### PR TITLE
Add helper to delete LCE from capsule

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -858,6 +858,34 @@ class Capsule(Entity, EntityReadMixin, EntitySearchMixin):
         response = client.post(self.path('content_lifecycle_environments'), **kwargs)
         return _handle_response(response, self._server_config, synchronous, timeout)
 
+    def content_delete_lifecycle_environment(self, synchronous=True, timeout=None, **kwargs):
+        """Helper to disassociate lifecycle environment from capsule
+
+        Here is an example of how to use this method::
+            capsule.content_delete_lifecycle_environment(data={'environment_id': lce.id})
+
+        Constructs path:
+            /katello/api/capsules/:capsule_id/content/lifecycle_environments/:id
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param timeout: Maximum number of seconds to wait until timing out.
+            Defaults to ``nailgun.entity_mixins.TASK_TIMEOUT``.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+
+        """
+        kwargs = kwargs.copy()
+        kwargs.update(self._server_config.get_client_kwargs())
+        path = (
+            f'{self.path("content_lifecycle_environments")}/{kwargs["data"].pop("environment_id")}'
+        )
+        response = client.delete(path, **kwargs)
+        return _handle_response(response, self._server_config, synchronous, timeout)
+
     def content_lifecycle_environments(self, synchronous=True, timeout=None, **kwargs):
         """Helper to get all the lifecycle environments, associated with
         capsule

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -2206,9 +2206,15 @@ class GenericTestCase(TestCase):
             (entities.Template(**generic).exports, 'post'),
             (entities.VirtWhoConfig(**generic).deploy_script, 'get'),
         )
+        capsule = {'server_config': cfg, 'id': 1}
         repo_set = {'server_config': cfg, 'id': 1, 'product': 2}
         snapshot = {'server_config': cfg, 'id': 'snapshot-1', 'host': 1}
         cls.intelligent_methods_requests = (
+            (
+                entities.Capsule(**capsule).content_delete_lifecycle_environment,
+                'delete',
+                {'environment_id': 2},
+            ),
             (entities.RepositorySet(**repo_set).available_repositories, 'get', {'product_id': 2}),
             (entities.RepositorySet(**repo_set).disable, 'put', {'product_id': 2}),
             (entities.RepositorySet(**repo_set).enable, 'put', {'product_id': 2}),


### PR DESCRIPTION
##### Description of changes

Adds helper to disassociate lifecycle environment from a capsule

##### Upstream API documentation, plugin, or feature links

<sat>/apidoc/v2/capsule_content.en.html

##### Functional demonstration

```
$ pytest tests/foreman/api/test_capsulecontent.py::TestCapsuleContentManagement::test_positive_remove_capsule_orphans
=================================================================== test session starts ===================================================================
...
collected 1 item                                                                                                                                          

tests/foreman/api/test_capsulecontent.py .                                                                                                          [100%]

======================================================== 1 passed, 1 warning in 111.38s (0:01:51) =========================================================
```

