### PR TITLE
[6.13.z] Add support for RHCloud Cloud Connector

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -6993,6 +6993,34 @@ class RHCIDeployment(
         return _handle_response(response, self._server_config, synchronous, timeout)
 
 
+class RHCloud(Entity):
+    """A representation of a RHCloud entity."""
+
+    def __init__(self, server_config=None, **kwargs):
+        self._fields = {
+            'organization': entity_fields.OneToOneField(Organization),
+            'location': entity_fields.OneToOneField(Location),
+        }
+        super().__init__(server_config, **kwargs)
+        self._meta = {'api_path': 'api/v2/rh_cloud'}
+
+    def path(self, which=None):
+        """Extend ``nailgun.entity_mixins.Entity.path``."""
+        if which in ("enable_connector",):
+            return f'{super().path(which="base")}/{which}'
+        return super().path(which)
+
+    def enable_connector(self, synchronous=True, timeout=None, **kwargs):
+        """Function to enable RH Cloud connector"""
+        kwargs = kwargs.copy()
+        kwargs.update(self._server_config.get_client_kwargs())
+        kwargs['data'] = {}
+        if data := _payload(self.get_fields(), self.get_values()):
+            kwargs['data'] = data
+        response = client.post(self.path('enable_connector'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous, timeout)
+
+
 class RoleLDAPGroups(Entity):
     """A representation of a Role LDAP Groups entity."""
 
@@ -8566,7 +8594,7 @@ class AnsibleRoles(Entity):
         ``super`` is called otherwise.
 
         """
-        if which in ("sync"):
+        if which in ("sync",):
             return f'{super().path(which="base")}/{which}'
         return super().path(which)
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -164,6 +164,7 @@ class InitTestCase(TestCase):
                 entities.Report,
                 entities.Repository,
                 entities.RepositorySet,
+                entities.RHCloud,
                 entities.Role,
                 entities.RoleLDAPGroups,
                 entities.ScapContents,
@@ -382,6 +383,7 @@ class PathTestCase(TestCase):
             (entities.ForemanTask, 'bulk_resume'),
             (entities.ForemanTask, 'bulk_search'),
             (entities.ForemanTask, 'summary'),
+            (entities.RHCloud, 'enable_connector'),
             (entities.Host, 'bulk/install_content'),
             (entities.Template, 'imports'),
             (entities.Template, 'exports'),
@@ -2201,6 +2203,7 @@ class GenericTestCase(TestCase):
             (entities.Template(**generic).exports, 'post'),
             (entities.VirtWhoConfig(**generic).deploy_script, 'get'),
         )
+        plain_taxonomy = {'server_config': cfg, 'organization': 1, 'location': 2}
         capsule = {'server_config': cfg, 'id': 1}
         repo_set = {'server_config': cfg, 'id': 1, 'product': 2}
         snapshot = {'server_config': cfg, 'id': 'snapshot-1', 'host': 1}
@@ -2213,6 +2216,11 @@ class GenericTestCase(TestCase):
             (entities.RepositorySet(**repo_set).available_repositories, 'get', {'product_id': 2}),
             (entities.RepositorySet(**repo_set).disable, 'put', {'product_id': 2}),
             (entities.RepositorySet(**repo_set).enable, 'put', {'product_id': 2}),
+            (
+                entities.RHCloud(**plain_taxonomy).enable_connector,
+                'post',
+                {'organization_id': 1, 'location_id': 2},
+            ),
             (entities.Snapshot(**snapshot).revert, 'put', {}),
         )
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/nailgun/pull/920

##### Description of changes

This PR adds Nailgun support for RHCloud Cloud Connector API.

##### Functional demonstration

This feature is tested with Robottelo test tests/foreman/api/test_rhc.py::test_positive_configure_cloud_connector,
see https://github.com/SatelliteQE/robottelo/pull/11395 PRT run.

```
# Running in Robottelo tests/foreman/api/test_rhc.py::test_positive_configure_cloud_connector.
result = module_target_sat.api.RHCloud().enable_connector(organization_id=module_rhc_org.id)
print(result)
{'id': 4, 'targeting_id': 4, 'job_category': 'Maintenance Operations', 'task_id': '97612455-60d8-45e4-904f-d7b067b9e74f', 'task_group_id': 16, 'triggering_id': 4, 'description': 'Configure Cloud Connector', 'concurrency_level': None, 'time_span': None, 'execution_timeout_interval': None, 'password': None, 'key_passphrase': None, 'remote_execution_feature_id': 17, 'effective_user_password': None, 'ssh_user': None, 'time_to_pickup': None}
```

##### Additional Information

Nailgun tests addded and passing.