### PR TITLE
[6.14.z] Add TablePreferences entity

### DIFF
--- a/nailgun/entity_mixins.py
+++ b/nailgun/entity_mixins.py
@@ -1308,7 +1308,7 @@ class EntitySearchMixin:
             normalized.append(attrs)
         return normalized
 
-    def search(self, fields=None, query=None, filters=None):
+    def search(self, fields=None, query=None, filters=None, path_fields={}):
         """Search for entities.
 
         At its simplest, this method searches for all entities of a given kind.
@@ -1392,11 +1392,11 @@ class EntitySearchMixin:
         entities = []
         for result in results:
             try:
-                entity = type(self)(self._server_config, **result)
+                entity = type(self)(self._server_config, **path_fields, **result)
             except TypeError:
                 # in the event that an entity's init is overwritten
                 # with a positional server_config
-                entity = type(self)(**result)
+                entity = type(self)(**path_fields, **result)
             entities.append(entity)
         if filters is not None:
             entities = self.search_filter(entities, filters)


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/nailgun/pull/928

##### Description of changes
Added TablePreferences entity.

##### Functional demonstration

Shouldn't cause regression, this test uses search and hasn't changed:
```
$ pytest tests/foreman/api/test_contentview.py::test_positive_admin_user_actions
================================================================= test session starts =================================================================
platform linux -- Python 3.9.16, pytest-7.3.1, pluggy-1.0.0 -- /home/lhellebr/git/robottelo/venv/bin/python
Mandatory Requirements Available: jinja2==3.1.2 broker[docker]==0.3.2 pytest-xdist==3.3.1 wrapanapi==3.5.15 requests==2.31.0 pytest-reportportal==5.1.8
Optional Requirements Available: pre-commit==3.3.2 redis==4.5.5 manage>=0.1.13 sphinx==7.0.1
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/lhellebr/git/robottelo
configfile: pytest.ini
plugins: cov-3.0.0, services-2.2.1, xdist-3.2.1, reportportal-5.1.7, mock-3.10.0, ibutsu-2.2.4
collected 1 item                                                                                                                                      

tests/foreman/api/test_contentview.py::test_positive_admin_user_actions PASSED                                                                  [100%]

================================================================= 1 passed in 56.59s ==================================================================

```
The same happens when I change that test to use ServerConfig explicitly, and don't change anything else (so it doesn't specify the new argument).

This is a new test using it:
```
$ pytest tests/foreman/api/test_user.py::TestUser::test_positive_table_preferences
================================================================= test session starts =================================================================
platform linux -- Python 3.9.16, pytest-7.3.1, pluggy-1.0.0 -- /home/lhellebr/git/robottelo/venv/bin/python
Mandatory Requirements Available: jinja2==3.1.2 pytest-xdist==3.3.1 broker[docker]==0.3.2 requests==2.31.0 wrapanapi==3.5.15 pytest-reportportal==5.1.8
Optional Requirements Available: redis==4.5.5 pre-commit==3.3.2 manage>=0.1.13 sphinx==7.0.1
cachedir: .pytest_cache
shared_function enabled - OFF - scope:  - storage: file
rootdir: /home/lhellebr/git/robottelo
configfile: pytest.ini
plugins: cov-3.0.0, services-2.2.1, xdist-3.2.1, reportportal-5.1.7, mock-3.10.0, ibutsu-2.2.4
collected 1 item                                                                                                                                      

tests/foreman/api/test_user.py::TestUser::test_positive_create_with_username 
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> PDB set_trace (IO-capturing turned off) >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
> /home/lhellebr/git/robottelo/tests/foreman/api/test_user.py(428)test_positive_create_with_username()
-> assert hasattr(tp, 'name')
(Pdb) c

>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> PDB continue (IO-capturing resumed) >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
PASSED                                                             [100%]

================================================================= 1 passed in 58.13s ==================================================================

```