### PR TITLE
[6.14.z] Play ansible roles on host

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -4619,6 +4619,7 @@ class Host(
             'errata/applicability',
             'facts',
             'packages',
+            'play_roles',
             'power',
             'puppetclass_ids',
             'smart_class_parameters',
@@ -4881,6 +4882,25 @@ class Host(
         return _handle_response(
             client.delete(path, **kwargs), self._server_config, synchronous, timeout
         )
+
+    def play_ansible_roles(self, synchronous=True, timeout=None, **kwargs):
+        """Play all assigned ansible roles on a Host
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param timeout: Maximum number of seconds to wait until timing out.
+            Defaults to ``nailgun.entity_mixins.TASK_TIMEOUT``.
+        :param kwargs: Arguments to pass to requests.
+        :returns: Ansible task id
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+
+        """
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.post(self.path('play_roles'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous, timeout)['task_id']
 
     def list_provisioning_templates(self, synchronous=True, timeout=None, **kwargs):
         """List all Provisioning templates assigned to a Host

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -331,6 +331,7 @@ class PathTestCase(TestCase):
             (entities.Host, 'smart_class_parameters'),
             (entities.Host, 'ansible_roles'),
             (entities.Host, 'assign_ansible_roles'),
+            (entities.Host, 'play_roles'),
             (entities.HostGroup, 'ansible_roles'),
             (entities.HostGroup, 'assign_ansible_roles'),
             (entities.HostGroup, 'clone'),
@@ -3218,6 +3219,22 @@ class HostTestCase(TestCase):
         self.assertEqual(len(put.call_args[0]), 1)  # post called with 1 positional argument
         self.assertEqual(len(put.call_args[1]), 0)  # post called with no keyword argument
         self.assertEqual(put.call_args[0][0], 'foo/api/v2/hosts/42/disassociate')
+
+    def test_play_ansible_roles(self):
+        """Play Ansible roles"""
+        cfg = config.ServerConfig(url='foo')
+        host = entities.Host(cfg, id=42)
+        exp_ret = mock.MagicMock()
+        exp_ret.status = ACCEPTED
+        exp_ret.content = {'bar': 'baz', 'task_id': 43}
+        with mock.patch.object(client, 'post', return_value=exp_ret) as post:
+            res = host.play_ansible_roles()
+        self.assertEqual(post.call_count, 1)
+        self.assertEqual(len(post.call_args), 2)
+        self.assertEqual(len(post.call_args[0]), 1)  # post called with 1 positional argument
+        self.assertEqual(len(post.call_args[1]), 0)  # post called with no keyword argument
+        self.assertEqual(post.call_args[0][0], 'foo/api/v2/hosts/42/play_roles')
+        self.assertEqual(res, 43)
 
 
 class PuppetClassTestCase(TestCase):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/nailgun/pull/936

Add a method to play ansible roles on a host.
Example:
```
host = api.Host().search(query={'search': f'name={rex_contenthost.hostname}'})[0]
host.play_roles()
```