### PR TITLE
Trigger robottelo image update workflow on merge

### DIFF
--- a/.github/workflows/trigger_robottelo_workflow.yml
+++ b/.github/workflows/trigger_robottelo_workflow.yml
@@ -1,0 +1,20 @@
+name: Send trigger for updating robottelo image on quay.
+on:
+  push:
+    branches:
+      - master
+      - 6.*.z
+
+jobs:
+  trigger-robottelo-workflow:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger workflow in robottelo repo
+        run: |
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.CHERRYPICK_PAT }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/SatelliteQE/robottelo/actions/workflows/update_robottelo_image.yml/dispatches \
+            -d '{"ref":"'"${GITHUB_REF##*/}"'"}'


### PR DESCRIPTION
Problem statement: Currently, the Robottelo image is only updated when a Robottelo PR is merged, which means that it won't be updated if there are any changes merged in Airgun/Nailgun. This can cause issues when running automation as it might not have the latest code changes from these repositories.

Solution: We can add a new [workflow_dispatch](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch) trigger that [listens for any changes](https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event) in the Airgun/Nailgun repositories. When any PR is merged in those repos, the trigger will run the specific branch workflow that updates the Robottelo image. This ensures that the Robottelo image is always up-to-date with the latest code changes.

Depends on https://github.com/SatelliteQE/robottelo/pull/11428