### PR TITLE
Remove Python 3.9 support from nailgun

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, '3.10']
+        python-version: ['3.10', '3.11']
     steps:
       - name: Checkout Nailgun
         uses: actions/checkout@v2


### PR DESCRIPTION
##### Description of changes

As discussed on slack, we are removing support for Python 3.9 from our frameworks.

