### PR TITLE
[6.14.z] Add pxe_loader to Host

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -3987,6 +3987,25 @@ class Host(
             'traces_status': entity_fields.IntegerField(min_val=-1, max_val=2),
             'traces_status_label': entity_fields.StringField(),
             'uuid': entity_fields.StringField(),
+            'pxe_loader': entity_fields.StringField(
+                choices=(
+                    'PXELinux BIOS',
+                    'PXELinux UEFI',
+                    'Grub UEFI',
+                    'Grub2 BIOS'
+                    'Grub2 ELF'
+                    'Grub2 UEFI'
+                    'Grub2 UEFI SecureBoot'
+                    'Grub2 UEFI HTTP'
+                    'Grub2 UEFI HTTPS'
+                    'Grub2 UEFI HTTPS SecureBoot'
+                    'iPXE Embedded'
+                    'iPXE UEFI HTTP'
+                    'iPXE Chain BIOS'
+                    'iPXE Chain UEFI',
+                ),
+                default='PXELinux BIOS',
+            ),
         }
         self._owner_type = None  # actual ``owner_type`` value
         self._meta = {'api_path': 'api/v2/hosts'}


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/nailgun/pull/966

pxe_loader  option already exist for HG, but was missing for Host.

Dependant PR for https://github.com/SatelliteQE/robottelo/pull/11940