### PR TITLE
[6.13.z] Remove Python 3.9 support from nailgun

### DIFF
--- a/.github/workflows/merge_to_master.yml
+++ b/.github/workflows/merge_to_master.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, '3.10']
+        python-version: ['3.10', '3.11']
     steps:
       - name: Checkout Nailgun
         uses: actions/checkout@v2
@@ -70,10 +70,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - name: Setup python 3.8
+      - name: Setup python 3.10
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: '3.10'
       - name: Install pypa/build
         run: python -m pip install build --user
       - name: Build a binary wheel and a source tarball

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, '3.10']
+        python-version: ['3.10', '3.11']
     steps:
       - name: Checkout Nailgun
         uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -42,10 +42,10 @@ setup(
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
     ],
     packages=find_packages(exclude=['docs', 'tests']),
     install_requires=REQUIREMENTS,
-    python_requires='>=3.8',
+    python_requires='>=3.10',
 )


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/nailgun/pull/967

##### Description of changes

As discussed on slack, we are removing support for Python 3.9 from our frameworks.

