### PR TITLE
[6.12.z] Changing return value for Discovery create method

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -1309,7 +1309,7 @@ class DiscoveryRule(
         <https://bugzilla.redhat.com/show_bug.cgi?id=1381129>`_.
 
         """
-        return type(self)(
+        return DiscoveryRule(
             self._server_config,
             id=self.create_json(create_missing)['id'],
         ).read()


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/nailgun/pull/978

I was facing ` TypeError: DiscoveryRule.__init__() got multiple values for argument 'server_config'` as I started using sat object in the test scenarios.
