### PR TITLE
Adding organization_id to ActivationKey entity

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -226,6 +226,7 @@ class ActivationKey(
                 Organization,
                 required=True,
             ),
+            'organization_id': entity_fields.IntegerField(),
             'purpose_usage': entity_fields.StringField(),
             'purpose_role': entity_fields.StringField(),
             'purpose_addons': entity_fields.ListField(),


### PR DESCRIPTION
##### Description of changes

Adding ```organization_id``` to the ActivationKey entity 

##### Upstream API documentation, plugin, or feature links

Robottelo PR: https://github.com/SatelliteQE/robottelo/pull/12348
