### PR TITLE
[6.14.z] Remove pre-commit GH action

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -38,9 +38,6 @@ jobs:
           pip install --compile --no-cache-dir pycurl
           pip install -U -r requirements.txt -r requirements-dev.txt --no-cache-dir
 
-      - name: Pre Commit Checks
-        uses: pre-commit/action@v2.0.0
-
       - name: Test Nailgun Coverage
         run: |
           make test-coverage

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,8 @@
 # configuration for pre-commit git hooks
 
+ci:
+  autofix_prs: false  # disable autofixing PRs
+
 repos:
 - repo: https://github.com/psf/black
   rev: 23.3.0


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/nailgun/pull/997

This PR removes [pre-commit/action](https://github.com/pre-commit/action) in favor of [pre-commit.ci](https://github.com/apps/pre-commit-ci) that was enabled on the nailgun repository by @JacobCallahan.