### PR TITLE
Add support for capsule content counts

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -837,6 +837,10 @@ class Capsule(Entity, EntityReadMixin, EntitySearchMixin):
             ),
             'organization': entity_fields.OneToManyField(Organization),
             'url': entity_fields.StringField(required=True),
+            'hosts_count': entity_fields.IntegerField(),
+            'download_policy': entity_fields.StringField(),
+            'supported_pulp_types': entity_fields.StringField(),
+            'lifecycle_environments': entity_fields.StringField(),
         }
         self._meta = {
             'api_path': 'katello/api/capsules',
@@ -943,6 +947,42 @@ class Capsule(Entity, EntityReadMixin, EntitySearchMixin):
         response = client.get(self.path('content_sync'), **kwargs)
         return _handle_response(response, self._server_config, synchronous, timeout)
 
+    def content_counts(self, synchronous=True, timeout=None, **kwargs):
+        """List content counts for the capsule.
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param timeout: Maximum number of seconds to wait until timing out.
+            Defaults to ``nailgun.entity_mixins.TASK_TIMEOUT``.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+        """
+        kwargs = kwargs.copy()
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.get(self.path('content_counts'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous, timeout)
+
+    def content_update_counts(self, synchronous=True, timeout=None, **kwargs):
+        """Update content counts for the capsule.
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param timeout: Maximum number of seconds to wait until timing out.
+            Defaults to ``nailgun.entity_mixins.TASK_TIMEOUT``.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+        """
+        kwargs = kwargs.copy()
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.post(self.path('content_update_counts'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous, timeout)
+
     def path(self, which=None):
         """Extend ``nailgun.entity_mixins.Entity.path``.
 
@@ -952,7 +992,10 @@ class Capsule(Entity, EntityReadMixin, EntitySearchMixin):
             /capsules/<id>/content/lifecycle_environments
         content_sync
             /capsules/<id>/content/sync
-
+        content_counts
+            /capsules/<id>/content/counts
+        content_update_counts
+            /capsules/<id>/content/update_counts
 
         ``super`` is called otherwise.
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -564,7 +564,12 @@ class PathTestCase(TestCase):
         * ``Capsule().path('content_sync')``
         """
         capsule = entities.Capsule(self.cfg, id=gen_integer(1, 100))
-        for which in ('content_lifecycle_environments', 'content_sync'):
+        for which in (
+            'content_lifecycle_environments',
+            'content_sync',
+            'content_counts',
+            'content_update_counts',
+        ):
             with self.subTest(which):
                 path = capsule.path(which)
                 which_parts = which.split("_", 1)
@@ -2102,6 +2107,8 @@ class GenericTestCase(TestCase):
             (entities.Capsule(**generic).content_get_sync, 'get'),
             (entities.Capsule(**generic).content_lifecycle_environments, 'get'),
             (entities.Capsule(**generic).content_sync, 'post'),
+            (entities.Capsule(**generic).content_counts, 'get'),
+            (entities.Capsule(**generic).content_update_counts, 'post'),
             (entities.Role(**generic).clone, 'post'),
             (entities.ProvisioningTemplate(**generic).build_pxe_default, 'post'),
             (entities.ProvisioningTemplate(**generic).clone, 'post'),


### PR DESCRIPTION
##### Description of changes
This PR adds
1. support for capsule content count endpoints added in 6.15/stream
2. a few fields that appear useful to me and API returns them already

##### Upstream API documentation, plugin, or feature links

https://<<SAT_FQDN>>/apidoc/v2/capsule_content.en.html

##### Functional demonstration
```
# Demonstrate functional Snapshot read in ipython
In [1]: from robottelo.hosts import Satellite
In [2]: sat = Satellite('satellite.redhat.com')
In [3]: ngc = sat.api.Capsule().search(query={'search': f'name=capsule.redhat.com'})[0]
In [4]: ngc.content_counts()
Out[4]: 
{'content_view_versions': {'4': {'repositories': {'4': {'rpm': 58,
     'erratum': 32,
     'rpm.repo_metadata_file': 1},
    '10': {'rpm': 32,
     'erratum': 4,
     'package_group': 2,
     'rpm.packagecategory': 1}},
   'cv_version_content_counts': {'rpm': 90,
    'erratum': 36,
    'package_group': 2,
    'rpm.packagecategory': 1,
    'rpm.repo_metadata_file': 1}}}}
In [5]: ngc.content_update_counts()
Out[5]: 
{'id': '0d498591-fda8-4287-b5e3-3c577de28967',
 'label': 'Actions::Katello::CapsuleContent::UpdateContentCounts',
 'pending': False,
 'action': 'Update Content Counts',
 'username': 'admin',
 'started_at': '2023-10-18 13:42:19 UTC',
 'ended_at': '2023-10-18 13:42:20 UTC',
 'duration': '0.555393',
 'state': 'stopped',
 'result': 'success',
 'progress': 1.0,
 'input': {'smart_proxy_id': 2,
  'current_request_id': '40535e72-ded4-445d-b187-5015d2a7d198',
  'current_timezone': 'UTC',
  'current_organization_id': None,
  'current_location_id': None,
  'current_user_id': 4},
 'output': {},
 'humanized': {'action': 'Update Content Counts',
  'input': [],
  'output': '',
  'errors': []},
 'cli_example': None,
 'start_at': '2023-10-18 13:42:19 UTC',
 'available_actions': {'cancellable': False, 'resumable': False}}
```
