### PR TITLE
[6.14.z] Add missing counts provided by CVV endpoint

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2395,18 +2395,30 @@ class ContentViewVersion(Entity, EntityDeleteMixin, EntityReadMixin, EntitySearc
 
     def __init__(self, server_config=None, **kwargs):
         self._fields = {
+            'ansible_collection_count': entity_fields.IntegerField(),
+            'ansible_collection_repository_count': entity_fields.IntegerField(),
+            'docker_manifest_count': entity_fields.IntegerField(),
+            'docker_manifest_list_count': entity_fields.IntegerField(),
+            'docker_repository_count': entity_fields.IntegerField(),
+            'docker_tag_count': entity_fields.IntegerField(),
+            'component_view_count': entity_fields.IntegerField(),
             'content_view': entity_fields.OneToOneField(ContentView),
             'description': entity_fields.StringField(),
             'environment': entity_fields.OneToManyField(LifecycleEnvironment),
             'errata_counts': entity_fields.DictField(),
             'file_count': entity_fields.IntegerField(),
+            'file_repository_count': entity_fields.IntegerField(),
             'filters_applied': entity_fields.BooleanField(),
             'major': entity_fields.IntegerField(),
             'minor': entity_fields.IntegerField(),
             'module_stream_count': entity_fields.IntegerField(),
+            'name': entity_fields.StringField(),
             'package_count': entity_fields.IntegerField(),
+            'package_group_count': entity_fields.IntegerField(),
             'repository': entity_fields.OneToManyField(Repository),
+            'srpm_count': entity_fields.IntegerField(),
             'version': entity_fields.StringField(),
+            'yum_repository_count': entity_fields.IntegerField(),
         }
         self._meta = {
             'api_path': 'katello/api/v2/content_view_versions',


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/nailgun/pull/1019

##### Description of changes
`GET /katello/api/content_view_versions/:id` returns more fields than we collected. This PR just adds those content-counts related.

##### Functional demonstration

```
$ curl -sku admin:changeme https://satellite.redhat.com/katello/api/content_view_versions/34 | jq | grep count
      "host_count": 0,
      "activation_key_count": 0
      "host_count": 0,
      "activation_key_count": 1
  "ansible_collection_count": 2,
  "docker_manifest_count": 152,
  "docker_manifest_list_count": 18,
  "docker_tag_count": 24,
  "file_count": 3,
  "rpm_count": 36,
  "modulemd_count": 7,
  "erratum_count": 6,
  "package_group_count": 2,
  "srpm_count": 0,
  "module_stream_count": 7,
  "package_count": 36,
  "component_view_count": 0,
  "ansible_collection_repository_count": 1,
  "docker_repository_count": 1,
  "file_repository_count": 1,
  "yum_repository_count": 1,
  "errata_counts": {
```

```
In [1]: from robottelo.hosts import Satellite
In [2]: sat = Satellite('satellite.redhat.com')
In [3]: sat.api.ContentViewVersion(id=34).read()
Out[4]: robottelo.hosts.DecClass(ansible_collection_count=2, ansible_collection_repository_count=1, docker_manifest_count=152, docker_manifest_list_count=18, docker_repository_count=1, docker_tag_count=24, component_view_count=0, content_view=nailgun.entities.ContentView(id=32), description=None, environment=[nailgun.entities.LifecycleEnvironment(id=31), nailgun.entities.LifecycleEnvironment(id=32)], errata_counts={'security': 3, 'bugfix': 0, 'enhancement': 3, 'total': 6}, file_count=3, file_repository_count=1, filters_applied=False, major=1, minor=0, module_stream_count=7, name='dalJwSyFhP 1.0', package_count=36, package_group_count=2, repository=[nailgun.entities.Repository(id=158), nailgun.entities.Repository(id=160), nailgun.entities.Repository(id=159), nailgun.entities.Repository(id=161)], srpm_count=0, version='1.0', yum_repository_count=1, id=34)
```

##### Additional info

I can see the same fields returned from 6.14, so adding `6.14.z` flag, although I don't plan to use in 6.14.
