### PR TITLE
add workflow to label cherry-pick versions on Pre-Commit-CI PRs

### DIFF
--- a/.github/labels.yaml
+++ b/.github/labels.yaml
@@ -1,0 +1,8 @@
+---
+supported-branch-labels:
+  - 'CherryPick'
+  - '6.15.z'
+  - '6.14.z'
+  - '6.13.z'
+  - '6.12.z'
+

--- a/.github/workflows/pre_commit_labels.yml
+++ b/.github/workflows/pre_commit_labels.yml
@@ -1,0 +1,37 @@
+name: add cherry-pick version labels to pre-commit-ci pr's
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - ready_for_review
+      - reopened
+      - synchronize
+
+jobs:
+  add-labels:
+    runs-on: ubuntu-latest
+    if: github.actor == 'pre-commit-bot'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Read labels from YAML
+        id: read-labels
+        run: |
+          LABELS=$(python3 -c "import yaml; print(' '.join(yaml.safe_load(open('./.github/labels.yaml'))['supported-branch-labels']))")
+          echo "LABELS=$LABELS" >> "$GITHUB_OUTPUT"
+
+      - name: apply cherry-pick version labels.
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.CHERRYPICK_PAT }}
+          script: |
+            const labels = '${{ steps.read-labels.outputs.LABELS }}';
+            const prNumber = '${{ github.event.number }}';
+            github.rest.issues.addLabels({
+              issue_number: prNumber,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: labels.split(' ')
+            }); 


### PR DESCRIPTION
### Description of changes:

This pull request introduces a GitHub Actions workflow that automatically adds cherry-pick version labels to PRs created by the pre-commit-bot. The labels include supported versions, such as '6.14.z,' '6.13.z,' and '6.12.z.'

This is required because we should not miss cherrypicking cause the issue of failure later, this will provide for stabilization  

### Tested with: 
https://github.com/omkarkhatavkar/robottelo/actions/runs/8046870508/job/21974978603?pr=217
 