### PR TITLE
[6.14.z] fixed the type error for some remaining entities

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -8082,7 +8082,7 @@ class TailoringFile(
         <https://bugzilla.redhat.com/show_bug.cgi?id=1381129>`_.
 
         """
-        return type(self)(
+        return TailoringFile(
             self._server_config,
             id=self.create_json(create_missing)['id'],
         ).read()
@@ -8530,7 +8530,7 @@ class ScapContents(
         <https://bugzilla.redhat.com/show_bug.cgi?id=1381129>`_.
 
         """
-        return type(self)(
+        return ScapContents(
             self._server_config,
             id=self.create_json(create_missing)['id'],
         ).read()
@@ -8649,7 +8649,7 @@ class Webhooks(
         """
         self._fields['event'] = entity_fields.StringField(required=True, choices=self.get_events())
 
-        return type(self)(
+        return Webhooks(
             self._server_config,
             id=self.create_json(create_missing)['id'],
         ).read()


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/nailgun/pull/1029

#### Description of changes

Getting TypeError: Webhooks.__init__() got multiple values for argument 'server_config' after the move from entities.Webhook to target_sat.api.Webhook. 

(https://github.com/SatelliteQE/robottelo/pull/13060#issuecomment-1803465554)
https://github.com/SatelliteQE/robottelo/pull/13048

#### Changes 
Removing the call to find the class indirectly and changing to direct call as other entities  

