### PR TITLE
New API endpoint for bulk/refresh all ACSs

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -523,6 +523,8 @@ class AlternateContentSource(
             /katello/api/alternate_content_sources/:id/refresh
         bulk_refresh
             /katello/api/alternate_content_sources/bulk/refresh
+        bulk_refresh_all
+            /katello/api/alternate_content_sources/bulk/refresh_all
         bulk_destroy
             /katello/api/alternate_content_sources/bulk/destroy
         """
@@ -530,6 +532,7 @@ class AlternateContentSource(
             return f'{super().path(which="self")}/{which}'
         elif which in (
             'bulk/refresh',
+            'bulk/refresh_all',
             'bulk/destroy',
         ):
             return f'{super().path(which="base")}/{which}'
@@ -552,6 +555,24 @@ class AlternateContentSource(
         kwargs = kwargs.copy()
         kwargs.update(self._server_config.get_client_kwargs())
         response = client.post(self.path('refresh'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous, timeout)
+
+    def bulk_refresh_all(self, synchronous=True, timeout=None, **kwargs):
+        """Refresh all ACSes present.
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param timeout: Maximum number of seconds to wait until timing out.
+            Defaults to ``nailgun.entity_mixins.TASK_TIMEOUT``.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all content decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+        """
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.post(self.path('bulk/refresh_all'), **kwargs)
         return _handle_response(response, self._server_config, synchronous, timeout)
 
     def bulk_refresh(self, synchronous=True, timeout=None, **kwargs):

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -360,6 +360,7 @@ class PathTestCase(TestCase):
         """Execute ``entity().path(which=…)``."""
         for entity, which in (
             (entities.AlternateContentSource, 'bulk/refresh'),
+            (entities.AlternateContentSource, 'bulk/refresh_all'),
             (entities.AlternateContentSource, 'bulk/destroy'),
             (entities.AnsibleRoles, 'sync'),
             (entities.AnsiblePlaybooks, 'sync'),


### PR DESCRIPTION
### Description of addition
- Support new API endpoint, ACS:`bulk/refresh_all` with method named `bulk_refresh_all()`
- This endpoint was added in 
https://github.com/Katello/katello/pull/10646
- We can still use `.bulk_refresh(data={'ids': acs_id_list})` to refresh only a specific set of ACSs
- The new option is intended to refresh all ACSs present without specific `ids` being passed.

### Functional demonstration
``` 
[SETUP] Multiple ACSs created and refreshed once, then ...

[IN] (Pdb) module_target_sat.api.AlternateContentSource().bulk_refresh_all()

[OUT] {'id': '39c86797-e657-491a-aa8d-a5b3f4d38727', 'label': 'Actions::BulkAction', 'pending': False, 
'action': 'Refresh Alternate Content Source refresh alternate content source; ...', 'username': 'admin', 
'started_at': '2024-01-31 19:27:06 UTC', 'ended_at': '2024-01-31 19:27:38 UTC', 'duration': '32.910878', 
'state': 'stopped', 'result': 'success', 'progress': 1.0, 'input': {'action_class': 'Actions::Katello::AlternateContentSource::Refresh', 'target_ids': [1, 2, 3, 4, 5, 6, 7], 'target_class': 
'Katello::AlternateContentSource', 'args': [], 'kwargs': {}, 'current_request_id': '4cb592d7-a0a1-4532-8c4b-b8b1d4c7f52b', 
'current_timezone': 'UTC', 'current_organization_id': None, 'current_location_id': None, 'current_user_id': 4, 
'dynflow': {}}, 'output': {'planned_count': 7, 'cancelled_count': 0, 'total_count': 7, 'failed_count': 0, 
'pending_count': 0, 'success_count': 7}, 'humanized': {'action': 'Refresh Alternate Content Source', 
'input': ['refresh alternate content source', '...'], 'output': '7 task(s), 7 success, 0 fail', 'errors': []}, 
'cli_example': None, 'start_at': '2024-01-31 19:27:06 UTC', 'available_actions': {'cancellable': False, 'resumable': False}}      
```
### Refreshed ACSs:
![image](https://github.com/SatelliteQE/nailgun/assets/109112035/ad37bd5c-9bd4-4bc7-94a2-69352d9879d9)

### Tasks found:
![image](https://github.com/SatelliteQE/nailgun/assets/109112035/6785ba5f-42b3-4b75-baa6-e8f5fbd957b9)

### BulkAction main task (the Action Name is long):
BulkAction Task Name is just "Refresh Alternate Content Source refresh alternate content source refresh alternate ... "
A long string of the subtask(s) names appended to each other.
![image](https://github.com/SatelliteQE/nailgun/assets/109112035/ea46d95d-dfb4-430a-91a9-33c6ecfad0dd)

### BulkAction sub-tasks:
![image](https://github.com/SatelliteQE/nailgun/assets/109112035/ee1b5571-3b10-4403-ac73-dd34b97da30c)
