### PR TITLE
[6.14.z] update entity object with parametrized server_config rather default

### DIFF
--- a/nailgun/entity_mixins.py
+++ b/nailgun/entity_mixins.py
@@ -814,6 +814,7 @@ class EntityReadMixin:
                 # in the event that an entity's init is overwritten
                 # with a positional server_config
                 entity = type(self)()
+                entity._server_config = self._server_config
         if attrs is None:
             attrs = self.read_json(params=params)
         if ignore is None:


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/nailgun/pull/1106

##### Description of changes

Currently server_config was not getting set while reading the entity API call using target_sat

```
        dom = target_sat.api.Domain(server_config=sc, id=dom.id).read()
        dom.organization = [filter_taxonomies['org']]
        with pytest.raises(HTTPError):
            dom.update(['organization']) 

```
After this PR the `dom` object or any other api component object can access the API calls using the custom server_config set by parameter .
