### PR TITLE
[6.15.z] Add support for the reclaim_space endpoint

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -1004,6 +1004,24 @@ class Capsule(Entity, EntityReadMixin, EntitySearchMixin):
         response = client.post(self.path('content_update_counts'), **kwargs)
         return _handle_response(response, self._server_config, synchronous, timeout)
 
+    def content_reclaim_space(self, synchronous=True, timeout=None, **kwargs):
+        """Reclaim space for all on_demand repos synced on the Capsule.
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param timeout: Maximum number of seconds to wait until timing out.
+            Defaults to ``nailgun.entity_mixins.TASK_TIMEOUT``.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+        """
+        kwargs = kwargs.copy()
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.post(self.path('content_reclaim_space'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous, timeout)
+
     def path(self, which=None):
         """Extend ``nailgun.entity_mixins.Entity.path``.
 
@@ -1017,6 +1035,8 @@ class Capsule(Entity, EntityReadMixin, EntitySearchMixin):
             /capsules/<id>/content/counts
         content_update_counts
             /capsules/<id>/content/update_counts
+        content_reclaim_space
+            /capsules/<id>/content/reclaim_space
 
         ``super`` is called otherwise.
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -568,6 +568,7 @@ class PathTestCase(TestCase):
             'content_sync',
             'content_counts',
             'content_update_counts',
+            'content_reclaim_space',
         ):
             with self.subTest(which):
                 path = capsule.path(which)
@@ -2108,6 +2109,7 @@ class GenericTestCase(TestCase):
             (entities.Capsule(**generic).content_sync, 'post'),
             (entities.Capsule(**generic).content_counts, 'get'),
             (entities.Capsule(**generic).content_update_counts, 'post'),
+            (entities.Capsule(**generic).content_reclaim_space, 'post'),
             (entities.Role(**generic).clone, 'post'),
             (entities.ProvisioningTemplate(**generic).build_pxe_default, 'post'),
             (entities.ProvisioningTemplate(**generic).clone, 'post'),


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/nailgun/pull/1111

##### Description of changes

Adds support for the Capsule `reclaim_space` endpoint.


##### Upstream API documentation, plugin, or feature links

See the apidoc for Capsule_content.


##### Functional demonstration

In robottelo [PR#14397](https://github.com/SatelliteQE/robottelo/pull/14397).
