### PR TITLE
[6.15.z] new entity NotificationRecipients

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -8916,3 +8916,17 @@ class TablePreferences(
         return super().search(
             fields=fields, query=query, filters=filters, path_fields={'user': self.user}
         )
+
+
+class NotificationRecipients(Entity, EntityReadMixin):
+    """A representation of /notification_recipients endpoint."""
+
+    def __init__(self, server_config=None, **kwargs):
+        self._fields = {
+            'notifications': entity_fields.ListField(),
+        }
+        self._meta = {
+            'api_path': '/notification_recipients',
+            'read_type': 'base',
+        }
+        super().__init__(server_config, **kwargs)

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -3999,3 +3999,34 @@ class ScapContentsTestCase(TestCase):
             _get_required_field_names(entity),
             set(entity.get_values().keys()),
         )
+
+
+class NotificationRecipientsTestCase(TestCase):
+    """Tests for :class:`nailgun.entities.NotificationRecipients`."""
+
+    def test_to_json(self):
+        """Check json serialisation on nested entities."""
+        notifications_kwargs = {
+            "notifications": [
+                {
+                    "id": 28,
+                    "seen": False,
+                    "level": "info",
+                    "text": "The fastest guide to configuring Red Hat Satellite ever",
+                    "created_at": "2024-03-20T17:24:33.596Z",
+                    "group": "Community",
+                    "actions": {
+                        "links": [
+                            {
+                                "href": "https://www.redhat.com/en/blog/fastest-guide-configuring-red-hat-satellite-ever",
+                                "title": "Open",
+                                "external": True,
+                            }
+                        ]
+                    },
+                }
+            ]
+        }
+        cfg = config.ServerConfig(url='https://foo.bar', verify=False, auth=('foo', 'bar'))
+        notifications = entities.NotificationRecipients(cfg, **notifications_kwargs)
+        self.assertDictEqual(notifications_kwargs, json.loads(notifications.to_json()))


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/nailgun/pull/1118

Added new entity `NotificationRecipients` for `/notification_recipients` endpoint.

This PR is required by https://github.com/SatelliteQE/robottelo/pull/14592
