### PR TITLE
[6.15.z] Remove codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,7 +1,0 @@
-github_checks:
-  annotations: false
-
-# https://docs.codecov.io/docs/github-checks-beta
-# Annotations are shown for unchanged files on the diff
-# Turn off all annotations until this is more configurable
-# The codecov comment will still be made on the PR

--- a/.github/workflows/merge_to_master.yml
+++ b/.github/workflows/merge_to_master.yml
@@ -42,10 +42,6 @@ jobs:
       - name: Pre Commit Checks
         uses: pre-commit/action@v2.0.0
 
-      - name: Test Nailgun Coverage
-        run: |
-          make test-coverage
-
       - name: Make Docs
         run: |
           make docs-html
@@ -59,11 +55,6 @@ jobs:
       - name: Analysis (git diff)
         if: failure()
         run: git diff
-
-      - name: Upload Codecov Coverage
-        uses: codecov/codecov-action@v1.0.13
-        with:
-          fail_ci_if_error: true
 
   build-n-publish:
     name: Build and publish Python 🐍 distributions 📦 to PyPI

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -38,9 +38,8 @@ jobs:
           pip install --compile --no-cache-dir pycurl
           pip install -U -r requirements.txt -r requirements-dev.txt --no-cache-dir
 
-      - name: Test Nailgun Coverage
-        run: |
-          make test-coverage
+      - name: Run Tests
+        run: make test
 
       - name: Make Docs
         run: |
@@ -56,7 +55,3 @@ jobs:
         if: failure()
         run: git diff
 
-      - name: Upload Codecov Coverage
-        uses: codecov/codecov-action@v1.0.13
-        with:
-          fail_ci_if_error: true

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ help:
 	@echo "Please use \`make <target>' where <target> is one of:"
 	@echo "  help           to show this message"
 	@echo "  test           to run unit tests"
-	@echo "  test-coverage  to run unit tests and measure test coverage"
 	@echo "  docs-html      to generate HTML documentation"
 	@echo "  docs-clean     to remove documentation"
 	@echo "  package        to generate installable Python packages"
@@ -21,9 +20,6 @@ docs-clean:
 test:
 	python $(TEST_OPTIONS)
 
-test-coverage:
-	coverage run --source nailgun $(TEST_OPTIONS)
-
 package:
 	./setup.py sdist bdist_wheel --universal
 
@@ -33,4 +29,4 @@ package-clean:
 publish: package
 	twine upload dist/*
 
-.PHONY: help docs-html docs-clean test test-coverage package package-clean publish
+.PHONY: help docs-html docs-clean test package package-clean publish

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,3 @@ combine-as-imports = true
 [tool.ruff.mccabe]
 max-complexity = 25
 
-[tool.coverage.run]
-omit = ["tests/*"]
-include = ["nailgun/*.py"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,9 +14,5 @@ wheel
 # For `make publish`
 twine
 
-# For code coverage
-codecov==2.1.13
-coverage[toml]
-
 # For linting
 ruff


### PR DESCRIPTION
##### Description of changes
Codecov was removed from master as its no longer required in PR https://github.com/SatelliteQE/nailgun/pull/1102
We're missing this changes in zstream branches and codecov checks fails on zstream PRs, so removing this from all supported branches
Example: https://github.com/SatelliteQE/nailgun/pull/1124

