### PR TITLE
[6.15.z] Add outputs, rerun, cancel endpoints in JobInvocation entity

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -1922,6 +1922,84 @@ class JobInvocation(Entity, EntityReadMixin, EntitySearchMixin):
         self._meta = {'api_path': 'api/job_invocations'}
         super().__init__(server_config, **kwargs)
 
+    def path(self, which=None):
+        """Extend ``nailgun.entity_mixins.Entity.path``.
+
+        The format of the returned path depends on the value of ``which``:
+
+        cancel
+            /api/job_invocations/<id>/cancel
+        rerun
+            /api/job_invocations/<id>/rerun
+        outputs
+            /api/job_invocations/<id>/outputs
+
+        ``super`` is called otherwise.
+        """
+        if which in (
+            'cancel',
+            'rerun',
+            'outputs',
+        ):
+            return f'{super().path(which="self")}/{which}'
+        return super().path(which)
+
+    def cancel(self, synchronous=True, timeout=None, **kwargs):
+        """Cancel JobInvocation running on the host.
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param timeout: Maximum number of seconds to wait until timing out.
+            Defaults to ``nailgun.entity_mixins.TASK_TIMEOUT``.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+
+        """
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.post(self.path('cancel'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous, timeout)
+
+    def rerun(self, synchronous=True, timeout=None, **kwargs):
+        """Rerun JobInvocation which already ran on the host.
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param timeout: Maximum number of seconds to wait until timing out.
+            Defaults to ``nailgun.entity_mixins.TASK_TIMEOUT``.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+        """
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.post(self.path('rerun'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous, timeout)
+
+    def outputs(self, synchronous=True, timeout=None, **kwargs):
+        """Get output of JobInvocation running on the host.
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param timeout: Maximum number of seconds to wait until timing out.
+            Defaults to ``nailgun.entity_mixins.TASK_TIMEOUT``.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all JSON decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+
+        """
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.get(self.path('outputs'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous, timeout)
+
     def run(self, synchronous=True, **kwargs):
         """Run an existing job template.
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/nailgun/pull/1139

##### Description of changes
Missing outputs, rerun, cancel endpoints in JobInvocation entity
##### Upstream API documentation, plugin, or feature links

Link to any relevant upstream API documentation that relates to the content of the PR.

##### Functional demonstration
```
In [28]: result = sat.api.JobInvocation(id=20).outputs()

In [29]: [i for i in result['outputs'][0]['output'] if i['output'] == 'Exit status: 0']
Out[29]:
[{'output_type': 'stdout',
  'output': 'Exit status: 0',
  'timestamp': 1715268351.528926}]
```

##### Additional Information

Any additional notes for reviewers, comments about the change, TODO lists on WIP PRs, etc.
