### PR TITLE
Unblock Robottelo PRs failing with recent nailgun changes

### DIFF
--- a/.github/workflows/auto_assignment.yaml
+++ b/.github/workflows/auto_assignment.yaml
@@ -15,7 +15,7 @@ jobs:
     if: "!contains(github.event.pull_request.labels.*.name, 'Auto_Cherry_Picked')"
     runs-on: ubuntu-latest
     steps:
-      - uses: kentaro-m/auto-assign-action@v1.2.6
+      - uses: kentaro-m/auto-assign-action@v2.0.0
         with:
           repo-token: "${{ secrets.CHERRYPICK_PAT || github.token }}"
           configuration-path: ".github/auto_assign.yml"


### PR DESCRIPTION
### Purpose

To unblock automation testing for Robottelo PRs
drop commits from yesterday and since

https://github.com/SatelliteQE/robottelo/pull/15085
https://github.com/SatelliteQE/robottelo/pull/15165

### Related issues
- All automation failing at creation of Organization entity, all testing with `module_org` fails
- See Issue #1038 