### PR TITLE
[6.15.z] Update Entity.__eq__ isinstance check to work in either direction

### DIFF
--- a/nailgun/entity_mixins.py
+++ b/nailgun/entity_mixins.py
@@ -595,7 +595,7 @@ class Entity:
         :param other: entity to compare self to
         :return: boolean indicating if entities are equal or not
         """
-        if not isinstance(other, type(self)):
+        if not isinstance(other, type(self)) and not isinstance(self, type(other)):
             return False
         return self.to_json_dict() == other.to_json_dict()
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/nailgun/pull/1153

##### Description of changes

Update `Entity.__eq__` to check for class compatibility in both directions. This fixes robottelo test errors that occur when comparing a `nailgun.entities.User` instance against an instance of robottelo's wrapper class `robottelo.hosts.DecClass`:

```
14:46:30      @pytest.mark.tier2
14:46:30      def test_positive_create_and_update_with_user(
14:46:30          module_org, module_location, module_user, module_target_sat
14:46:30      ):
14:46:30          """Create and update host with user specified
14:46:30      
14:46:30          :id: 72e20f8f-17dc-4e38-8ac1-d08df8758f56
14:46:30      
14:46:30          :expectedresults: A host is created and updated with expected user assigned
14:46:30          """
14:46:30          host = module_target_sat.api.Host(
14:46:30              owner=module_user, owner_type='User', organization=module_org, location=module_location
14:46:30          ).create()
14:46:30  >       assert host.owner.read() == module_user
14:46:30  E       AssertionError: assert nailgun.entities.User(admin=False, auth_source=nailgun.entities.AuthSourceLDAP(id=1), auth_source_name='Internal', def..., login='AYpQhUAYUeu', mail='hAzyluvC@example.com', organization=[nailgun.entities.Organization(id=13)], role=[], id=5) == robottelo.hosts.DecClass(admin=False, auth_source=nailgun.entities.AuthSourceLDAP(id=1), auth_source_name='Internal', ..., login='AYpQhUAYUeu', mail='hAzyluvC@example.com', organization=[nailgun.entities.Organization(id=13)], role=[], id=5)
14:46:30  E        +  where nailgun.entities.User(admin=False, auth_source=nailgun.entities.AuthSourceLDAP(id=1), auth_source_name='Internal', def..., login='AYpQhUAYUeu', mail='hAzyluvC@example.com', organization=[nailgun.entities.Organization(id=13)], role=[], id=5) = <bound method User.read of nailgun.entities.User(id=5)>()
14:46:30  E        +    where <bound method User.read of nailgun.entities.User(id=5)> = nailgun.entities.User(id=5).read
14:46:30  E        +      where nailgun.entities.User(id=5) = nailgun.entities.Host(all_parameters=[{'priority': 0, 'created_at': '2024-02-21 00:29:10 UTC', 'updated_at': '2024-02-...nailgun.entities.Interface(host=nailgun.entities.Host(id=8), id=8)], build_status_label='Installed', owner_type='User').owner
14:46:30  
14:46:30  tests/foreman/api/test_host.py:471: AssertionError
14:46:30  =============================== warnings summary ======
```

##### Upstream API documentation, plugin, or feature links

##### Functional demonstration

robottelo PRT results: TBD