### PR TITLE
host: added field reported_data

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -4203,6 +4203,7 @@ class Host(
             'puppetclass': entity_fields.OneToManyField(PuppetClass),
             'puppet_proxy': entity_fields.OneToOneField(SmartProxy),
             'realm': entity_fields.OneToOneField(Realm),
+            'reported_data': entity_fields.DictField(),
             'root_pass': entity_fields.StringField(length=(8, 30), str_type='alpha'),
             'subnet': entity_fields.OneToOneField(Subnet),
             'token': entity_fields.StringField(),
@@ -4714,13 +4715,12 @@ class Host(
             attrs['host_parameters_attributes'] = attrs.pop('parameters')
         else:
             ignore.add('host_parameters_attributes')
-        if 'content_facet_attributes' not in attrs:
-            ignore.add('content_facet_attributes')
         if 'traces_status' not in attrs and 'traces_status_label' not in attrs:
             ignore.add('traces_status')
             ignore.add('traces_status_label')
-        if 'token' not in attrs:
-            ignore.add('token')
+        for optional_attr in ['content_facet_attributes', 'token', 'reported_data']:
+            if optional_attr not in attrs:
+                ignore.add(optional_attr)
         ignore.add('compute_attributes')
         ignore.add('interfaces_attributes')
         ignore.add('root_pass')


### PR DESCRIPTION
##### Description of changes

Added new field `reported_data` to the `Host` entity.
This field is optional and it is not present for all host instances,
only for those reporting real data, like bare metal hosts and so.


##### Functional demonstration

Example:
```
In [1]: from nailgun.entities import Host
In [2]: host = Host().search(query={'search': f'name=sat.instance.addr.com'})[0]
In [3]: host.reported_data
Out [3]:
{
    "boot_time": "2024-06-21 16:44:18 +0200",
    "cores": 6,
    "sockets": 6,
    "disks_total": 107374182400,
    "kernel_version": "5.14.0-427.20.1.el9_4.x86_64",
    "bios_vendor": "SeaBIOS",
    "bios_release_date": "04/01/2014",
    "bios_version": "1.16.1-1.el9"
}
```
