### PR TITLE
Add repo_data option to host registration command

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -6815,6 +6815,7 @@ class RegistrationCommand(Entity, EntityCreateMixin, EntityReadMixin):
             'update_packages': entity_fields.BooleanField(default=False),
             'force': entity_fields.BooleanField(default=False),
             'ignore_subman_errors': entity_fields.BooleanField(default=False),
+            'repo_data': entity_fields.ListField(),
         }
 
         self._meta = {'api_path': '/api/registration_commands'}


### PR DESCRIPTION
##### Description of changes

Add repo_data option to host registration command

##### Upstream API documentation, plugin, or feature links

The foreman upstream api is not up to date so I can only link the PR
https://github.com/theforeman/foreman/pull/10162

##### Functional demonstration

I am executing it via robottelo I do not know how to extract the raw api call.

##### Additional Information
None
