### PR TITLE
[6.15.z] Add support for debian repository creation

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -6773,7 +6773,7 @@ class Repository(
             ),
             'content_counts': entity_fields.DictField(),
             'content_type': entity_fields.StringField(
-                choices=('puppet', 'yum', 'file', 'docker', 'ostree'),
+                choices=('puppet', 'yum', 'file', 'docker', 'ostree', 'deb'),
                 default='yum',
                 required=True,
             ),
@@ -6814,12 +6814,17 @@ class Repository(
                 choices=('global_default_http_proxy', 'none', 'use_selected_http_proxy')
             ),
             'http_proxy_id': entity_fields.IntegerField(),
+            'deb_releases': entity_fields.StringField(),
+            'deb_components': entity_fields.StringField(),
+            'deb_architectures': entity_fields.StringField(),
         }
         if self._fields['content_type'].choices == 'yum':
             self._fields['download_policy'].required = True
         self._meta = {
             'api_path': 'katello/api/v2/repositories',
         }
+        if kwargs.get('content_type') == 'deb':
+            self._fields['deb_releases'].default = 'stable'
         super().__init__(server_config=server_config, **kwargs)
 
     def path(self, which=None):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/nailgun/pull/1203

##### Description of changes

Add support for debian repository creation

##### Functional demonstration

All tests are green

##### Additional Information

I'm not sure if there should be explicit tests for debian repo creation?
