### PR TITLE
[6.16.z] Bump pascalgn/automerge-action from 0.16.3 to 0.16.4

### DIFF
--- a/.github/workflows/automerge.yaml
+++ b/.github/workflows/automerge.yaml
@@ -103,7 +103,7 @@ jobs:
 
       - id: automerge
         name: Auto merge of cherry-picked PRs.
-        uses: pascalgn/automerge-action@v0.16.3
+        uses: pascalgn/automerge-action@v0.16.4
         if: steps.waitforstatuschecks.outputs.status == 'success'
         env:
           GITHUB_TOKEN: "${{ secrets.CHERRYPICK_PAT }}"


### PR DESCRIPTION
This PR backports changes from #1226
- **Changes for new 6.16.z branch (#1218)**
- **[pre-commit.ci] pre-commit autoupdate (#1216)**
