### PR TITLE
[6.14.z] Add possibility to query deb packages for host

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -4431,6 +4431,24 @@ class Host(
         response = client.get(self.path('packages'), **kwargs)
         return _handle_response(response, self._server_config, synchronous, timeout)
 
+    def debs(self, synchronous=True, timeout=None, **kwargs):
+        """List debian packages installed on the host.
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param timeout: Maximum number of seconds to wait until timing out.
+            Defaults to ``nailgun.entity_mixins.TASK_TIMEOUT``.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all content decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+        """
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.get(self.path('debs'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous, timeout)
+
     def module_streams(self, synchronous=True, timeout=None, **kwargs):
         """List module_streams available for the host.
 
@@ -4737,6 +4755,7 @@ class Host(
             'errata/applicability',
             'facts',
             'packages',
+            'debs',
             'play_roles',
             'power',
             'puppetclass_ids',


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/nailgun/pull/1233

##### Description of changes

Add possibility to query deb packages for host


##### Upstream API documentation, plugin, or feature links

There is no up to date foreman documentation online but the api is listed [here](https://github.com/Katello/katello/blob/master/engines/bastion_katello/app/assets/javascripts/bastion_katello/hosts/host-debs.factory.js)

##### Functional demonstration

```
ipdb> host.debs({"per_page": 20})
{'total': 385, 'subtotal': 385, 'selectable': 385, 'page': 1, 'per_page': 20, 'error': None, 'search': None, 'sort': {'by': 'name', 'order': 'asc'}, 'results':  ...
```

##### Additional Information
possible PRT test `tests/foreman/api/test_errata.py`