### PR TITLE
Remove Purpose addons from Nailgun

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -227,7 +227,6 @@ class ActivationKey(
             ),
             'purpose_usage': entity_fields.StringField(),
             'purpose_role': entity_fields.StringField(),
-            'purpose_addons': entity_fields.ListField(),
             'release_version': entity_fields.StringField(),
             'service_level': entity_fields.StringField(),
             'unlimited_hosts': entity_fields.BooleanField(),


### PR DESCRIPTION
##### Description of changes
- purpose_addons is removed from katello https://github.com/Katello/katello/pull/11196 causing robottelo tests to fail and blocking stream snap templatization pipeline.

Describe in detail the changes made, and any potential impacts to callers.
- remove purpose_addons
##### Upstream API documentation, plugin, or feature links
- https://github.com/Katello/katello/pull/11196

##### Functional demonstration
Provide an execution of the modified code, with ipython code blocks or screen shots.
- Can't the change is not available in downstream snap so can't test it yet.
