### PR TITLE
Remove the token field from flatpak remote

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -3540,7 +3540,6 @@ class FlatpakRemote(
             'organization': entity_fields.OneToOneField(Organization, required=True),
             'description': entity_fields.StringField(),
             'username': entity_fields.StringField(),
-            'token': entity_fields.StringField(),
             'registry_url': entity_fields.StringField(),
             'seeded': entity_fields.BooleanField(),
         }


### PR DESCRIPTION
##### Description of changes
We have decided not-to return the auth tokens at all.


##### Upstream API documentation, plugin, or feature links
https://issues.redhat.com/browse/SAT-30106
https://github.com/Katello/katello/pull/11261


##### Functional demonstration
Same as https://github.com/SatelliteQE/nailgun/pull/1255 - token is not returned.