### PR TITLE
[6.15.z] Add AnsibleVariable to entities

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -8977,6 +8977,47 @@ class AnsibleRoles(
         return _handle_response(response, self._server_config, synchronous, timeout)
 
 
+class AnsibleVariable(
+    Entity,
+    EntityCreateMixin,
+    EntityReadMixin,
+    EntityDeleteMixin,
+    EntitySearchMixin,
+    EntityUpdateMixin,
+):
+    """A representation of a Ansible Variable entity."""
+
+    def __init__(self, server_config=None, **kwargs):
+        self._fields = {
+            'variable': entity_fields.StringField(required=True),
+            'ansible_role_id': entity_fields.IntegerField(required=True),
+            'default_value': entity_fields.StringField(),
+            'override_value_order': entity_fields.StringField(),
+            'description': entity_fields.StringField(),
+            'validator_type': entity_fields.ListField(),
+            'validator_rule': entity_fields.StringField(),
+            'variable_type': entity_fields.StringField(
+                default='string',
+                choices=(
+                    'string',
+                    'boolean',
+                    'integer',
+                    'real',
+                    'array',
+                    'hash',
+                    'yaml',
+                    'json',
+                ),
+            ),
+            'merge_overrides': entity_fields.BooleanField(),
+            'merge_default': entity_fields.BooleanField(),
+            'avoid_duplicates': entity_fields.BooleanField(),
+            'override': entity_fields.BooleanField(),
+        }
+        self._meta = {'api_path': 'ansible/api/ansible_variables'}
+        super().__init__(server_config=server_config, **kwargs)
+
+
 class TablePreferences(
     Entity,
     EntityCreateMixin,

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -93,6 +93,7 @@ class InitTestCase(TestCase):
                 entities.ActivationKey,
                 entities.AlternateContentSource,
                 entities.AnsibleRoles,
+                entities.AnsibleVariable,
                 entities.AnsiblePlaybooks,
                 entities.Architecture,
                 entities.ArfReport,


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/nailgun/pull/1220

##### Description of changes

Add AnsibleVariable to entities

##### Upstream API documentation, plugin, or feature links

I would like to reference to api doc but the latest version I can find is 3.4 ...

##### Functional demonstration

Example:
```
module_target_sat.api.AnsibleVariable(
            variable="foreman_cloud_connector_user",
            default_value="foo",
            ansible_role_id=ansible_role_id,
        ).create()
robottelo.hosts.DecClass(variable='foreman_cloud_connector_user', ansible_role_id=24, default_value='foo', id=54)
```

