### PR TITLE
Using Py3.13 for build/publish to PyPI GHA

### DIFF
--- a/.github/workflows/merge_to_master.yml
+++ b/.github/workflows/merge_to_master.yml
@@ -61,10 +61,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - name: Setup python 3.10
+      - name: Setup python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.13'
       - name: Install pypa/build
         run: python -m pip install build --user
       - name: Build a binary wheel and a source tarball


### PR DESCRIPTION
This GHA update was missed in PR: https://github.com/SatelliteQE/nailgun/pull/1261

Already fixed in the cherrypick of mentioned PR