### PR TITLE
Add donwload cuncurrency for repository

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -7033,6 +7033,7 @@ class Repository(
             'deb_releases': entity_fields.StringField(),
             'deb_components': entity_fields.StringField(),
             'deb_architectures': entity_fields.StringField(),
+            'download_concurrency': entity_fields.IntegerField(),
         }
         if self._fields['content_type'].choices == 'yum':
             self._fields['download_policy'].required = True
@@ -7103,6 +7104,7 @@ class Repository(
         ignore.add('organization')
         ignore.add('upstream_password')
         ignore.add('mirror_on_sync')
+        ignore.add('download_concurrency')
         return super().read(entity, attrs, ignore, params)
 
     def create_missing(self):

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1292,7 +1292,10 @@ class ReadTestCase(TestCase):
                 {'discovery', 'remote_execution_proxy', 'subnet_parameters_attributes'},
             ),
             (entities.Subscription, {'organization'}),
-            (entities.Repository, {'organization', 'upstream_password', 'mirror_on_sync'}),
+            (
+                entities.Repository,
+                {'organization', 'upstream_password', 'mirror_on_sync', 'download_concurrency'},
+            ),
             (entities.User, {'password'}),
             (entities.ScapContents, {'scap_file'}),
             (entities.TailoringFile, {'scap_file'}),


### PR DESCRIPTION
##### Description of changes

Add donwload cuncurrency for repository

##### Upstream API documentation, plugin, or feature links

https://apidocs.theforeman.org/katello/latest/apidoc/v2/repositories/create.html

##### Functional demonstration

log output:
```
2025-02-11 09:34:21 - nailgun.client - DEBUG - Making HTTP POST request to https://...katello/api/v2/repositories with options {'auth': None, 'verify': None, 'headers': {'content-type': 'application/json'}}, no params and data {"name": "test-uln", "content_type": "yum", "download_policy": "on_demand", "url": "uln://ovm2_2.1.1_i386_patch", "upstream_username": "***", "upstream_password": "***", "download_concurrency": 1, "organization_id": 8, "product_id": 304}
```


