### PR TITLE
Add RHCloud.advisor_engine_config API

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -7669,7 +7669,7 @@ class RHCloud(Entity):
 
     def path(self, which=None):
         """Extend ``nailgun.entity_mixins.Entity.path``."""
-        if which in ("enable_connector",):
+        if which in ("enable_connector", "advisor_engine_config"):
             return f'{super().path(which="base")}/{which}'
         return super().path(which)
 
@@ -7681,6 +7681,13 @@ class RHCloud(Entity):
         if data := _payload(self.get_fields(), self.get_values()):
             kwargs['data'] = data
         response = client.post(self.path('enable_connector'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous, timeout)
+
+    def advisor_engine_config(self, synchronous=True, timeout=None, **kwargs):
+        """Get advisor engine configuration information."""
+        kwargs = kwargs.copy()
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.get(self.path('advisor_engine_config'), **kwargs)
         return _handle_response(response, self._server_config, synchronous, timeout)
 
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -395,6 +395,7 @@ class PathTestCase(TestCase):
             (entities.ForemanTask, 'bulk_search'),
             (entities.ForemanTask, 'summary'),
             (entities.RHCloud, 'enable_connector'),
+            (entities.RHCloud, 'advisor_engine_config'),
             (entities.Template, 'imports'),
             (entities.Template, 'exports'),
         ):
@@ -2225,6 +2226,7 @@ class GenericTestCase(TestCase):
                 'post',
                 {'organization_id': 1, 'location_id': 2},
             ),
+            (entities.RHCloud(**plain_taxonomy).advisor_engine_config, 'get', {}),
             (entities.Snapshot(**snapshot).revert, 'put', {}),
         )
 


### PR DESCRIPTION
##### Description of changes

Add `advisor_engine_config` method to the `RHCloud` entity, to call and return the response from the new API method introduced in https://github.com/theforeman/foreman_rh_cloud/pull/932

##### Upstream API documentation, plugin, or feature links

https://github.com/theforeman/foreman_rh_cloud/pull/932

Needed for robottelo tests:

SAT-30174
https://github.com/SatelliteQE/robottelo/pull/17342

##### Functional demonstration

Example:
```
>>> from robottelo.hosts import Satellite
>>> sat = Satellite(hostname='XXX')
>>> sat.api.RHCloud().advisor_engine_config()
{'use_local_advisor_engine': False}
```

##### Additional Information

