### PR TITLE
[6.17.z] Add ip6 for host class

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -4313,6 +4313,7 @@ class Host(
             'interface': entity_fields.OneToManyField(Interface),
             'interfaces_attributes': entity_fields.DictField(),
             'ip': entity_fields.StringField(),
+            'ip6': entity_fields.StringField(),
             'location': entity_fields.OneToOneField(Location, required=True),
             'mac': entity_fields.MACAddressField(),
             'managed': entity_fields.BooleanField(),


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/nailgun/pull/1282

Adding ip6 for host class required for IPv6 host to report the IPv6 address
Dependent robottelo PR: https://github.com/SatelliteQE/robottelo/pull/17340