### PR TITLE
[6.17.z] Add view/entity for booted container images page

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -4823,6 +4823,24 @@ class Host(
         response = client.get(self.path('facts'), **kwargs)
         return _handle_response(response, self._server_config, synchronous, timeout)
 
+    def get_bootc_images(self, synchronous=True, timeout=None, **kwargs):
+        """List all bootc_images, for all hosts.
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param timeout: Maximum number of seconds to wait until timing out.
+            Defaults to ``nailgun.entity_mixins.TASK_TIMEOUT``.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all content decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+        """
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.get(self.path('bootc_images'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous, timeout)
+
     def upload_facts(self, synchronous=True, timeout=None, **kwargs):
         """Upload facts for a host, creating the host if required.
 
@@ -4985,6 +5003,7 @@ class Host(
         ):
             return f'{super().path(which="self")}/{which}'
         elif which in (
+            'bootc_images',
             'bulk/add_subscriptions',
             'bulk/remove_subscriptions',
             'bulk/available_incremental_updates',


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/nailgun/pull/1277

##### Description of changes

Adds one new API endpoint that supports bootc

##### Functional demonstration
Supports: https://github.com/SatelliteQE/robottelo/pull/17634
PRT runs over there.
