### PR TITLE
Remove Python 3.10 support

### DIFF
--- a/.github/workflows/merge_to_master.yml
+++ b/.github/workflows/merge_to_master.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.11', '3.12', '3.13']
     steps:
       - name: Checkout Nailgun
         uses: actions/checkout@v4

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.11', '3.12', '3.13']
     steps:
       - name: Checkout Nailgun
         uses: actions/checkout@v4

--- a/setup.py
+++ b/setup.py
@@ -40,12 +40,11 @@ setup(
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
-        'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
     ],
     packages=find_packages(exclude=['docs', 'tests']),
     install_requires=REQUIREMENTS,
-    python_requires='>=3.10',
+    python_requires='>=3.11',
 )


### PR DESCRIPTION
### Problem Statement
We can not update the Sphinx library without dropping Python 3.10 - SatelliteQE/robottelo#17638.

### Solution
Drop Python 3.10 suport.


### Related Issues
SatelliteQE/robottelo#17638
SatelliteQE/robottelo#17666
SatelliteQE/robottelo#17557
