### PR TITLE
[6.15.z] Add setuptools to dev dependencies

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,6 +10,7 @@ sphinx
 
 # For `make package`
 wheel
+setuptools
 
 # For `make publish`
 twine


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/nailgun/pull/1286

PEP 594 caused the removal of 19 modules in Python 3.13 stdlib.

https://discuss.python.org/t/pep-594-has-been-implemented-python-3-13-removes-20-stdlib-modules/27124

We need `setuptools` to `make package`. Therefore, this patch adds an explicit dependency to `requirements-dev.txt`.


Fixing the following:
```
./setup.py sdist bdist_wheel --universal
Traceback (most recent call last):
  File "/home/runner/work/nailgun/nailgun/./setup.py", line 10, in <module>
    from setuptools import find_packages, setup
ModuleNotFoundError: No module named 'setuptools'
make: *** [Makefile:24: package] Error 1
```