### PR TITLE
Add quiesce and ram option to snapshot api

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -8025,6 +8025,8 @@ class Snapshot(
             'name': entity_fields.StringField(required=True),
             'description': entity_fields.StringField(required=False),
             'host': entity_fields.OneToOneField(Host, required=True, parent=True),
+            'include_ram': entity_fields.BooleanField(required=False),
+            'quiesce': entity_fields.BooleanField(required=False),
         }
         super().__init__(server_config=server_config, **kwargs)
         self._meta = {
@@ -8063,6 +8065,8 @@ class Snapshot(
         if ignore is None:
             ignore = set()
         ignore.add('host')
+        ignore.add('include_ram')
+        ignore.add('quiesce')
         return super().read(entity, attrs, ignore, params)
 
     def search_normalize(self, results):

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1456,7 +1456,7 @@ class ReadTestCase(TestCase):
         ):
             entities.Snapshot(self.cfg, id=2, host=3).read()
         # `call_args` is a two-tuple of (positional, keyword) args.
-        self.assertEqual({'host'}, read.call_args[0][2])
+        self.assertEqual({'quiesce', 'include_ram', 'host'}, read.call_args[0][2])
 
     def test_host_with_interface(self):
         """Call :meth:`nailgun.entities.Host.read`.


### PR DESCRIPTION
##### Description of changes

Add two missing options to snapshot api

##### Upstream API documentation, plugin, or feature links

https://github.com/ATIX-AG/foreman_snapshot_management/blob/master/app/models/foreman_snapshot_management/proxmox_extensions.rb#L13

##### Functional demonstration

```
nailgun.client - DEBUG - Making HTTP POST request to https://.../api/v2/hosts/11/snapshots with options {'auth': None, 'verify': None, 'headers': {'content-type': 'application/json'}}, no params and data {"name": "snap1_alma_9_False_True", "include_ram": true, "quiesce": false, "host_id": 11}.
2025-03-31 11:55:30 - nailgun.client - DEBUG - Received HTTP 201 response: {"description":null,"id":null,"name":"snap1_alma_9_False_True","formatted_created_at":null,"created_at":null,"parent_id":null,"children_ids":null}
```

##### Additional Information


