### PR TITLE
Add rolling key for CVs

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2900,6 +2900,7 @@ class ContentView(
                 required=True,
             ),
             'repository': entity_fields.OneToManyField(Repository),
+            'rolling': entity_fields.BooleanField(),
             'solve_dependencies': entity_fields.BooleanField(),
             'version': entity_fields.OneToManyField(ContentViewVersion),
         }

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -2558,6 +2558,7 @@ class ContentViewTestCase(TestCase):
                     "id": 3,
                 }
             ],
+            "rolling": False,
             "versions": [
                 {
                     "id": 4,


### PR DESCRIPTION
#### Description of changes
Rolling Content Views are heading into 6.18.0, see https://issues.redhat.com/browse/SAT-28495 


#### Upstream API documentation, plugin, or feature links
<sat_fqdn>/apidoc/v2/content_views/create.en.html


#### Functional demonstration
```
from robottelo.hosts import Satellite
>>> sat = Satellite('satellite.redhat.com')
>>> sat.api.ContentView(rolling=True, organization=1).create()
robottelo.hosts.DecClass(auto_publish=False, component=[], composite=False, content_host_count=0, description=None, environment=[nailgun.entities.LifecycleEnvironment(id=1)], label='avlqrtv', last_published='2025-05-07 15:29:15 UTC', name='avlqrtv', needs_publish=False, next_version='2.0', organization=nailgun.entities.Organization(id=1), repository=[], rolling=True, solve_dependencies=False, version=[nailgun.entities.ContentViewVersion(id=11)], id=12)

>>> sat.api.ContentView(id=12).read()
robottelo.hosts.DecClass(auto_publish=False, component=[], composite=False, content_host_count=0, description=None, environment=[nailgun.entities.LifecycleEnvironment(id=1)], label='avlqrtv', last_published='2025-05-07 15:29:15 UTC', name='avlqrtv', needs_publish=False, next_version='2.0', organization=nailgun.entities.Organization(id=1), repository=[], rolling=True, solve_dependencies=False, version=[nailgun.entities.ContentViewVersion(id=11)], id=12)

>>> sat.api.ContentView(id=4).read()
robottelo.hosts.DecClass(auto_publish=False, component=[], composite=False, content_host_count=0, description='', environment=[nailgun.entities.LifecycleEnvironment(id=1), nailgun.entities.LifecycleEnvironment(id=2), nailgun.entities.LifecycleEnvironment(id=8), nailgun.entities.LifecycleEnvironment(id=9)], label='CV-2', last_published='2025-05-05 09:54:59 UTC', name='CV-2', needs_publish=False, next_version='2.0', organization=nailgun.entities.Organization(id=1), repository=[nailgun.entities.Repository(id=4), nailgun.entities.Repository(id=7), nailgun.entities.Repository(id=5), nailgun.entities.Repository(id=6)], rolling=False, solve_dependencies=False, version=[nailgun.entities.ContentViewVersion(id=4)], id=4)

>>> sat.api.ContentView(id=12, description='roll').update()
robottelo.hosts.DecClass(auto_publish=False, component=[], composite=False, content_host_count=0, description='roll', environment=[nailgun.entities.LifecycleEnvironment(id=1)], label='avlqrtv', last_published='2025-05-07 15:29:15 UTC', name='avlqrtv', needs_publish=False, next_version='2.0', organization=nailgun.entities.Organization(id=1), repository=[], rolling=True, solve_dependencies=False, version=[nailgun.entities.ContentViewVersion(id=11)], id=12)

>>> sat.api.ContentView(id=12).delete()
{'id': 'f9f18989-dc85-4f51-bbfe-100f4f6ece0f', 'label': 'Actions::Katello::ContentView::Destroy', 'pending': False, 'action': "Delete content view 'avlqrtv'; organization 'Default Organization'", 'username': 'admin', 'started_at': '2025-05-07 15:38:04 UTC', 'ended_at': '2025-05-07 15:38:04 UTC', 'duration': '0.284156', 'state': 'stopped', 'result': 'success', 'progress': 1.0, 'input': {'content_view': {'id': 12, 'name': 'avlqrtv', 'label': 'avlqrtv'}, 'organization': {'id': 1, 'name': 'Default Organization', 'label': 'Default_Organization'}, 'services_checked': ['pulp3'], 'remote_user': 'admin', 'remote_cp_user': 'admin', 'current_request_id': '93912913-e6a5-40c4-87cc-13dac7a0f00a', 'current_timezone': 'UTC', 'current_organization_id': None, 'current_location_id': None, 'current_user_id': 4}, 'output': {}, 'humanized': {'action': 'Delete', 'input': [['content_view', {'text': "content view 'avlqrtv'", 'link': '/content_views/12/versions'}], ['organization', {'text': "organization 'Default Organization'", 'link': '/organizations/1/edit'}]], 'output': '', 'errors': []}, 'cli_example': None, 'start_at': '2025-05-07 15:38:04 UTC', 'available_actions': {'cancellable': False, 'resumable': False}}
```

