### PR TITLE
[6.16.z] ContentView::RemoveVersion (from the CV and any ENVs)

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2986,6 +2986,8 @@ class ContentView(
             /content_views/<id>/content_view_versions
         publish
             /content_views/<id>/publish
+        remove
+            /content_views/<id>/remove
 
         ``super`` is called otherwise.
 
@@ -2994,6 +2996,7 @@ class ContentView(
             'content_view_versions',
             'copy',
             'publish',
+            'remove',
         ):
             return f'{super().path(which="self")}/{which}'
         return super().path(which)
@@ -3017,6 +3020,42 @@ class ContentView(
             kwargs['data']['id'] = self.id
         kwargs.update(self._server_config.get_client_kwargs())
         response = client.post(self.path('publish'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous, timeout)
+
+    def remove_version(self, versions, synchronous=True, timeout=None):
+        """Remove published content view Version(s) from this content view.
+
+        Also remove the CV from the Version's environment(s), including Library.
+
+        :param versions: ContentViewVersion (entity) or ID (int) to remove.
+            can also pass a list of entities, or a list of IDs.
+        """
+        content_view = self.read()
+        matched_versions = []
+        environment_ids = set()
+        # Normalize into a list of ids; from a single entity/:id, or a list.
+        if isinstance(versions, list):
+            version_ids = [v.id if hasattr(v, 'id') else int(v) for v in versions]
+        else:
+            version_ids = [versions.id if hasattr(versions, 'id') else int(versions)]
+        # Match the Version ID from CV to the provided Versions
+        for vid in version_ids:
+            matched_versions = [v for v in content_view.version if v.id == vid]
+            for version in matched_versions:
+                v = version.read()
+                environment_ids.update(env.id for env in v.environment)
+        if not matched_versions:
+            raise ValueError(
+                f'No Version(s) or :id(s) provided: {versions} ,'
+                f' matched the published Versions of the Content-View[id:{content_view.id}]: {content_view.version}'
+            )
+        environment_ids = list(environment_ids)
+        # PUT request: `remove` these CVV-ids and ENV-ids from this CV.
+        response = client.put(
+            f'{self.path("remove")}',
+            json={'content_view_version_ids': version_ids, 'environment_ids': environment_ids},
+            **self._server_config.get_client_kwargs(),
+        )
         return _handle_response(response, self._server_config, synchronous, timeout)
 
     def copy(self, synchronous=True, timeout=None, **kwargs):


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/nailgun/pull/1304

### Problem Statement
**_1:_** Currently, we cannot api DELETE a `ContentViewVersion` if it is published to any LCE, including Library, ISE 500.
**_2:_** There is no api method to remove/delete a `ContentViewVersion` from the `ContentView` , only for removing a single environment by :id
***_3:_*** We do not currently have an api method that calls the same endpoint, as the UI ContentViewVersion Delete wizard. 
See solution.

### Related Issues
- We must first remove the Version from any published/promoted environments, including library, before attempting to Delete.
- `ContentViewVersion.delete()` calls the Katello Destroy api, performs no checks or steps before 
     attempting bulk Destroy. `DELETE , "/content_view_versions/:id", ("Remove content view version")`
^ on any published CVV, yields:  
     ```
     E  requests.exceptions.HTTPError: ('500 Server Error: Internal Server Error for 
     HOSTNAME/katello/api/v2/content_view_versions/11', {'displayMessage': 'Cannot delete version while it 
     is in environments: Library', 'errors': ['Cannot delete version while it is in environments: Library']})
     ```

### Solution
- Would rather not override the `super() delete()` method for `ContentViewVersion` entity, and would have to remove from environments anyway. 
- Instead, lets add the method to `ContentView` entity: 
`CV.remove_version( CVV entity(ies)/:id(s), single or list )` 
from the CV called upon, as it is a slightly more involved process.
- endpoint `PUT, "/katello/api/v2/content_views/:id/remove"`
- or call via 
```
     _satellite.api.ContentView(:id).remove_version(
         versions={list or single}, synchronous, timeout,
     )
```

Similar in process to Robottelo's Hammer method- `cli.ContentView.remove({'content-view-versions': , 'id': })`
^ ref: [github/satQE/robottelo/master/cli/contentview.py#195](https://github.com/SatelliteQE/robottelo/blob/6ce068a74b9d4981a29ee1ba4901a716d92fb4a7/robottelo/cli/contentview.py#L195)

### PRT
Used in Repos/CV/AK cleanup of the following Robottelo MR, CoreFixture: Multiple Registered Contenthosts
[(Robottelo #18469)](https://github.com/SatelliteQE/robottelo/pull/18469)