### PR TITLE
Remove 6.14.z from dependabot PR labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,8 +15,6 @@ updates:
       - "CherryPick"
       - "dependencies"
       - "6.15.z"
-      - "6.14.z"
-      - "6.13.z"
 
   # Maintain dependencies for our GitHub Actions
   - package-ecosystem: "github-actions"
@@ -29,5 +27,3 @@ updates:
       - "CherryPick"
       - "dependencies"
       - "6.15.z"
-      - "6.14.z"
-      - "6.13.z"


### PR DESCRIPTION
### Problem Statement
6.14 became unsupported. Dependabot still labels its PRs with 6.14.z label.

### Solution
configure dependabot to not add the 6.14.z label to it's PRs

