### PR TITLE
Add explicit timeout to `entity_callable()` invocation in `call_entity_with_timeout()`

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -6603,7 +6603,7 @@ class Product(
         kwargs = kwargs.copy()  # shadow the passed-in kwargs
         kwargs.update(self._server_config.get_client_kwargs())
         response = client.post(self.path('sync'), **kwargs)
-        return _handle_response(response, self._server_config, synchronous, timeout)
+        return _handle_response(response, self._server_config, synchronous, timeout=timeout)
 
 
 class ProductBulkAction(Entity):

--- a/nailgun/entity_mixins.py
+++ b/nailgun/entity_mixins.py
@@ -73,7 +73,7 @@ def call_entity_method_with_timeout(entity_callable, timeout=300, **kwargs):
     original_task_timeout = TASK_TIMEOUT
     TASK_TIMEOUT = timeout
     try:
-        entity_callable(**kwargs)
+        entity_callable(timeout=timeout, **kwargs)
     finally:
         TASK_TIMEOUT = original_task_timeout
 


### PR DESCRIPTION
I found this issue while working on a Robottelo upgrade scenario refactor. I found that a test syncing the RHEL 7 server RPMs repo was consistently timing out after 300 seconds, though the `enable_sync_redhat_repo` API factory method uses a timeout of 1500 seconds by default. Eventually, I found that
`nailgun.entity_mixins.call_entity_with_timeout()` was invoking the entity callable without specifically passing the timeout. After the repo sync was initiated, `nailgun.entity_mixins._poll_task()` was being called with no timeout value specified, causing the `timeout` variable to be set to the `TASK_TIMEOUT` constant defined in the entity_mixins module, which has a value of 300 seconds. My repo sync was completing in ~360 seconds, so the test was consistently failing.

This PR adds a `timeout` keyword argument to the `entity_callable()` in `call_entity_with_timeout()` and, in the repository `sync()` entity method, changes the `timeout` argument in the call to `_handle_response()` from a keywork argument to a positional argument.