### PR TITLE
Add http_proxy to the SmartProxy entity

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -7950,9 +7950,10 @@ class SmartProxy(
     def __init__(self, server_config=None, **kwargs):
         self._fields = {
             'download_policy': entity_fields.StringField(
-                choices=('background', 'immediate', 'on_demand'),
+                choices=('on_demand', 'immediate', 'inherit', 'streamed'),
                 default='on_demand',
             ),
+            'http_proxy': entity_fields.OneToOneField(HTTPProxy),
             'name': entity_fields.StringField(
                 required=True, str_type='alpha', length=(6, 12), unique=True
             ),
@@ -8038,6 +8039,7 @@ class SmartProxy(
         if ignore is None:
             ignore = set()
         ignore.add('download_policy')
+        ignore.add('http_proxy')
         return super().read(entity, attrs, ignore, params)
 
     def update(self, fields=None):

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1288,7 +1288,7 @@ class ReadTestCase(TestCase):
             (entities.AzureRMComputeResource, {'secret_key'}),
             (entities.Errata, {'content_view_version', 'environment', 'repository'}),
             (entities.OVirtComputeResource, {'password'}),
-            (entities.SmartProxy, {'download_policy'}),
+            (entities.SmartProxy, {'download_policy', 'http_proxy'}),
             (entities.SmartClassParameters, {'hidden_value'}),
             (
                 entities.Subnet,


### PR DESCRIPTION
#### Description of changes
We can set ACS HTP proxy on any Capsule since long ago. This has never been added to the nailgun as it was never used and the endpoint doesn't return it on read. But now I can see a use case suitable for IPv6 testing.

This PR also updates the download policies to more recent values.

Robottelo PR will follow.


#### Upstream API documentation, plugin, or feature links
https://satellite.redhat.com/apidoc/v2/smart_proxies/update.en.html


#### Functional demonstration
```
sat = Satellite('satellite.redhat.com')
proxy = sat.enable_satellite_http_proxy()
caps = sat.nailgun_smart_proxy
caps.http_proxy = proxy
caps.update(['http_proxy'])
robottelo.hosts.DecClass(name='satellite.redhat.com', url='https://satellite.redhat.com:9090', location=[nailgun.entities.Location(id=2)], organization=[nailgun.entities.Organization(id=1), nailgun.entities.Organization(id=3)], id=1)
-> go to UI/Infrastructure/Capsules, click Edit on the internal capsule -> see the ACS HTTP Proxy has been updated
```
