### PR TITLE
[6.16.z] Replace hardcoded temp file path with tempfile in tests/test_config.py

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,6 +2,7 @@
 
 import builtins
 import json
+import tempfile
 from unittest import TestCase
 from unittest.mock import call, mock_open, patch
 
@@ -14,7 +15,7 @@ from nailgun.config import (
     _get_config_file_path,
 )
 
-FILE_PATH = '/tmp/bogus.json'  # noqa: S108
+FILE_PATH = tempfile.NamedTemporaryFile(suffix='.json', delete=False).name
 CONFIGS = {
     'default': {'url': 'http://example.com'},
     'Ask Aak': {'url': 'bogus value', 'auth': ['username', 'password']},


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/nailgun/pull/1316

This PR addresses a security best practice issue by replacing the hardcoded temporary file path `/tmp/bogus.json` with Python's standard `tempfile` module.

## Changes

- Added `import tempfile` to the imports
- Replaced `FILE_PATH = '/tmp/bogus.json'  # noqa: S108` with `FILE_PATH = tempfile.NamedTemporaryFile(suffix='.json', delete=False).name`
- Removed the `# noqa: S108` comment since the hardcoded temp file issue is now resolved

## Why this change?

The original code used a hardcoded path `/tmp/bogus.json` which violates security best practices (ruff rule S108 - hardcoded-temp-file). While the tests use mocked file operations and don't actually access the filesystem, using proper temporary file generation is the recommended approach.

## Testing

- All existing tests continue to pass (272 tests)
- The generated temporary file path maintains the same behavior for mocked operations
- Ruff linting now passes without needing the `# noqa: S108` suppression

The change is minimal and safe since all file operations in the tests are mocked with `mock_open`, so the actual file path value doesn't affect test behavior.

Fixes #982.

<!-- START COPILOT CODING AGENT TIPS -->
---

💬 Share your feedback on Copilot coding agent for the chance to win a $200 gift card! Click [here](https://survey.alchemer.com/s3/8343779/Copilot-Coding-agent) to start the survey.