### PR TITLE
[6.14.z] Add missing timeout when calling entity with timeout

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -6265,7 +6265,7 @@ class Product(
         kwargs = kwargs.copy()  # shadow the passed-in kwargs
         kwargs.update(self._server_config.get_client_kwargs())
         response = client.post(self.path('sync'), **kwargs)
-        return _handle_response(response, self._server_config, synchronous, timeout)
+        return _handle_response(response, self._server_config, synchronous, timeout=timeout)
 
 
 class ProductBulkAction(Entity):

--- a/nailgun/entity_mixins.py
+++ b/nailgun/entity_mixins.py
@@ -73,7 +73,7 @@ def call_entity_method_with_timeout(entity_callable, timeout=300, **kwargs):
     original_task_timeout = TASK_TIMEOUT
     TASK_TIMEOUT = timeout
     try:
-        entity_callable(**kwargs)
+        entity_callable(timeout=timeout, **kwargs)
     finally:
         TASK_TIMEOUT = original_task_timeout
 


### PR DESCRIPTION
Manual cherry pick of https://github.com/SatelliteQE/nailgun/pull/1311. We need to cherry pick this back to 6.14.z for some upgrade scenarios. For example, this is currently blocking https://github.com/SatelliteQE/robottelo/pull/18972.