### PR TITLE
[6.15.z] Add description key to _fields dictionary

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -2058,6 +2058,7 @@ class JobTemplate(
     def __init__(self, server_config=None, **kwargs):
         self._fields = {
             'audit_comment': entity_fields.StringField(),
+            'description': entity_fields.StringField(),
             'description_format': entity_fields.StringField(),
             'effective_user': entity_fields.DictField(),
             'job_category': entity_fields.StringField(),

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -2843,6 +2843,7 @@ class JobTemplateTestCase(TestCase):
         self.data = {
             'id': 1,
             'audit_comment': None,
+            'description': None,
             'description_format': None,
             'effective_user': None,
             'job_category': 'Commands',


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/nailgun/pull/1324

Adding description key to _fields dictionary to incorporate description feature for job-template 

Dependent PR: https://github.com/SatelliteQE/robottelo/pull/19093