### PR TITLE
Fix ruff linting issues to prepare for version bump

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -4987,8 +4987,8 @@ class Host(
         # the given host, but only if it does not have Puppet proxy assigned.
         if (
             'Puppet' not in _feature_list(self._server_config)
-            or 'puppetclasses' not in attrs
-            and not attrs['puppet_proxy']
+            or ('puppetclasses' not in attrs
+            and not attrs['puppet_proxy'])
         ):
             ignore.add('puppetclass')
         result = super().read(entity, attrs, ignore, params)

--- a/nailgun/entity_mixins.py
+++ b/nailgun/entity_mixins.py
@@ -614,6 +614,12 @@ class Entity:
             return False
         return self.to_json_dict() == other.to_json_dict()
 
+    def __hash__(self):
+        """Return hash based on entity type and id if available."""
+        if hasattr(self, 'id') and self.id is not None:
+            return hash((type(self), self.id))
+        return hash(type(self))
+
     def compare(self, other, filter_fcn=None):
         """Return True if properties can be compared in terms of eq.
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -221,7 +221,7 @@ class ReprTestCase(TestCase):
         """
         target = "nailgun.config.BaseServerConfig(url='bogus')"
         self.assertEqual(target, repr(BaseServerConfig('bogus')))
-        import nailgun
+        import nailgun  # noqa: PLC0415
 
         self.assertEqual(target, repr(eval(repr(BaseServerConfig('bogus')))))
 
@@ -237,7 +237,7 @@ class ReprTestCase(TestCase):
             "nailgun.config.BaseServerConfig(auth='flam', url='flim')",
         )
         self.assertIn(repr(BaseServerConfig('flim', auth='flam')), targets)
-        import nailgun
+        import nailgun  # noqa: PLC0415
 
         self.assertIn(repr(eval(repr(BaseServerConfig('flim', auth='flam')))), targets)
 
@@ -262,7 +262,7 @@ class ReprTestCase(TestCase):
         """
         target = "nailgun.config.ServerConfig(url='bogus')"
         self.assertEqual(target, repr(ServerConfig('bogus')))
-        import nailgun
+        import nailgun  # noqa: PLC0415
 
         self.assertEqual(target, repr(eval(repr(ServerConfig('bogus')))))
 
@@ -278,7 +278,7 @@ class ReprTestCase(TestCase):
             "nailgun.config.ServerConfig(auth='flam', url='flim')",
         )
         self.assertIn(repr(ServerConfig('flim', auth='flam')), targets)
-        import nailgun
+        import nailgun  # noqa: PLC0415
 
         self.assertIn(repr(eval(repr(ServerConfig('flim', auth='flam')))), targets)
 
@@ -307,7 +307,7 @@ class ReprTestCase(TestCase):
             "nailgun.config.ServerConfig(verify='flub', url='flim')",
         )
         self.assertIn(repr(ServerConfig('flim', verify='flub')), targets)
-        import nailgun
+        import nailgun  # noqa: PLC0415
 
         self.assertIn(repr(eval(repr(ServerConfig('flim', verify='flub')))), targets)
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -3013,15 +3013,15 @@ class HostGroupTestCase(TestCase):
         entity = self.entity
         entity.id = 1
         func_param_dict = {entity.add_ansible_role: 'ansible_role_id'}
-        for func in func_param_dict:
+        for func, param in func_param_dict.items():
             self.assertEqual(inspect.getfullargspec(func), EXPECTED_ARGSPEC)
-            kwargs = {'kwarg': gen_integer(), 'data': {func_param_dict[func]: gen_integer()}}
+            kwargs = {'kwarg': gen_integer(), 'data': {param: gen_integer()}}
             with mock.patch.object(entities, '_handle_response') as handlr:
                 with mock.patch.object(client, 'put') as client_request:
                     response = func(**kwargs)
             self.assertEqual(client_request.call_count, 1)
             self.assertEqual(len(client_request.call_args[0]), 1)
-            self.assertNotIn(func_param_dict[func], client_request.call_args[1]['data'])
+            self.assertNotIn(param, client_request.call_args[1]['data'])
             self.assertEqual(client_request.call_args[1], kwargs)
             self.assertEqual(handlr.call_count, 1)
             self.assertEqual(handlr.return_value, response)
@@ -3044,15 +3044,15 @@ class HostGroupTestCase(TestCase):
             entity.delete_puppetclass: 'puppetclass_id',
             entity.remove_ansible_role: 'ansible_role_id',
         }
-        for func in func_param_dict:
+        for func, param in func_param_dict.items():
             self.assertEqual(inspect.getfullargspec(func), EXPECTED_ARGSPEC)
-            kwargs = {'kwarg': gen_integer(), 'data': {func_param_dict[func]: gen_integer()}}
+            kwargs = {'kwarg': gen_integer(), 'data': {param: gen_integer()}}
             with mock.patch.object(entities, '_handle_response') as handlr:
                 with mock.patch.object(client, 'delete') as client_request:
                     response = func(**kwargs)
             self.assertEqual(client_request.call_count, 1)
             self.assertEqual(len(client_request.call_args[0]), 1)
-            self.assertNotIn(func_param_dict[func], client_request.call_args[1]['data'])
+            self.assertNotIn(param, client_request.call_args[1]['data'])
             self.assertEqual(client_request.call_args[1], kwargs)
             self.assertEqual(handlr.call_count, 1)
             self.assertEqual(handlr.return_value, response)
@@ -3190,15 +3190,15 @@ class HostTestCase(TestCase):
         """
         entity = entities.Host(self.cfg, id=1)
         func_param_dict = {entity.add_ansible_role: 'ansible_role_id'}
-        for func in func_param_dict:
+        for func, param in func_param_dict.items():
             self.assertEqual(inspect.getfullargspec(func), EXPECTED_ARGSPEC)
-            kwargs = {'kwarg': gen_integer(), 'data': {func_param_dict[func]: gen_integer()}}
+            kwargs = {'kwarg': gen_integer(), 'data': {param: gen_integer()}}
             with mock.patch.object(entities, '_handle_response') as handlr:
                 with mock.patch.object(client, 'put') as client_request:
                     response = func(**kwargs)
             self.assertEqual(client_request.call_count, 1)
             self.assertEqual(len(client_request.call_args[0]), 1)
-            self.assertNotIn(func_param_dict[func], client_request.call_args[1]['data'])
+            self.assertNotIn(param, client_request.call_args[1]['data'])
             self.assertEqual(client_request.call_args[1], kwargs)
             self.assertEqual(handlr.call_count, 1)
             self.assertEqual(handlr.return_value, response)
@@ -3220,15 +3220,15 @@ class HostTestCase(TestCase):
             entity.delete_puppetclass: 'puppetclass_id',
             entity.remove_ansible_role: 'ansible_role_id',
         }
-        for func in func_param_dict:
+        for func, param in func_param_dict.items():
             self.assertEqual(inspect.getfullargspec(func), EXPECTED_ARGSPEC)
-            kwargs = {'kwarg': gen_integer(), 'data': {func_param_dict[func]: gen_integer()}}
+            kwargs = {'kwarg': gen_integer(), 'data': {param: gen_integer()}}
             with mock.patch.object(entities, '_handle_response') as handlr:
                 with mock.patch.object(client, 'delete') as client_request:
                     response = func(**kwargs)
             self.assertEqual(client_request.call_count, 1)
             self.assertEqual(len(client_request.call_args[0]), 1)
-            self.assertNotIn(func_param_dict[func], client_request.call_args[1]['data'])
+            self.assertNotIn(param, client_request.call_args[1]['data'])
             self.assertEqual(client_request.call_args[1], kwargs)
             self.assertEqual(handlr.call_count, 1)
             self.assertEqual(handlr.return_value, response)

--- a/tests/test_entity_mixins.py
+++ b/tests/test_entity_mixins.py
@@ -475,8 +475,8 @@ class EntityTestCase(TestCase):
             config.ServerConfig.get()
         except (KeyError, config.ConfigFileError):
             self.cfg.save()
-        import nailgun
-        import tests
+        import nailgun  # noqa: PLC0415
+        import tests  # noqa: PLC0415
 
         self.assertEqual(repr(eval(repr(entity))), target)
 
@@ -495,8 +495,8 @@ class EntityTestCase(TestCase):
             config.ServerConfig.get()
         except (KeyError, config.ConfigFileError):
             self.cfg.save()
-        import nailgun
-        import tests
+        import nailgun  # noqa: PLC0415
+        import tests  # noqa: PLC0415
 
         self.assertEqual(repr(eval(repr(entity))), target)
 
@@ -519,8 +519,8 @@ class EntityTestCase(TestCase):
             config.ServerConfig.get()
         except (KeyError, config.ConfigFileError):
             self.cfg.save()
-        import nailgun
-        import tests
+        import nailgun  # noqa: PLC0415
+        import tests  # noqa: PLC0415
 
         self.assertEqual(repr(eval(repr(entity))), target)
 


### PR DESCRIPTION
## Summary
- Fix PLW1641: Add `__hash__` method to Entity class
- Fix PLC0206: Use `.items()` for dictionary iteration instead of iterating over keys
- Fix PLC0415: Add noqa comments for intentional mid-function imports needed for `eval()` testing

## Test plan
- [x] All existing tests pass (272 tests)
- [x] `ruff check` passes with no errors
- [x] `make test` succeeds

This PR prepares the codebase for upcoming ruff version bumps by addressing current linting issues while maintaining backward compatibility and test functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)