### PR TITLE
[6.16.z] Fix ruff linting issues to prepare for version bump

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -4782,10 +4782,8 @@ class Host(
         # Ignore puppetclass attribute if we are running against Puppet disabled
         # instance. Ignore it also if the API does not return puppetclasses for
         # the given host, but only if it does not have Puppet proxy assigned.
-        if (
-            'Puppet' not in _feature_list(self._server_config)
-            or 'puppetclasses' not in attrs
-            and not attrs['puppet_proxy']
+        if 'Puppet' not in _feature_list(self._server_config) or (
+            'puppetclasses' not in attrs and not attrs['puppet_proxy']
         ):
             ignore.add('puppetclass')
         result = super().read(entity, attrs, ignore, params)

--- a/nailgun/entity_mixins.py
+++ b/nailgun/entity_mixins.py
@@ -614,6 +614,12 @@ class Entity:
             return False
         return self.to_json_dict() == other.to_json_dict()
 
+    def __hash__(self):
+        """Return hash based on entity type and id if available."""
+        if getattr(self, 'id', None) is not None:
+            return hash((type(self), self.id))
+        return hash(type(self))
+
     def compare(self, other, filter_fcn=None):
         """Return True if properties can be compared in terms of eq.
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -2997,15 +2997,15 @@ class HostGroupTestCase(TestCase):
         entity = self.entity
         entity.id = 1
         func_param_dict = {entity.add_ansible_role: 'ansible_role_id'}
-        for func in func_param_dict:
+        for func, param in func_param_dict.items():
             self.assertEqual(inspect.getfullargspec(func), EXPECTED_ARGSPEC)
-            kwargs = {'kwarg': gen_integer(), 'data': {func_param_dict[func]: gen_integer()}}
+            kwargs = {'kwarg': gen_integer(), 'data': {param: gen_integer()}}
             with mock.patch.object(entities, '_handle_response') as handlr:
                 with mock.patch.object(client, 'put') as client_request:
                     response = func(**kwargs)
             self.assertEqual(client_request.call_count, 1)
             self.assertEqual(len(client_request.call_args[0]), 1)
-            self.assertNotIn(func_param_dict[func], client_request.call_args[1]['data'])
+            self.assertNotIn(param, client_request.call_args[1]['data'])
             self.assertEqual(client_request.call_args[1], kwargs)
             self.assertEqual(handlr.call_count, 1)
             self.assertEqual(handlr.return_value, response)
@@ -3028,15 +3028,15 @@ class HostGroupTestCase(TestCase):
             entity.delete_puppetclass: 'puppetclass_id',
             entity.remove_ansible_role: 'ansible_role_id',
         }
-        for func in func_param_dict:
+        for func, param in func_param_dict.items():
             self.assertEqual(inspect.getfullargspec(func), EXPECTED_ARGSPEC)
-            kwargs = {'kwarg': gen_integer(), 'data': {func_param_dict[func]: gen_integer()}}
+            kwargs = {'kwarg': gen_integer(), 'data': {param: gen_integer()}}
             with mock.patch.object(entities, '_handle_response') as handlr:
                 with mock.patch.object(client, 'delete') as client_request:
                     response = func(**kwargs)
             self.assertEqual(client_request.call_count, 1)
             self.assertEqual(len(client_request.call_args[0]), 1)
-            self.assertNotIn(func_param_dict[func], client_request.call_args[1]['data'])
+            self.assertNotIn(param, client_request.call_args[1]['data'])
             self.assertEqual(client_request.call_args[1], kwargs)
             self.assertEqual(handlr.call_count, 1)
             self.assertEqual(handlr.return_value, response)
@@ -3174,15 +3174,15 @@ class HostTestCase(TestCase):
         """
         entity = entities.Host(self.cfg, id=1)
         func_param_dict = {entity.add_ansible_role: 'ansible_role_id'}
-        for func in func_param_dict:
+        for func, param in func_param_dict.items():
             self.assertEqual(inspect.getfullargspec(func), EXPECTED_ARGSPEC)
-            kwargs = {'kwarg': gen_integer(), 'data': {func_param_dict[func]: gen_integer()}}
+            kwargs = {'kwarg': gen_integer(), 'data': {param: gen_integer()}}
             with mock.patch.object(entities, '_handle_response') as handlr:
                 with mock.patch.object(client, 'put') as client_request:
                     response = func(**kwargs)
             self.assertEqual(client_request.call_count, 1)
             self.assertEqual(len(client_request.call_args[0]), 1)
-            self.assertNotIn(func_param_dict[func], client_request.call_args[1]['data'])
+            self.assertNotIn(param, client_request.call_args[1]['data'])
             self.assertEqual(client_request.call_args[1], kwargs)
             self.assertEqual(handlr.call_count, 1)
             self.assertEqual(handlr.return_value, response)
@@ -3204,15 +3204,15 @@ class HostTestCase(TestCase):
             entity.delete_puppetclass: 'puppetclass_id',
             entity.remove_ansible_role: 'ansible_role_id',
         }
-        for func in func_param_dict:
+        for func, param in func_param_dict.items():
             self.assertEqual(inspect.getfullargspec(func), EXPECTED_ARGSPEC)
-            kwargs = {'kwarg': gen_integer(), 'data': {func_param_dict[func]: gen_integer()}}
+            kwargs = {'kwarg': gen_integer(), 'data': {param: gen_integer()}}
             with mock.patch.object(entities, '_handle_response') as handlr:
                 with mock.patch.object(client, 'delete') as client_request:
                     response = func(**kwargs)
             self.assertEqual(client_request.call_count, 1)
             self.assertEqual(len(client_request.call_args[0]), 1)
-            self.assertNotIn(func_param_dict[func], client_request.call_args[1]['data'])
+            self.assertNotIn(param, client_request.call_args[1]['data'])
             self.assertEqual(client_request.call_args[1], kwargs)
             self.assertEqual(handlr.call_count, 1)
             self.assertEqual(handlr.return_value, response)


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/nailgun/pull/1328

## Summary
- Fix PLW1641: Add `__hash__` method to Entity class
- Fix PLC0206: Use `.items()` for dictionary iteration instead of iterating over keys
- Apply Black formatting fixes for code style consistency

## Test plan
- [x] All existing tests pass (272 tests)
- [x] `ruff check` passes with no errors
- [x] `make test` succeeds
- [x] `pre-commit run -a` passes all hooks (black, ruff, check yaml, debug statements)

This PR prepares the codebase for upcoming ruff version bump #1253 by addressing current linting issues while maintaining backward compatibility and test functionality. All pre-commit hooks now pass successfully.

🤖 Generated with [Claude Code](https://claude.ai/code)