### PR TITLE
[6.17.z] [pre-commit.ci] pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,16 +5,16 @@ ci:
 
 repos:
 - repo: https://github.com/psf/black
-  rev: 24.10.0
+  rev: 25.1.0
   hooks:
   - id: black
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.7.3
+  rev: v0.12.8
   hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v5.0.0
+  rev: v6.0.0
   hooks:
   - id: check-yaml
   - id: debug-statements

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -221,7 +221,7 @@ class ReprTestCase(TestCase):
         """
         target = "nailgun.config.BaseServerConfig(url='bogus')"
         self.assertEqual(target, repr(BaseServerConfig('bogus')))
-        import nailgun
+        import nailgun  # noqa: PLC0415
 
         self.assertEqual(target, repr(eval(repr(BaseServerConfig('bogus')))))
 
@@ -237,7 +237,7 @@ class ReprTestCase(TestCase):
             "nailgun.config.BaseServerConfig(auth='flam', url='flim')",
         )
         self.assertIn(repr(BaseServerConfig('flim', auth='flam')), targets)
-        import nailgun
+        import nailgun  # noqa: PLC0415
 
         self.assertIn(repr(eval(repr(BaseServerConfig('flim', auth='flam')))), targets)
 
@@ -262,7 +262,7 @@ class ReprTestCase(TestCase):
         """
         target = "nailgun.config.ServerConfig(url='bogus')"
         self.assertEqual(target, repr(ServerConfig('bogus')))
-        import nailgun
+        import nailgun  # noqa: PLC0415
 
         self.assertEqual(target, repr(eval(repr(ServerConfig('bogus')))))
 
@@ -278,7 +278,7 @@ class ReprTestCase(TestCase):
             "nailgun.config.ServerConfig(auth='flam', url='flim')",
         )
         self.assertIn(repr(ServerConfig('flim', auth='flam')), targets)
-        import nailgun
+        import nailgun  # noqa: PLC0415
 
         self.assertIn(repr(eval(repr(ServerConfig('flim', auth='flam')))), targets)
 
@@ -307,7 +307,7 @@ class ReprTestCase(TestCase):
             "nailgun.config.ServerConfig(verify='flub', url='flim')",
         )
         self.assertIn(repr(ServerConfig('flim', verify='flub')), targets)
-        import nailgun
+        import nailgun  # noqa: PLC0415
 
         self.assertIn(repr(eval(repr(ServerConfig('flim', verify='flub')))), targets)
 

--- a/tests/test_entity_mixins.py
+++ b/tests/test_entity_mixins.py
@@ -475,8 +475,8 @@ class EntityTestCase(TestCase):
             config.ServerConfig.get()
         except (KeyError, config.ConfigFileError):
             self.cfg.save()
-        import nailgun
-        import tests
+        import nailgun  # noqa: PLC0415
+        import tests  # noqa: PLC0415
 
         self.assertEqual(repr(eval(repr(entity))), target)
 
@@ -495,8 +495,8 @@ class EntityTestCase(TestCase):
             config.ServerConfig.get()
         except (KeyError, config.ConfigFileError):
             self.cfg.save()
-        import nailgun
-        import tests
+        import nailgun  # noqa: PLC0415
+        import tests  # noqa: PLC0415
 
         self.assertEqual(repr(eval(repr(entity))), target)
 
@@ -519,8 +519,8 @@ class EntityTestCase(TestCase):
             config.ServerConfig.get()
         except (KeyError, config.ConfigFileError):
             self.cfg.save()
-        import nailgun
-        import tests
+        import nailgun  # noqa: PLC0415
+        import tests  # noqa: PLC0415
 
         self.assertEqual(repr(eval(repr(entity))), target)
 


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/nailgun/pull/1253

<!--pre-commit.ci start-->
updates:
- [github.com/psf/black: 24.10.0 → 25.1.0](https://github.com/psf/black/compare/24.10.0...25.1.0)
- [github.com/astral-sh/ruff-pre-commit: v0.7.3 → v0.12.8](https://github.com/astral-sh/ruff-pre-commit/compare/v0.7.3...v0.12.8)
- [github.com/pre-commit/pre-commit-hooks: v5.0.0 → v6.0.0](https://github.com/pre-commit/pre-commit-hooks/compare/v5.0.0...v6.0.0)
<!--pre-commit.ci end-->