### PR TITLE
Add application_name field to FlatpakRemoteRepository

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -3553,6 +3553,7 @@ class FlatpakRemoteRepository(
         self._fields = {
             'flatpak_remote_id': entity_fields.IntegerField(required=True),
             'name': entity_fields.StringField(),
+            'application_name': entity_fields.StringField(),
             'label': entity_fields.StringField(),
         }
         self._meta = {


### PR DESCRIPTION
##### Description of changes
Recently the `application_name` has been added to the flatpak remote repository to help users pick the correct app name for REX. However, we could use that information too. We just need to add it to the known fields.


##### Functional demonstration
```
>>> from robottelo.hosts import Satellite
>>> sat = Satellite('SAT_FQDN')
>>> sat.api.FlatpakRemoteRepository(id=9).read()
robottelo.hosts.DecClass(flatpak_remote_id=3, name='rhel10/firefox-flatpak', application_name='org.mozilla.firefox', label='8ec304a4-3e65-46da-ba89-2f2fd1256fda', id=9)
```

