### PR TITLE
[master]: Changes for 6.18.z new branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
     schedule:
       interval: "daily"
     labels:
+      - '6.18.z'
       - '6.17.z'
       - '6.16.z'
       - "CherryPick"
@@ -22,6 +23,7 @@ updates:
     schedule:
       interval: "daily"
     labels:
+      - '6.18.z'
       - '6.17.z'
       - '6.16.z'
       - "CherryPick"


### PR DESCRIPTION

  ### Problem Statement
  New 6.18.z downstream and master points to stream that is 6.19
  ### Solution
  - Dependabot.yaml cherrypicks to 6.18.z
