### PR TITLE
[6.17.z] Add entity for content view environments endpoint

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -3200,6 +3200,42 @@ class ContentViewComponent(Entity, EntityReadMixin, EntityUpdateMixin):
         return _handle_response(response, self._server_config, synchronous, timeout)
 
 
+class ContentViewEnvironment(
+    Entity,
+):
+    """A representation of a Content View Environments entity."""
+
+    def __init__(self, server_config=None, **kwargs):
+        self._fields = {
+            'organization_id': entity_fields.IntegerField(),
+            'label': entity_fields.StringField(),
+            'lifecycle_environment_id': entity_fields.IntegerField(),
+            'content_view_id': entity_fields.IntegerField(),
+            'activation_key_id': entity_fields.IntegerField(),
+            'host_id': entity_fields.IntegerField(),
+            'search': entity_fields.StringField(),
+            'page': entity_fields.IntegerField(),
+            'per_page': entity_fields.IntegerField(),
+            'order': entity_fields.StringField(),
+            'full_result': entity_fields.BooleanField(),
+            'sort_by': entity_fields.StringField(),
+            'sort_order': entity_fields.StringField(),
+        }
+        self._meta = {
+            'api_path': 'katello/api/content_view_environments',
+            'read_type': 'base',
+        }
+        super().__init__(server_config=server_config, **kwargs)
+
+    def list_content_view_environments(self, params=None, synchronous=True, timeout=None, **kwargs):
+        """Get the list of content view environments, passing along any query parameters."""
+        kwargs = kwargs.copy()
+        kwargs.update(self._server_config.get_client_kwargs())
+        url = f'{self._server_config.url}/{self._meta["api_path"]}'
+        response = client.get(url, params=params, **kwargs)
+        return _handle_response(response, self._server_config, synchronous, timeout)
+
+
 class Domain(
     Entity,
     EntityCreateMixin,


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/nailgun/pull/1357

This PR adds an entity class for the content view environments endpoint. This is required for automating SAT-34301.

##### Upstream API documentation, plugin, or feature links

https://apidocs.theforeman.org/katello/4.18/apidoc/v2/content_view_environments/index.html

##### Demonstration

PRT run in https://github.com/SatelliteQE/robottelo/pull/19581.