### PR TITLE
Drop field mapping for Filter

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -3564,13 +3564,9 @@ class Filter(
 
     def __init__(self, server_config=None, **kwargs):
         self._fields = {
-            'location': entity_fields.OneToManyField(Location),
-            'organization': entity_fields.OneToManyField(Organization),
             'permission': entity_fields.OneToManyField(Permission),
             'role': entity_fields.OneToOneField(Role, required=True),
             'search': entity_fields.StringField(),
-            'override': entity_fields.BooleanField(),
-            'unlimited': entity_fields.BooleanField(),
         }
         self._meta = {'api_path': 'api/v2/filters'}
         super().__init__(server_config=server_config, **kwargs)
@@ -3583,14 +3579,6 @@ class Filter(
 
         """
         return {'filter': super().create_payload()}
-
-    def read(self, entity=None, attrs=None, ignore=None, params=None):
-        """Deal with different named data returned from the server."""
-        if attrs is None:
-            attrs = self.read_json()
-        attrs['override'] = attrs.pop('override?')
-        attrs['unlimited'] = attrs.pop('unlimited?')
-        return super().read(entity, attrs, ignore, params)
 
     def update_payload(self, fields=None):
         """Wrap submitted data within an extra dict."""

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1213,7 +1213,6 @@ class ReadTestCase(TestCase):
             # entities.UserGroup,  # see test_attrs_arg_v2
             entities.ContentView,
             entities.Domain,
-            entities.Filter,
             entities.Host,
             entities.Media,
             entities.RHCIDeployment,
@@ -1265,11 +1264,6 @@ class ReadTestCase(TestCase):
                 entities.Host(self.cfg),
                 {'parameters': None, 'puppet_proxy': None},
                 {'host_parameters_attributes': None, 'puppet_proxy': None},
-            ),
-            (
-                entities.Filter(self.cfg),
-                {'override?': None, 'unlimited?': None},
-                {'override': None, 'unlimited': None},
             ),
         )
         for entity, attrs_before, attrs_after in test_data:


### PR DESCRIPTION
##### Description of changes

A change in Foreman drops the option to override filters as well as dropping the unlimited field. Those fields previously required mapping, there won't be any need for that anymore.
Also taxonomies have been removed from filters.

##### Upstream API documentation, plugin, or feature links

https://github.com/theforeman/foreman/pull/10370
