### PR TITLE
[6.18.z] Add Python 3.14 for PR checks in GHA

### DIFF
--- a/.github/workflows/merge_to_master.yml
+++ b/.github/workflows/merge_to_master.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11', '3.12', '3.13']
+        python-version: ['3.12', '3.13', '3.14']
     steps:
       - name: Checkout Nailgun
         uses: actions/checkout@v5
@@ -64,7 +64,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: '3.14'
       - name: Install pypa/build
         run: python -m pip install build --user
       - name: Build a binary wheel and a source tarball

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11', '3.12', '3.13']
+        python-version: ['3.12', '3.13', '3.14']
     steps:
       - name: Checkout Nailgun
         uses: actions/checkout@v5

--- a/setup.py
+++ b/setup.py
@@ -40,11 +40,11 @@ setup(
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
-        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
     ],
     packages=find_packages(exclude=['docs', 'tests']),
     install_requires=REQUIREMENTS,
-    python_requires='>=3.11',
+    python_requires='>=3.12',
 )


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/nailgun/pull/1364

### Problem Statement
Python 3.14 was released on October 7, 2025, and we're not covering this in the PR checks in GHA yet

### Solution
Add Python 3.14 for PR checks in GHA and bump Py3.12 as new required Python version to match CI