### PR TITLE
Remove auto_attach option from Activation Key

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -212,7 +212,6 @@ class ActivationKey(
 
     def __init__(self, server_config=None, **kwargs):
         self._fields = {
-            'auto_attach': entity_fields.BooleanField(),
             'content_view': entity_fields.OneToOneField(ContentView),
             'description': entity_fields.StringField(),
             'environment': entity_fields.OneToOneField(LifecycleEnvironment),


### PR DESCRIPTION
##### Description of changes

Remove auto_attach option from Activation key
##### Upstream API documentation, plugin, or feature links
https://github.com/Katello/katello/commit/244654f6e6d93d091c0e94bc40b918921b4bdeee dropped support for it.