### PR TITLE
[6.18.z] feat: Add methods to manage autosign entries for puppet/openvox on a SmartProxy

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -8084,6 +8084,32 @@ class SmartProxy(
             client.post(path, **kwargs), self._server_config, synchronous, timeout
         )
 
+    def add_autosign_entry(self, certname, **kwargs):
+        """Add an entry to the puppetserver's autosign file.
+
+        :param certname: Name the host is going to register with
+        """
+        kwargs = kwargs.copy()
+        kwargs.update(self._server_config.get_client_kwargs())
+        path = f'{self.path()}/autosign'
+        return _handle_response(
+            client.post(path, data={'id': certname}, **kwargs),
+            self._server_config,
+        )
+
+    def delete_autosign_entry(self, certname, **kwargs):
+        """Delete an entry from the puppetserver's autosign file.
+
+        :param certname: Name of the host to be deleted from the autosign file
+        """
+        kwargs = kwargs.copy()
+        kwargs.update(self._server_config.get_client_kwargs())
+        path = f'{self.path()}/autosign/{certname}'
+        return _handle_response(
+            client.delete(path, **kwargs),
+            self._server_config,
+        )
+
     def read(self, entity=None, attrs=None, ignore=None, params=None):
         """Ignore ``download_policy`` field as it's never returned by the server.
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -3459,6 +3459,39 @@ class SmartProxyTestCase(TestCase):
                 if 'environment' in param:
                     self.assertIn('/environments', post.call_args[0][0])
 
+    def test_add_autosign_entry(self):
+        """Call :meth:`nailgun.entities.SmartProxy.add_autosign_entry`.
+
+        Assert that
+        * correct fqdn is sent,
+        * proper path is built.
+        """
+        certname = "host.example.com"
+        with self.subTest():
+            with mock.patch.object(client, 'post') as post:
+                self.smart_proxy.add_autosign_entry(certname)
+                self.assertEqual(post.call_count, 1)
+                self.assertIn(f'{self.smart_proxy.path()}/autosign', post.call_args[0][0])
+                self.assertEqual(len(post.call_args[1]), 1)
+                self.assertEqual(post.call_args[1], {'data': {'id': 'host.example.com'}})
+
+    def test_delete_autosign_entry(self):
+        """Call :meth:`nailgun.entities.SmartProxy.add_autosign_entry`.
+
+        Assert that
+        * correct fqdn is sent,
+        * proper path is built.
+        """
+        certname = "host.example.com"
+        with self.subTest():
+            with mock.patch.object(client, 'delete') as delete:
+                self.smart_proxy.delete_autosign_entry(certname)
+                self.assertEqual(delete.call_count, 1)
+                self.assertIn(
+                    f'{self.smart_proxy.path()}/autosign/{certname}', delete.call_args[0][0]
+                )
+                self.assertEqual(len(delete.call_args[1]), 0)
+
 
 class SubscriptionTestCase(TestCase):
     """Tests for :class:`nailgun.entities.Subscription`."""


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/nailgun/pull/1376

Added two methods to SmartProxy to manage autosign entries on the puppetserver.
The methods allow to add and delete autosign entries.

This is an implementation of https://apidocs.theforeman.org/foreman/3.16/apidoc/v2/autosign.html for POST and DELETE requests.


Example:
```
host = target_sat.api.Host().search(query={'name': some_host_name})[0]
host.puppet_ca_proxy.add_autosign_entry(host.name)
host.puppet_ca_proxy.delete_autosign_entry(host.name)
```