### PR TITLE
[6.18.z] Add bulk applicable and installable errata endpoints

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -4934,6 +4934,44 @@ class Host(
         response = client.post(self.path('bulk/available_incremental_updates'), **kwargs)
         return _handle_response(response, self._server_config, synchronous, timeout)
 
+    def bulk_applicable_errata(self, synchronous=True, timeout=None, **kwargs):
+        """Fetch applicable errata for one or more hosts.
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param timeout: Maximum number of seconds to wait until timing out.
+            Defaults to ``nailgun.entity_mixins.TASK_TIMEOUT``.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all content decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+
+        """
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.post(self.path('bulk/applicable_errata'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous, timeout)
+
+    def bulk_installable_errata(self, synchronous=True, timeout=None, **kwargs):
+        """Fetch installable errata for one or more hosts.
+
+        :param synchronous: What should happen if the server returns an HTTP
+            202 (accepted) status code? Wait for the task to complete if
+            ``True``. Immediately return the server's response otherwise.
+        :param timeout: Maximum number of seconds to wait until timing out.
+            Defaults to ``nailgun.entity_mixins.TASK_TIMEOUT``.
+        :param kwargs: Arguments to pass to requests.
+        :returns: The server's response, with all content decoded.
+        :raises: ``requests.exceptions.HTTPError`` If the server responds with
+            an HTTP 4XX or 5XX message.
+
+        """
+        kwargs = kwargs.copy()  # shadow the passed-in kwargs
+        kwargs.update(self._server_config.get_client_kwargs())
+        response = client.post(self.path('bulk/installable_errata'), **kwargs)
+        return _handle_response(response, self._server_config, synchronous, timeout)
+
     def get_facts(self, synchronous=True, timeout=None, **kwargs):
         """List all fact values of a given host.
 
@@ -5135,6 +5173,8 @@ class Host(
             'bulk/add_subscriptions',
             'bulk/remove_subscriptions',
             'bulk/available_incremental_updates',
+            'bulk/applicable_errata',
+            'bulk/installable_errata',
             'bulk/traces',
             'bulk/resolve_traces',
             'bulk/destroy',

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -2178,6 +2178,8 @@ class GenericTestCase(TestCase):
             (entities.Host(**generic).bulk_destroy, 'put'),
             (entities.Host(**generic).bulk_traces, 'post'),
             (entities.Host(**generic).bulk_resolve_traces, 'put'),
+            (entities.Host(**generic).bulk_applicable_errata, 'post'),
+            (entities.Host(**generic).bulk_installable_errata, 'post'),
             (entities.HostGroup(**generic).add_puppetclass, 'post'),
             (entities.HostGroup(**generic).assign_ansible_roles, 'post'),
             (entities.HostGroup(**generic).clone, 'post'),


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/nailgun/pull/1375

##### Description of changes
Adding two errata related endpoints.

##### Upstream API documentation, plugin, or feature links
SAT/apidoc/v2/hosts_bulk_actions/applicable_errata.en.html
SAT/apidoc/v2/hosts_bulk_actions/installable_errata.en.html

##### Functional demonstration
Robottelo PR: https://github.com/SatelliteQE/robottelo/pull/20193