### PR TITLE
Remove deprecated CV/LCE params from ActivationKey and HostGroup

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -4118,6 +4118,7 @@ class HostGroup(
         ignore.add('root_pass')
         ignore.add('kickstart_repository')
         ignore.add('compute_resource')
+        ignore.add('content_view_environment_id')
 
         attrs = attrs or self.read_json()
         attrs['parent_id'] = attrs.pop('ancestry')  # either an ID or None

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -212,9 +212,8 @@ class ActivationKey(
 
     def __init__(self, server_config=None, **kwargs):
         self._fields = {
-            'content_view': entity_fields.OneToOneField(ContentView),
+            'content_view_environment_ids': entity_fields.ListField(),
             'description': entity_fields.StringField(),
-            'environment': entity_fields.OneToOneField(LifecycleEnvironment),
             'host_collection': entity_fields.OneToManyField(HostCollection),
             'max_hosts': entity_fields.IntegerField(),
             'name': entity_fields.StringField(
@@ -262,10 +261,42 @@ class ActivationKey(
             return f'{super().path(which="self")}/{which}'
         return super().path(which)
 
+    def read(self, entity=None, attrs=None, ignore=None, params=None):
+        """Handle the content_view_environments response format."""
+        if attrs is None:
+            attrs = self.read_json(params=params)
+        if ignore is None:
+            ignore = set()
+        ignore.add('content_view_environment_ids')
+        entity = super().read(entity, attrs, ignore, params)
+        entity.content_view_environments = attrs.get('content_view_environments', [])
+        return entity
+
+    @property
+    def content_view(self):
+        """Backward-compat: extract the first content view from content_view_environments."""
+        cves = getattr(self, 'content_view_environments', None)
+        if not cves:
+            return None
+        cv_data = cves[0].get('content_view')
+        if not cv_data:
+            return None
+        return ContentView(server_config=self._server_config, id=cv_data['id'])
+
+    @property
+    def environment(self):
+        """Backward-compat: extract the first lifecycle environment from content_view_environments."""
+        cves = getattr(self, 'content_view_environments', None)
+        if not cves:
+            return None
+        lce_data = cves[0].get('lifecycle_environment')
+        if not lce_data:
+            return None
+        return LifecycleEnvironment(server_config=self._server_config, id=lce_data['id'])
+
     def update_payload(self, fields=None):
         """Include organization_id in all payloads."""
         payload = super().update_payload(fields)
-        # organization is required for the AK update call
         payload['organization_id'] = self.organization.id
         return payload
 
@@ -4043,6 +4074,7 @@ class HostGroup(
         self._fields.update(
             {
                 'content_view': entity_fields.OneToOneField(ContentView),
+                'content_view_environment_id': entity_fields.IntegerField(),
                 'lifecycle_environment': entity_fields.OneToOneField(LifecycleEnvironment),
             }
         )
@@ -4062,13 +4094,12 @@ class HostGroup(
         ).read()
 
     def create_payload(self):
-        """Wrap submitted data within an extra dict.
-
-        For more information, see `Bugzilla #1151220
-        <https://bugzilla.redhat.com/show_bug.cgi?id=1151220>`_.
-
-        """
-        return {'hostgroup': super().create_payload()}
+        """Wrap submitted data within an extra dict."""
+        payload = super().create_payload()
+        if 'content_view_environment_id' in payload:
+            payload.pop('content_view_id', None)
+            payload.pop('lifecycle_environment_id', None)
+        return {'hostgroup': payload}
 
     def read(self, entity=None, attrs=None, ignore=None, params=None):
         """Deal with several bugs.
@@ -4110,7 +4141,11 @@ class HostGroup(
 
     def update_payload(self, fields=None):
         """Wrap submitted data within an extra dict."""
-        return {'hostgroup': super().update_payload(fields)}
+        payload = super().update_payload(fields)
+        if 'content_view_environment_id' in payload:
+            payload.pop('content_view_id', None)
+            payload.pop('lifecycle_environment_id', None)
+        return {'hostgroup': payload}
 
     def path(self, which=None):
         """Extend ``nailgun.entity_mixins.Entity.path``.

--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -275,10 +275,10 @@ class ActivationKey(
     @property
     def content_view(self):
         """Backward-compat: extract the first content view from content_view_environments."""
-        cves = getattr(self, 'content_view_environments', None)
-        if not cves:
+        cvenvs = getattr(self, 'content_view_environments', None)
+        if not cvenvs:
             return None
-        cv_data = cves[0].get('content_view')
+        cv_data = cvenvs[0].get('content_view')
         if not cv_data:
             return None
         return ContentView(server_config=self._server_config, id=cv_data['id'])
@@ -286,10 +286,10 @@ class ActivationKey(
     @property
     def environment(self):
         """Backward-compat: extract the first lifecycle environment from content_view_environments."""
-        cves = getattr(self, 'content_view_environments', None)
-        if not cves:
+        cvenvs = getattr(self, 'content_view_environments', None)
+        if not cvenvs:
             return None
-        lce_data = cves[0].get('lifecycle_environment')
+        lce_data = cvenvs[0].get('lifecycle_environment')
         if not lce_data:
             return None
         return LifecycleEnvironment(server_config=self._server_config, id=lce_data['id'])

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -3007,7 +3007,12 @@ class HostGroupTestCase(TestCase):
         )
         self.assertSetEqual(
             read.call_args[0][2],  # ignore for EntityReadMixin.read call
-            {'compute_resource', 'kickstart_repository', 'root_pass'},
+            {
+                'compute_resource',
+                'content_view_environment_id',
+                'kickstart_repository',
+                'root_pass',
+            },
         )
         self.read_json_pacther.stop()
         self.read_pacther.stop()

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -2692,6 +2692,42 @@ class ActivationKeyTestCase(TestCase):
         expected_dct['name'] = 'test_ak_new'
         self.assertEqual(expected_dct, activation_key.update_payload())
 
+    def test_content_view_property(self):
+        """content_view property extracts CV from content_view_environments."""
+        cfg = config.ServerConfig(url='foo')
+        ak = entities.ActivationKey(cfg, name='test_ak', organization=42)
+        ak.content_view_environments = [
+            {
+                'content_view': {'id': 10, 'name': 'Default'},
+                'lifecycle_environment': {'id': 20, 'name': 'Library'},
+            }
+        ]
+        cv = ak.content_view
+        self.assertIsInstance(cv, entities.ContentView)
+        self.assertEqual(cv.id, 10)
+
+    def test_environment_property(self):
+        """Environment property extracts LCE from content_view_environments."""
+        cfg = config.ServerConfig(url='foo')
+        ak = entities.ActivationKey(cfg, name='test_ak', organization=42)
+        ak.content_view_environments = [
+            {
+                'content_view': {'id': 10, 'name': 'Default'},
+                'lifecycle_environment': {'id': 20, 'name': 'Library'},
+            }
+        ]
+        lce = ak.environment
+        self.assertIsInstance(lce, entities.LifecycleEnvironment)
+        self.assertEqual(lce.id, 20)
+
+    def test_content_view_property_empty(self):
+        """content_view returns None when content_view_environments is empty."""
+        cfg = config.ServerConfig(url='foo')
+        ak = entities.ActivationKey(cfg, name='test_ak', organization=42)
+        ak.content_view_environments = []
+        self.assertIsNone(ak.content_view)
+        self.assertIsNone(ak.environment)
+
 
 class ReportTemplateTestCase(TestCase):
     """Tests for :class:`nailgun.entities.ReportTemplate`."""


### PR DESCRIPTION
##### Description of changes

Remove the deprecated separate `content_view` and `environment` fields from `ActivationKey`, replacing them with `content_view_environment_ids` to match the Katello 4.21+ API changes (Fixes #39330).

**ActivationKey:**
- Remove `content_view` (OneToOneField) and `environment` (OneToOneField) from `_fields`
- Add `content_view_environment_ids` (ListField) for create/update payloads
- Override `read()` to populate `content_view_environments` from the API response
- Add backward-compat `@property` for `content_view` and `environment` (read-only, extracts from first content view environment)

**HostGroup:**
- Add `content_view_environment_id` (IntegerField) to `_fields`
- Update `create_payload()` and `update_payload()` to strip legacy `content_view_id`/`lifecycle_environment_id` when `content_view_environment_id` is present

##### Upstream API documentation, plugin, or feature links

Katello PR: https://github.com/Katello/katello/pull/11753 (branch `sat-38100-remove-deprecated-cv-lce-params`)
Robottelo PR: https://github.com/SatelliteQE/robottelo/pull/21644

##### Functional demonstration

Callers update from:
```python
ak = ActivationKey(content_view=cv, environment=lce, organization=org).create()
```
to:
```python
ak = ActivationKey(content_view_environment_ids=[cvenv_id], organization=org).create()
```

Read-side backward compat is preserved:
```python
ak = ActivationKey(id=123).read()
ak.content_view.id      # still works via @property
ak.environment.id        # still works via @property
ak.content_view_environments  # new: list of dicts with full CV/LCE data
```

##### Additional Information

Companion Robottelo PR will follow with test updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)