### PR TITLE
[6.19.z] Fix test_identical_args to ignore type annotations in signature comparison

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -130,8 +130,15 @@ class ClientTestCase(TestCase):
         signature as ``requests.delete``.
 
         """
+
+        def _strip_annotations(sig):
+            params = [
+                p.replace(annotation=inspect.Parameter.empty) for p in sig.parameters.values()
+            ]
+            return sig.replace(parameters=params, return_annotation=inspect.Parameter.empty)
+
         for meth in ('delete', 'get', 'head', 'patch', 'post', 'put'):
             self.assertEqual(
-                inspect.signature(getattr(client, meth)),
-                inspect.signature(getattr(requests, meth)),
+                _strip_annotations(inspect.signature(getattr(client, meth))),
+                _strip_annotations(inspect.signature(getattr(requests, meth))),
             )


### PR DESCRIPTION
Cherrypick of PR: https://github.com/SatelliteQE/nailgun/pull/1421

## Summary

- `requests` 2.33.0 added type annotations (e.g. `url: '_t.UriType'`, `**kwargs: 'Unpack[...]'`) to its public functions
- `test_identical_args` used `inspect.signature()` to compare nailgun's wrappers directly against `requests` functions, which failed because nailgun's wrappers intentionally don't replicate those annotations
- Added a `_strip_annotations` helper that removes annotations from both signatures before comparing, so the test still validates parameter names, kinds, and defaults

## Test plan

- [x] `make test` passes with `requests>=2.33.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)