### PR TITLE
Add cacert attribute to ldap auth source entity

### DIFF
--- a/nailgun/entities.py
+++ b/nailgun/entities.py
@@ -723,6 +723,7 @@ class AuthSourceLDAP(
             'account': entity_fields.StringField(),
             'attr_photo': entity_fields.StringField(),
             'base_dn': entity_fields.StringField(),
+            'cacert': entity_fields.StringField(),
             'groups_base': entity_fields.StringField(),
             'host': entity_fields.StringField(
                 required=True,


### PR DESCRIPTION
##### Description of changes

https://github.com/theforeman/foreman/pull/11107 adds a cacert attribute to ldap auth servers. This extends the ldap auth source entity with the new attribute.

##### Upstream API documentation, plugin, or feature links

See the issue in description plus:

- https://redhat.atlassian.net/browse/SAT-47369
- https://redhat.atlassian.net/browse/SAT-45933

##### Functional demonstration

Example:
```
# curl -u admin:changeme http://localhost:3000/api/v2/auth_source_ldaps/6 | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2326  100  2326    0     0  18425      0 --:--:-- --:--:-- --:--:-- 18460
{
  "host": "myipa.something.somewhere",
  "port": 389,
  "account": "admin",
  "base_dn": "",
  "ldap_filter": "",
  "attr_login": "uid",
  "attr_firstname": "givenName",
  "attr_lastname": "sn",
  "attr_mail": "mail",
  "attr_photo": "jpegPhoto",
  "onthefly_register": true,
  "usergroup_sync": true,
  "tls": false,
  "cacert": "-----BEGIN CERTIFICATE-----\r\nMIIEgzCCAuugAwIBAgIQUqw4p3BlVM9IOZ5Y7QI/RjANBgkqhkiG9w0BAQsFADBL\r\nMSkwJwYDVQQKDCBSSE9TLTAxLlBST0QuUFNJLlJEVTIuUkVESEFULkNPTTEeMBwG\r\nA1UEAwwVQ2VydGlmaWNhdGUgQXV0aG9yaXR5MB4XDTI2MDcyMjA5MTIzNFoXDTQ2\r\nMDcyMjA5MTIzNFowSzEpMCcGA1UECgwgUkhPUy0wMS5QUk9ELlBTSS5SRFUyLlJF\r\nREhBVC5DT00xHjAcBgNVBAMMFUNlcnRpZmljYXRlIEF1dGhvcml0eTCCAaIwDQYJ\r\nKoZIhvcNAQEBBQADggGPADCCAYoCggGBAOa6O3i9AwHf47zYiXmvL93OFI+SxJ7H\r\n5kXN2nx5/KzG4I59+f7E68Tz0c/BQOddBgAb7X4wWNeOm0iZELqlVBe41GfGj+Xc\r\nCXqwC2C28tKd/03MzaVkKaA/GQMDyqhNRpxAXP6DowW8FAFOnumpQo+ocO8VMncv\r\nH/NC9aQcGtz/xGx4zoTfIxC8cwnVZIVD32uLdVBZEqsO4oKjvIEwU4OBBiTwdsQB\r\nap7Qs2bEu5UL65aBla0nilAOiizVvJnhInjd72Cye4E1pQAIO4B8fZ/Zv2NOsr3U\r\n6ni28JF4qNQ+A/cwUUpViMPKX1JMMR/osNmYWPKVDhMyacyPbgjq1vcwKrdzD6G5\r\nKfSbmil/ThJzt45t2ir2VFZZqomu1q7eONSvcWP0k1bwoqnoxwkQcM6sTJ28JCRj\r\nd3V5PqUOE4a5c31o+PeeKWwkqtD+F/eYVMZAGUa3bEDcGd0Z37pA+LglYDcAMUKt\r\nqJZ+LzvkHMTkyyBmAhcvWYdmCU3KQrmmUQIDAQABo2MwYTAdBgNVHQ4EFgQU6a5y\r\nds/CpGxEUSQH7rYobAikz58wHwYDVR0jBBgwFoAU6a5yds/CpGxEUSQH7rYobAik\r\nz58wDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAcYwDQYJKoZIhvcNAQEL\r\nBQADggGBAG3llw0DC9fk8DYnR1GL/viBNCLFoIXSivuOi0HpyKSArqDdLJQSbcqa\r\nb9RkaXNWDZCyqIHMkDWbl6s6/xwsWENvTyOTCcmZb8FYetfpGgKoSZh6rAHKIdwD\r\nM2G7ABFyKgFj40gjFaJ65fW3BPIC+ckzuKtiu9UxiB20FkVKYuJv7fObHbEnMW6r\r\n7JKVA0JDIfm7sNWpxW7mkmoXzoXJxHZTXubDhdDbCfqdvEjKCPGHb5httfmOm4Rf\r\noSL9Ay+d3GNDywFYLV3SZiR4PnXHshfg+xZ1iCZBeZDOgFXbQfZNTqEPk5RUYOqs\r\ngi1E3ac7lxVfTZMmG3UAa/QNX+SxPDGePiNRb/RgEyUqIy5otjgw5jrG/2/RXg5w\r\n7wZw6vrVYxqMZZQkO0Kp318+6dlCNCvuUSAKtZwi7LHUgVUPwIa8MrkNmFInjWj6\r\nBmwGT+oT8JpJOR+SX7ltfO9RLhAeWnpxDdHTRmi0fW35WXVYj+EkDvEyNYidHRN1\r\nM1AswgFE0Q==\r\n-----END CERTIFICATE-----",
  "server_type": "free_ipa",
  "groups_base": "",
  "ldap_group_membership": "posix",
  "created_at": "2026-07-22 10:03:23 UTC",
  "updated_at": "2026-07-22 10:11:14 UTC",
  "id": 6,
  "type": "AuthSourceLdap",
  "name": "myipa.something.somewhere",
  "use_netgroups": false,
  "external_usergroups": [],
  "locations": [],
  "organizations": []
}
```

##### Additional Information

N/A
