### PR TITLE
[master]: Changes for 6.20.z new branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
     schedule:
       interval: "daily"
     labels:
+      - '6.20.z'
       - '6.19.z'
       - '6.18.z'
       - '6.17.z'
@@ -24,6 +25,7 @@ updates:
     schedule:
       interval: "daily"
     labels:
+      - '6.20.z'
       - '6.19.z'
       - '6.18.z'
       - '6.17.z'


### PR DESCRIPTION

  ### Problem Statement
  New 6.20.z downstream and master points to stream that is 6.21
  ### Solution
  - Dependabot.yaml cherrypicks to 6.20.z
